### PR TITLE
Restrict tile activation to mandatory phase at start or completion

### DIFF
--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -128,8 +128,8 @@ class TurnEngine
   def tile_activatable?(tile)
     return false if tile["used"]
     return false unless "Tiles::#{tile["klass"]}".safe_constantize
-    return false unless @game.mandatory_count == Game::MANDATORY_COUNT ||
-      @game.mandatory_count <= 0 || !@game.current_player.settlements_remaining?
+    return false unless @game.current_action["type"] == "mandatory" &&
+      (@game.mandatory_count == Game::MANDATORY_COUNT || @game.mandatory_count <= 0)
     @game.instantiate
     ctx = { player_order: @game.current_player.order, board_contents: @game.board_contents, board: @game.board }
     Tiles::Tile.from_hash(tile).activatable?(**ctx)

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -246,7 +246,13 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.update!(mandatory_count: 1)
     tile = { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false }
 
-    # mandatory_count=1: not at MANDATORY_COUNT(3), not <= 0, settlements remaining → blocked
+    assert_not @engine.tile_activatable?(tile)
+  end
+
+  test "tile_activatable? returns false when a tile action is already in progress" do
+    @game.update!(current_action: { "type" => "oasis" }, mandatory_count: 0)
+    tile = { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false }
+
     assert_not @engine.tile_activatable?(tile)
   end
 


### PR DESCRIPTION
## Summary
- Tiles were incorrectly offered when another tile action was already in progress (e.g. `current_action["type"] == "oasis"`)
- Tiles were also incorrectly offered mid-mandatory (e.g. after 1 of 3 required builds)
- New rule: tiles are only selectable when `current_action["type"] == "mandatory"` AND `mandatory_count` is either at the full value (not started) or zero (completed)
- Removes the previous `!settlements_remaining?` escape hatch, which was a workaround and is no longer needed with this cleaner condition

## Test plan
- [ ] `tile_activatable?` returns false when `current_action` is a tile type (e.g. `"oasis"`)
- [ ] `tile_activatable?` returns false when mandatory builds are partially complete
- [ ] Manual: confirm tiles are not offered mid-mandatory or while another tile action is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)