### PR TITLE
Board/hex test coverage: registries, rename, delete dead code (#5)

### DIFF
--- a/app/models/boards/board.rb
+++ b/app/models/boards/board.rb
@@ -15,10 +15,25 @@ module Boards
       "L" => "Location"
     }
 
+    BOARD_CLASSES = {
+      "Farm"    => Boards::FarmBoard,
+      "Oasis"   => Boards::OasisBoard,
+      "Paddock" => Boards::PaddockBoard,
+      "Tavern"  => Boards::TavernBoard
+    }.freeze
+
+    TILE_CLASSES = {
+      "FarmTile"    => Tiles::FarmTile,
+      "OasisTile"   => Tiles::OasisTile,
+      "PaddockTile" => Tiles::PaddockTile,
+      "TavernTile"  => Tiles::TavernTile
+    }.freeze
+
     def initialize(game)
       @map = []
       game.boards.each do |section|
-        @map << "Boards::#{section[0]}Board".constantize.new(section[1])
+        board_class = BOARD_CLASSES.fetch(section[0]) { raise ArgumentError, "Unknown board type: #{section[0]}" }
+        @map << board_class.new(section[1])
       end
       @content = Array.new(20) { Array.new(20) }
       20.times do |row|
@@ -26,7 +41,8 @@ module Boards
           next if game.board_contents.empty?(row, col)
           klass = game.board_contents.tile_klass(row, col)
           if klass
-            @content[row][col] = "Tiles::#{klass}".constantize.new(game.board_contents.tile_qty(row, col))
+            tile_class = TILE_CLASSES.fetch(klass) { raise ArgumentError, "Unknown tile class: #{klass}" }
+            @content[row][col] = tile_class.new(game.board_contents.tile_qty(row, col))
           elsif (player = game.board_contents.player_at(row, col))
             @content[row][col] = Settlement.new(player)
           else

--- a/app/models/boards/board_section.rb
+++ b/app/models/boards/board_section.rb
@@ -8,7 +8,7 @@ module Boards
       raise "Map not implemented"
     end
 
-    def silver_hexes
+    def scoring_hexes
       []
     end
 

--- a/app/models/boards/farm_board.rb
+++ b/app/models/boards/farm_board.rb
@@ -15,7 +15,7 @@ module Boards
       ]
     end
 
-    def silver_hexes
+    def scoring_hexes
       [
         { r: 1, c: 1, k: "Castle" }
       ]

--- a/app/models/boards/oasis_board.rb
+++ b/app/models/boards/oasis_board.rb
@@ -15,7 +15,7 @@ module Boards
       ]
     end
 
-    def silver_hexes
+    def scoring_hexes
       [
         { r: 7, c: 1, k: "Castle" }
       ]

--- a/app/models/boards/paddock_board.rb
+++ b/app/models/boards/paddock_board.rb
@@ -15,7 +15,7 @@ module Boards
       ]
     end
 
-    def silver_hexes
+    def scoring_hexes
       [
         { r: 7, c: 5, k: "Castle" }
       ]

--- a/app/models/boards/tavern_board.rb
+++ b/app/models/boards/tavern_board.rb
@@ -15,7 +15,7 @@ module Boards
       ]
     end
 
-    def silver_hexes
+    def scoring_hexes
       [
         { r: 3, c: 3, k: "Castle" }
       ]

--- a/app/models/tiles/castle_tile.rb
+++ b/app/models/tiles/castle_tile.rb
@@ -1,4 +1,0 @@
-module Tiles
-  class CastleTile < Tile
-  end
-end

