### PR TITLE
Add payload column to Move for self-describing events (#88)

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -170,6 +170,7 @@ class Game < ApplicationRecord
       from: "supply",
       to: "[#{row}, #{col}]",
       reversible: true,
+      payload: { "card" => card_terrain },
       message: "#{game_player.player.handle} built a settlement on #{Boards::Board::TERRAIN_NAMES[card_terrain]}"
     )
     # - update supply
@@ -326,8 +327,11 @@ class Game < ApplicationRecord
     Rails.logger.debug(" - current player #{current_player.inspect}")
     instantiate
     game_player = current_player
+    card_discarded = game_player.hand
     self.discard.push(game_player.hand)
     game_player.hand = next_card
+    card_drawn = game_player.hand
+    reshuffled = self.discard.empty?
     self.mandatory_count = MANDATORY_COUNT
     self.current_action = { "type" => "mandatory" }
     next_order = (current_player.order + 1) % game_players.count
@@ -345,6 +349,8 @@ class Game < ApplicationRecord
       deliberate: true,
       action: "end_turn",
       reversible: false,
+      payload: { "card_discarded" => card_discarded, "card_drawn" => card_drawn,
+                 "reshuffled" => reshuffled, "deck_after" => self.deck.dup },
       message: "#{game_player.player.handle} ended their turn"
     )
     ActiveRecord::Base.transaction do
@@ -409,7 +415,7 @@ class Game < ApplicationRecord
         move.game_player.tiles = tiles.reject { |t| t["from"] == move.from }
         move.game_player.save
       when "forfeit_tile"
-        klass = board_contents.tile_klass(*Coordinate.from_key(move.from))
+        klass = move.payload["klass"]
         tiles = move.game_player.tiles || []
         move.game_player.tiles = tiles + [ { "klass" => klass, "from" => move.from, "used" => move.to == "true" } ]
         move.game_player.save
@@ -510,6 +516,7 @@ class Game < ApplicationRecord
           reversible: true,
           from: loc,
           to: tile["used"].to_s,
+          payload: { "klass" => klass },
           message: "#{game_player.player.handle} forfeited a #{klass.delete_suffix('Tile').downcase} tile"
         )
       end
@@ -537,6 +544,7 @@ class Game < ApplicationRecord
     tile = find_tile_pickup(game_player, row, col)
     return unless tile
 
+    qty_before = board_contents.tile_qty(*Coordinate.from_key(tile[:key]))
     self.move_count += 1
     self.moves.create(
       order: move_count,
@@ -546,6 +554,7 @@ class Game < ApplicationRecord
       from: tile[:key],
       to: "player_#{game_player.order}",
       reversible: true,
+      payload: { "klass" => tile[:klass], "qty_before" => qty_before },
       message: "#{game_player.player.handle} picked up a #{tile[:klass].delete_suffix('Tile')} tile"
     )
     # Decrement qty in place; entry remains even when qty reaches 0

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -8,6 +8,7 @@
 #  from           :string
 #  message        :string
 #  order          :integer
+#  payload        :jsonb
 #  reversible     :boolean
 #  to             :string
 #  created_at     :datetime         not null

--- a/db/migrate/20260327125644_add_payload_to_moves.rb
+++ b/db/migrate/20260327125644_add_payload_to_moves.rb
@@ -1,0 +1,5 @@
+class AddPayloadToMoves < ActiveRecord::Migration[8.1]
+  def change
+    add_column :moves, :payload, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_14_171251) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_27_125644) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -54,6 +54,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_14_171251) do
     t.bigint "game_player_id", null: false
     t.string "message"
     t.integer "order"
+    t.jsonb "payload"
     t.boolean "reversible"
     t.string "to"
     t.datetime "updated_at", null: false

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -646,6 +646,115 @@ class GameTest < ActiveSupport::TestCase
     assert_not game.tile_activatable?(tile)
   end
 
