### PR TITLE
True tile polymorphism: unified interface, from_hash, activatable? (#86)

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -288,15 +288,9 @@ class Game < ApplicationRecord
     return false if tile["used"]
     return false unless mandatory_count == MANDATORY_COUNT || mandatory_count <= 0 ||
       current_player.supply["settlements"] == 0
-    if tile["klass"] == "OasisTile"
-      instantiate
-      return Tiles::OasisTile.new(0).valid_destinations(
-        board_contents: board_contents,
-        board: @board,
-        player_order: current_player.order
-      ).any?
-    end
-    true
+    instantiate
+    ctx = { player_order: current_player.order, board_contents: board_contents, board: @board }
+    Tiles::Tile.from_hash(tile).activatable?(**ctx)
   end
 
   def turn_endable?

--- a/app/models/tiles/oasis_tile.rb
+++ b/app/models/tiles/oasis_tile.rb
@@ -1,6 +1,6 @@
 module Tiles
   class OasisTile < Tiles::Tile
-    def valid_destinations(board_contents:, board:, player_order:)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:)
       adjacent_desert = board_contents.settlements_for(player_order).flat_map do |r, c|
         board_contents.neighbors_where(r, c) do |nr, nc|
           board_contents.empty?(nr, nc) && board.terrain_at(nr, nc) == "D"
@@ -14,6 +14,10 @@ module Tiles
           [ r, c ] if board_contents.empty?(r, c) && board.terrain_at(r, c) == "D"
         end
       end
+    end
+
+    def activatable?(player_order:, board_contents:, board:)
+      valid_destinations(board_contents:, board:, player_order:).any?
     end
   end
 end

--- a/app/models/tiles/paddock_tile.rb
+++ b/app/models/tiles/paddock_tile.rb
@@ -11,7 +11,8 @@ module Tiles
       [ [ 1,  0 ],  [ 1, 1 ] ]    # SE
     ].freeze
 
-    def valid_destinations(from_row, from_col, board_contents:, board:)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order: nil)
+      return [] if from_row.nil? || from_col.nil?
       STRAIGHT_LINES.filter_map do |steps|
         dr1, dc1 = steps[from_row % 2]
         r1 = from_row + dr1
@@ -27,9 +28,9 @@ module Tiles
       end
     end
 
-    def selectable_settlements(player_order, board_contents:, board:)
+    def selectable_settlements(player_order:, board_contents:, board:)
       board_contents.settlements_for(player_order).filter_map do |r, c|
-        [ r, c ] if valid_destinations(r, c, board_contents: board_contents, board: board).any?
+        [ r, c ] if valid_destinations(from_row: r, from_col: c, board_contents:, board:).any?
       end
     end
   end

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -6,12 +6,22 @@ module Tiles
       @qty = qty
     end
 
-    def valid_destinations(from_row, from_col, board_contents:, board:)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:)
       []
     end
 
-    def selectable_settlements(player_order, board_contents:, board:)
+    def selectable_settlements(player_order:, board_contents:, board:)
       []
+    end
+
+    def activatable?(player_order:, board_contents:, board:)
+      true
+    end
+
+    def self.from_hash(hash)
+      "Tiles::#{hash['klass']}".constantize.new(0)
+    rescue NameError
+      raise ArgumentError, "Unknown tile class: #{hash['klass']}"
     end
   end
 end

--- a/test/models/tiles/oasis_tile_test.rb
+++ b/test/models/tiles/oasis_tile_test.rb
@@ -84,4 +84,40 @@ class Tiles::OasisTileTest < ActiveSupport::TestCase
 
     assert_empty result
   end