--- a/test/models/boards/board_test.rb
+++ b/test/models/boards/board_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class BoardTest < ActiveSupport::TestCase
+  GameStub = Struct.new(:boards, :board_contents)
+
+  def game_with_boards(*names)
+    contents = BoardState.new
+    GameStub.new(names.map { |n| [ n, 0 ] }, contents)
+  end
+
+  test "terrain_at delegates to the correct section based on row/col quadrant" do
+    # Sections: 0=Farm (rows 0-9, cols 0-9), 1=Oasis (rows 0-9, cols 10-19),
+    #           2=Paddock (rows 10-19, cols 0-9), 3=Tavern (rows 10-19, cols 10-19)
+    board = Boards::Board.new(game_with_boards("Farm", "Oasis", "Paddock", "Tavern"))
+
+    assert_equal "D", board.terrain_at(0, 0)   # Farm row 0: "DDCWWTTTGG"
+    assert_equal "D", board.terrain_at(0, 10)  # Oasis row 0: "DDCWWTTGGG"
+    assert_equal "C", board.terrain_at(10, 0)  # Paddock row 0: "CCCDDWDDDD"
+    assert_equal "F", board.terrain_at(10, 10) # Tavern row 0: "FDDMMDDCCC"
+  end
+
+  test "terrain_at uses local coordinates within each section" do
+    board = Boards::Board.new(game_with_boards("Farm", "Oasis", "Paddock", "Tavern"))
+
+    # Farm section 0: local (1,7) = "L"; global (1,7)
+    assert_equal "L", board.terrain_at(1, 7)
+    # Oasis section 1: local (2,7) = "L"; global (2, 10+7=17)
+    assert_equal "L", board.terrain_at(2, 17)
+    # Paddock section 2: local (2,8) = "L"; global (10+2=12, 8)
+    assert_equal "L", board.terrain_at(12, 8)
+    # Tavern section 3: local (6,2) = "L"; global (10+6=16, 10+2=12)
+    assert_equal "L", board.terrain_at(16, 12)
+  end
+
+  test "Board.new raises ArgumentError for unknown board type" do
+    assert_raises(ArgumentError) { Boards::Board.new(game_with_boards("Swamp")) }
+  end
+
+  test "Board.new raises ArgumentError for unknown tile class in board contents" do
+    contents = BoardState.new
+    contents.place_tile(0, 0, "GoblinTile", 2)
+    game = GameStub.new([], contents)
+    assert_raises(ArgumentError) { Boards::Board.new(game) }
+  end
+end

--- a/test/models/boards/farm_board_test.rb
+++ b/test/models/boards/farm_board_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class FarmBoardTest < ActiveSupport::TestCase
+  test "terrain_at returns correct terrain for known positions (unflipped)" do
+    board = Boards::FarmBoard.new(0)
+    assert_equal "D", board.terrain_at(0, 0)  # row 0: "DDCWWTTTGG"
+    assert_equal "L", board.terrain_at(1, 7)  # row 1: "DSCWTTTLGG" — location hex
+    assert_equal "W", board.terrain_at(9, 9)  # row 9: "TTTWWWWWWW"
+  end
+
+  test "location_hexes returns two Farm tile spawn positions" do
+    board = Boards::FarmBoard.new(0)
+    assert_equal [ { r: 1, c: 7, k: "Farm" }, { r: 5, c: 2, k: "Farm" } ], board.location_hexes
+  end
+
+  test "scoring_hexes returns the Castle scoring hex" do
+    board = Boards::FarmBoard.new(0)
+    assert_equal [ { r: 1, c: 1, k: "Castle" } ], board.scoring_hexes
+  end
+
+  test "terrain_at reflects flipped layout (rows and columns reversed)" do
+    board = Boards::FarmBoard.new(1)
+    # Flipped = map.reverse.map(&:reverse)
+    # Flipped row 0 = original row 9 reversed: "TTTWWWWWWW" → "WWWWWWWTTT"
+    assert_equal "W", board.terrain_at(0, 0)
+    # Flipped row 9 = original row 0 reversed: "DDCWWTTTGG" → "GGTTTTWCDD"
+    assert_equal "D", board.terrain_at(9, 9)
+  end
+end