+  # Move payload tests
+  #
+  # Each action type that has non-obvious or non-deterministic data stores a
+  # payload jsonb column on the Move record so events are self-describing.
+
+  test "build stores the terrain card played in payload" do
+    game = game_with_tile_at_2_7(qty: 0)  # Oasis board, Chris hand "T", build at (1,7)
+
+    game.build_settlement(1, 7)
+
+    build_move = game.moves.find_by(action: "build")
+    assert_equal "T", build_move.payload["card"]
+  end
+
+  test "end_turn stores card_discarded and card_drawn in payload" do
+    game = games(:game2player)
+    chris = game_players(:chris)
+    chris.hand = "G"
+    chris.save
+    game.deck = [ "C", "D", "F" ]
+    game.discard = []
+    game.save
+
+    game.end_turn
+
+    move = game.moves.find_by(action: "end_turn")
+    assert_equal "G", move.payload["card_discarded"]
+    assert_equal "C", move.payload["card_drawn"]
+    assert_equal false, move.payload["reshuffled"]
+  end
+
+  test "end_turn stores reshuffled true and deck_after when deck runs out mid-draw" do
+    game = games(:game2player)
+    chris = game_players(:chris)
+    chris.hand = "G"
+    chris.save
+    game.deck = [ "C" ]
+    game.discard = [ "D", "F", "T" ]
+    game.save
+
+    game.end_turn
+
+    move = game.moves.find_by(action: "end_turn")
+    assert_equal "G", move.payload["card_discarded"]
+    assert_equal "C", move.payload["card_drawn"]
+    assert_equal true, move.payload["reshuffled"]
+    assert_not_empty move.payload["deck_after"]
+  end
+
+  test "pick_up_tile stores tile klass and qty_before in payload" do
+    game = game_with_tile_at_2_7(qty: 2)
+
+    game.build_settlement(1, 7)
+
+    pickup_move = game.moves.find_by(action: "pick_up_tile")
+    assert_equal "OasisTile", pickup_move.payload["klass"]
+    assert_equal 2, pickup_move.payload["qty_before"]
+  end
+
+  test "forfeit_tile stores tile klass in payload" do
+    game = games(:game2player)
+    chris = game_players(:chris)
+    game.boards = [ [ "Oasis", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    game.board_contents = BoardState.new.tap do |s|
+      s.place_tile(2, 7, "OasisTile", 0)
+      s.place_settlement(1, 7, chris.order)
+    end
+    game.current_action = { "type" => "paddock", "from" => "[1, 7]" }
+    game.save
+    chris.tiles = [ { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false } ]
+    chris.save
+
+    game.move_settlement(1, 5)
+
+    forfeit_move = game.moves.find_by(action: "forfeit_tile")
+    assert_equal "OasisTile", forfeit_move.payload["klass"]
+  end
+
+  test "undo after forfeit_tile restores tile klass from payload not board state" do
+    # If undo read klass from board_contents it would get nil here (qty:0 entry exists
+    # but we'll remove it to prove undo reads from payload instead).
+    game = games(:game2player)
+    chris = game_players(:chris)
+    game.boards = [ [ "Oasis", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    game.board_contents = BoardState.new.tap do |s|
+      s.place_tile(2, 7, "OasisTile", 0)
+      s.place_settlement(1, 7, chris.order)
+    end
+    game.current_action = { "type" => "paddock", "from" => "[1, 7]" }
+    game.save
+    chris.tiles = [ { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false } ]
+    chris.save
+
+    game.move_settlement(1, 5)
+    game.reload
+
+    # Remove the tile entry from board_contents so undo cannot read klass from it
+    bc = game.board_contents
+    bc.instance_variable_get(:@cells).delete([ 2, 7 ])
+    game.board_contents = bc
+    game.save
+
+    game.undo_last_move
+    game.reload
+
+    restored = game_players(:chris).reload.tiles
+    assert_includes restored, { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false }
+  end
+
   private
 
   # Returns a saved, in-progress game using the Oasis board with a single tile


### PR DESCRIPTION
Resolves #88

Each action type that has non-obvious or non-deterministic data now stores a payload jsonb column on the Move record:

- build: card played (lost from player hand after end_turn)
- end_turn: card_discarded, card_drawn, reshuffled, deck_after (deck draw is the only random operation in the codebase)
- pick_up_tile: klass and qty_before
- forfeit_tile: klass

undo_last_move now reads klass from payload for forfeit_tile instead of re-reading board_contents, making it independent of snapshot state.