+
+  # --- from_hash ---
+
+  test "from_hash returns an OasisTile" do
+    assert_instance_of Tiles::OasisTile, Tiles::Tile.from_hash("klass" => "OasisTile")
+  end
+
+  # --- activatable? ---
+
+  test "activatable? is true when desert hexes are reachable" do
+    ctx = setup_board
+    tile = Tiles::OasisTile.new(0)
+    assert tile.activatable?(player_order: ctx[:chris].order, board_contents: ctx[:board_contents], board: ctx[:board])
+  end
+
+  test "activatable? is false when all desert hexes are occupied" do
+    desert_hexes = [
+      [0,0],[0,1],[1,0],[2,0],[2,1],[5,8],[6,8],[7,6],[7,7],[8,7],[8,8],
+      [0,13],[0,14],[0,16],[0,17],[0,18],[0,19],[1,13],[1,14],[1,16],[1,17],[1,18],[1,19],
+      [2,16],[2,17],[3,16],
+      [10,0],[10,1],[10,11],[10,12],[10,15],[10,16],[11,0],[11,12],[11,13],[11,14],
+      [13,5],[13,6],[14,6],[14,7],[15,7],[15,8],[16,8],[16,9],[16,10],
+      [17,8],[17,10],[17,11],[18,10],[18,11],[18,12],[19,10],[19,11]
+    ]
+    game = games(:game2player)
+    chris = game_players(:chris)
+    game.boards = [ [ "Oasis", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    game.board_contents = BoardState.new.tap do |s|
+      desert_hexes.each { |r, c| s.place_settlement(r, c, 1) }
+      s.place_settlement(4, 0, chris.order)
+    end
+    game.save
+    game.instantiate
+    tile = Tiles::OasisTile.new(0)
+    assert_not tile.activatable?(player_order: chris.order, board_contents: game.board_contents, board: game.board)
+  end
 end

--- a/test/models/tiles/paddock_tile_test.rb
+++ b/test/models/tiles/paddock_tile_test.rb
@@ -22,7 +22,7 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
     ctx = setup_board
     tile = Tiles::PaddockTile.new(0)
 
-    result = tile.valid_destinations(0, 14, board_contents: ctx[:board_contents], board: ctx[:board])
+    result = tile.valid_destinations(from_row: 0, from_col: 14, board_contents: ctx[:board_contents], board: ctx[:board])
 
     assert_includes result, [ 0, 12 ], "C terrain straight W 2 hops away"
     assert_includes result, [ 0, 16 ], "D terrain straight E 2 hops away"
@@ -37,7 +37,7 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
     ctx = setup_board { |s| s.place_settlement(0, 12, 1) }
     tile = Tiles::PaddockTile.new(0)
 
-    result = tile.valid_destinations(0, 14, board_contents: ctx[:board_contents], board: ctx[:board])
+    result = tile.valid_destinations(from_row: 0, from_col: 14, board_contents: ctx[:board_contents], board: ctx[:board])
 
     assert_not_includes result, [ 0, 12 ], "occupied cell excluded"
     assert_includes result, [ 0, 16 ]
@@ -47,7 +47,7 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
     ctx = setup_board
     tile = Tiles::PaddockTile.new(0)
 
-    result = tile.selectable_settlements(ctx[:chris].order,
+    result = tile.selectable_settlements(player_order: ctx[:chris].order,
       board_contents: ctx[:board_contents], board: ctx[:board])
 
     assert_includes result, [ 0, 14 ]
@@ -60,19 +60,15 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
     end
     tile = Tiles::PaddockTile.new(0)
 
-    result = tile.selectable_settlements(ctx[:chris].order,
+    result = tile.selectable_settlements(player_order: ctx[:chris].order,
       board_contents: ctx[:board_contents], board: ctx[:board])
 
     assert_empty result
   end
 
-  test "base Tile returns empty array for valid_destinations" do
-    tile = Tiles::Tile.new(0)
-    assert_equal [], tile.valid_destinations(0, 0, board_contents: BoardState.new, board: nil)
-  end
+  # --- from_hash ---
 
-  test "base Tile returns empty array for selectable_settlements" do
-    tile = Tiles::Tile.new(0)
-    assert_equal [], tile.selectable_settlements(0, board_contents: BoardState.new, board: nil)
+  test "from_hash returns a PaddockTile" do
+    assert_instance_of Tiles::PaddockTile, Tiles::Tile.from_hash("klass" => "PaddockTile")
   end
 end

--- a/test/models/tiles/tile_test.rb
+++ b/test/models/tiles/tile_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+# Tests for the Tile base class interface.
+# Does not reference any subclass — subclass-specific behaviour lives in subclass tests.
+
+class Tiles::TileTest < ActiveSupport::TestCase
+  test "valid_destinations returns empty array" do
+    assert_equal [], Tiles::Tile.new(0).valid_destinations(board_contents: BoardState.new, board: nil, player_order: 0)
+  end
+
+  test "selectable_settlements returns empty array" do
+    assert_equal [], Tiles::Tile.new(0).selectable_settlements(player_order: 0, board_contents: BoardState.new, board: nil)
+  end
+
+  test "activatable? returns true" do
+    assert Tiles::Tile.new(0).activatable?(player_order: 0, board_contents: BoardState.new, board: nil)
+  end
+
+  test "from_hash raises ArgumentError for unknown klass" do
+    assert_raises(ArgumentError) { Tiles::Tile.from_hash("klass" => "BogusTimeTile") }
+  end
+end


### PR DESCRIPTION
- Unify valid_destinations and selectable_settlements to keyword args across Tile, OasisTile, and PaddockTile (consistent base class contract)
- Add Tile.from_hash for rehydrating player-held tile hashes into objects
- Add Tile#activatable? (default true) and OasisTile#activatable? which checks valid_destinations — eliminating the if tile["klass"] == "OasisTile" type check from Game#tile_activatable?
- Add Tiles::TileTest covering base class defaults and from_hash error path
- Move from_hash and activatable? coverage into each subclass test file