--- a/test/models/boards/oasis_board_test.rb
+++ b/test/models/boards/oasis_board_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class OasisBoardTest < ActiveSupport::TestCase
+  test "terrain_at returns correct terrain for known positions" do
+    board = Boards::OasisBoard.new(0)
+    assert_equal "D", board.terrain_at(0, 0)  # row 0: "DDCWWTTGGG"
+    assert_equal "L", board.terrain_at(2, 7)  # row 2: "DDWFFTTLFG" — location hex
+    assert_equal "S", board.terrain_at(7, 1)  # row 7: "WSCFWLDDCW" — Castle (S)
+  end
+
+  test "location_hexes returns two Oasis tile spawn positions" do
+    board = Boards::OasisBoard.new(0)
+    assert_equal [ { r: 2, c: 7, k: "Oasis" }, { r: 7, c: 5, k: "Oasis" } ], board.location_hexes
+  end
+
+  test "scoring_hexes returns the Castle scoring hex" do
+    board = Boards::OasisBoard.new(0)
+    assert_equal [ { r: 7, c: 1, k: "Castle" } ], board.scoring_hexes
+  end
+end

--- a/test/models/boards/paddock_board_test.rb
+++ b/test/models/boards/paddock_board_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class PaddockBoardTest < ActiveSupport::TestCase
+  test "terrain_at returns correct terrain for known positions" do
+    board = Boards::PaddockBoard.new(0)
+    assert_equal "C", board.terrain_at(0, 0)  # row 0: "CCCDDWDDDD"
+    assert_equal "L", board.terrain_at(2, 8)  # row 2: "MMCMMWDDLF" — location hex
+    assert_equal "S", board.terrain_at(7, 5)  # row 7: "GGTWGSGFGT" — Castle (S)
+  end
+
+  test "location_hexes returns two Paddock tile spawn positions" do
+    board = Boards::PaddockBoard.new(0)
+    assert_equal [ { r: 2, c: 8, k: "Paddock" }, { r: 6, c: 1, k: "Paddock" } ], board.location_hexes
+  end
+
+  test "scoring_hexes returns the Castle scoring hex" do
+    board = Boards::PaddockBoard.new(0)
+    assert_equal [ { r: 7, c: 5, k: "Castle" } ], board.scoring_hexes
+  end
+end

--- a/test/models/boards/tavern_board_test.rb
+++ b/test/models/boards/tavern_board_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class TavernBoardTest < ActiveSupport::TestCase
+  test "terrain_at returns correct terrain for known positions" do
+    board = Boards::TavernBoard.new(0)
+    assert_equal "F", board.terrain_at(0, 0)  # row 0: "FDDMMDDCCC"
+    assert_equal "L", board.terrain_at(6, 2)  # row 6: "DFLCWTTLCG" — location hex
+    assert_equal "S", board.terrain_at(3, 3)  # row 3: "WWFSGGTTMM" — Castle (S)
+  end
+
+  test "location_hexes returns two Tavern tile spawn positions" do
+    board = Boards::TavernBoard.new(0)
+    assert_equal [ { r: 6, c: 2, k: "Tavern" }, { r: 6, c: 7, k: "Tavern" } ], board.location_hexes
+  end
+
+  test "scoring_hexes returns the Castle scoring hex" do
+    board = Boards::TavernBoard.new(0)
+    assert_equal [ { r: 3, c: 3, k: "Castle" } ], board.scoring_hexes
+  end
+end


### PR DESCRIPTION
## Summary

- Add 17 unit tests covering `BoardSection` flip logic, `terrain_at` spot checks, `location_hexes`, and `scoring_hexes` for all 4 board sections, plus `Board#terrain_at` section routing and `Board.new` error handling
- Replace `constantize` in `Board#initialize` with explicit `BOARD_CLASSES` / `TILE_CLASSES` registries — unknown names now raise `ArgumentError` with a clear message instead of a cryptic `NameError`
- Rename `silver_hexes` → `scoring_hexes` (names the role, not the terrain char; uniform `{r:, c:, k:}` interface consistent with `location_hexes`; forward-compatible with Palace/Silo hexes in expansions)
- Delete `Tiles::CastleTile` (dead code — Castle hexes never hold tiles)

## Test plan

- [ ] `bin/rails test test/models/boards/` — 17 tests, all green
- [ ] `bin/rails test` — full suite, 167 tests, all green
- [ ] `bin/rubocop app/models/boards/ test/models/boards/` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)