### PR TITLE
Block building tiles when player has no settlements left

### DIFF
--- a/app/models/tiles/farm_tile.rb
+++ b/app/models/tiles/farm_tile.rb
@@ -1,6 +1,7 @@
 module Tiles
   class FarmTile < Tiles::Tile
     def build_terrain = "G"
+    def builds_settlement? = true
 
     def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:)
       adjacent_grass = board_contents.settlements_for(player_order).flat_map do |r, c|

--- a/app/models/tiles/oasis_tile.rb
+++ b/app/models/tiles/oasis_tile.rb
@@ -1,6 +1,7 @@
 module Tiles
   class OasisTile < Tiles::Tile
     def build_terrain = "D"
+    def builds_settlement? = true
 
     def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:)
       adjacent_desert = board_contents.settlements_for(player_order).flat_map do |r, c|

--- a/app/models/tiles/tavern_tile.rb
+++ b/app/models/tiles/tavern_tile.rb
@@ -1,6 +1,7 @@
 module Tiles
   class TavernTile < Tiles::Tile
     BUILDABLE_TERRAIN = %w[C D F G T].freeze
+    def builds_settlement? = true
 
     # Each pair is [forward_dir, backward_dir]; each dir is [even_row_step, odd_row_step].
     DIRECTION_PAIRS = [

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -18,6 +18,10 @@ module Tiles
       true
     end
 
+    def builds_settlement?
+      false
+    end
+
     def self.from_hash(hash)
       "Tiles::#{hash['klass']}".constantize.new(0)
     rescue NameError

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -131,8 +131,10 @@ class TurnEngine
     return false unless @game.mandatory_count == Game::MANDATORY_COUNT ||
       @game.mandatory_count <= 0 || !@game.current_player.settlements_remaining?
     @game.instantiate
+    tile_obj = Tiles::Tile.from_hash(tile)
+    return false if tile_obj.builds_settlement? && !@game.current_player.settlements_remaining?
     ctx = { player_order: @game.current_player.order, board_contents: @game.board_contents, board: @game.board }
-    Tiles::Tile.from_hash(tile).activatable?(**ctx)
+    tile_obj.activatable?(**ctx)
   end
 
   def turn_endable?

--- a/test/models/tiles/farm_tile_test.rb
+++ b/test/models/tiles/farm_tile_test.rb
@@ -130,4 +130,8 @@ class Tiles::FarmTileTest < ActiveSupport::TestCase
     tile = Tiles::FarmTile.new(0)
     assert_not tile.activatable?(player_order: chris.order, board_contents: game.board_contents, board: game.board)
   end
+
+  test "builds_settlement? returns true" do
+    assert Tiles::FarmTile.new(0).builds_settlement?
+  end
 end

--- a/test/models/tiles/oasis_tile_test.rb
+++ b/test/models/tiles/oasis_tile_test.rb
@@ -126,4 +126,8 @@ class Tiles::OasisTileTest < ActiveSupport::TestCase
     tile = Tiles::OasisTile.new(0)
     assert_not tile.activatable?(player_order: chris.order, board_contents: game.board_contents, board: game.board)
   end
+
+  test "builds_settlement? returns true" do
+    assert Tiles::OasisTile.new(0).builds_settlement?
+  end
 end

--- a/test/models/tiles/paddock_tile_test.rb
+++ b/test/models/tiles/paddock_tile_test.rb
@@ -71,4 +71,8 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
   test "from_hash returns a PaddockTile" do
     assert_instance_of Tiles::PaddockTile, Tiles::Tile.from_hash("klass" => "PaddockTile")
   end
+
+  test "builds_settlement? returns false" do
+    assert_not Tiles::PaddockTile.new(0).builds_settlement?
+  end
 end

--- a/test/models/tiles/tavern_tile_test.rb
+++ b/test/models/tiles/tavern_tile_test.rb
@@ -155,4 +155,8 @@ class Tiles::TavernTileTest < ActiveSupport::TestCase
   test "from_hash returns a TavernTile" do
     assert_instance_of Tiles::TavernTile, Tiles::Tile.from_hash("klass" => "TavernTile")
   end
+
+  test "builds_settlement? returns true" do
+    assert Tiles::TavernTile.new(0).builds_settlement?
+  end
 end

--- a/test/models/tiles/tile_test.rb
+++ b/test/models/tiles/tile_test.rb
@@ -16,6 +16,10 @@ class Tiles::TileTest < ActiveSupport::TestCase
     assert Tiles::Tile.new(0).activatable?(player_order: 0, board_contents: BoardState.new, board: nil)
   end
 
+  test "builds_settlement? returns false" do
+    assert_not Tiles::Tile.new(0).builds_settlement?
+  end
+
   test "from_hash raises ArgumentError for unknown klass" do
     assert_raises(ArgumentError) { Tiles::Tile.from_hash("klass" => "BogusTimeTile") }
   end

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -250,6 +250,18 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_not @engine.tile_activatable?(tile)
   end
 
+  test "tile_activatable? returns false for a building tile when player has no settlements left" do
+    @game.current_player.update!(supply: { "settlements" => 0 })
+    @game.update!(mandatory_count: 0)
+    tile = { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false }
+
+    assert_not @engine.tile_activatable?(tile)
+  end
+
+  test "PaddockTile#builds_settlement? returns false" do
+    assert_not Tiles::PaddockTile.new(0).builds_settlement?
+  end
+
   private
 
   def find_tile_trigger_pair


### PR DESCRIPTION
## Summary
- Adds `builds_settlement?` to `Tiles::Tile` base class (returns `false`)
- Overrides to `true` on `OasisTile`, `FarmTile`, and `TavernTile`
- Guards `tile_activatable?` in `TurnEngine` to return `false` for building tiles when the player's supply is exhausted
- `PaddockTile` (movement) is unaffected and remains activatable with zero supply

## Test plan
- [ ] `builds_settlement?` returns `false` on base `Tile` and `PaddockTile`
- [ ] `builds_settlement?` returns `true` on `OasisTile`, `FarmTile`, `TavernTile`
- [ ] `tile_activatable?` returns `false` for an Oasis tile when supply is 0
- [ ] Manual: confirm building tiles are not offered as options when settlements are exhausted

🤖 Generated with [Claude Code](https://claude.com/claude-code)