### PR TITLE
Block all game actions once a game is completed

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,4 +1,6 @@
 class GamesController < ApplicationController
+  before_action :require_game_playing, only: [ :action, :select_action, :end_turn, :undo_move ]
+
   def new
     @game = Game.new
   end
@@ -30,13 +32,6 @@ class GamesController < ApplicationController
   # 3. use a tile that I have to move a piece on the board
   def action
     Rails.logger.debug("TURN ACTION PARAMS: #{action_params.inspect}")
-    @game = Current.user.games.find(action_params[:id])
-    unless @game
-      respond_to do |format|
-        format.json { render json: { message: "Cannot find game" } }
-      end
-      return
-    end
 
     coord = Coordinate.new(action_params[:build_row], action_params[:build_col])
     engine = TurnEngine.new(@game)
@@ -62,7 +57,6 @@ class GamesController < ApplicationController
   end
 
   def select_action
-    @game = Current.user.games.find(params[:id])
     TurnEngine.new(@game).select_action(params[:action_type])
     respond_to do |format|
       format.html { redirect_to @game }
@@ -73,7 +67,6 @@ class GamesController < ApplicationController
 
   def end_turn
     Rails.logger.debug("END TURN action")
-    @game = Current.user.games.find(params[:id])
     current_gp = @game.game_players.find_by(player: Current.user)
     engine = TurnEngine.new(@game)
     engine.end_turn if current_gp == @game.current_player && engine.turn_endable?
@@ -104,7 +97,6 @@ class GamesController < ApplicationController
 
   def undo_move
     Rails.logger.debug("UNDO MOVE action")
-    @game = Current.user.games.find(params[:id])
     engine = TurnEngine.new(@game)
     engine.undo_last_move if engine.undo_allowed?
     respond_to do |format|
@@ -115,6 +107,11 @@ class GamesController < ApplicationController
   end
 
   private
+
+  def require_game_playing
+    @game = Current.user.games.find(params[:id])
+    head :no_content unless @game.playing?
+  end
 
   def action_params
     params.permit(:id, :build_row, :build_col)

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -189,6 +189,46 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     post undo_move_game_url(game)
     assert_redirected_to game_path(game)
   end
+
+  test "POST action does nothing when game is completed" do
+    game = games(:game2player)
+    game.update!(state: "completed")
+    move_count_before = game.moves.count
+
+    post action_game_url(game), params: { build_row: 0, build_col: 0 }, as: :turbo_stream
+
+    assert_equal move_count_before, game.moves.count
+  end
+
+  test "POST select_action does nothing when game is completed" do
+    game = games(:game2player)
+    game.update!(state: "completed")
+    action_before = game.current_action
+
+    post select_action_game_url(game), params: { action_type: "oasis" }, as: :turbo_stream
+
+    assert_equal action_before, game.reload.current_action
+  end
+
+  test "POST end_turn does nothing when game is completed" do
+    game = games(:game2player)
+    game.update!(state: "completed", mandatory_count: 0)
+    move_count_before = game.moves.count
+
+    post end_turn_game_url(game), as: :turbo_stream
+
+    assert_equal move_count_before, game.moves.count
+  end
+
+  test "POST undo_move does nothing when game is completed" do
+    game = games(:game2player)
+    game.update!(state: "completed")
+    move_count_before = game.moves.count
+
+    post undo_move_game_url(game), as: :turbo_stream
+
+    assert_equal move_count_before, game.moves.count
+  end
 end
 
 class GamesControllerUnauthenticatedTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
## Summary
- Adds `before_action :require_game_playing` to `GamesController`, scoped to `action`, `select_action`, `end_turn`, and `undo_move`
- Returns `204 No Content` immediately if the game is not in the `playing` state
- Removes redundant per-action game loading (now done once in the before_action)

## Test plan
- [ ] `POST action` does nothing when game is completed
- [ ] `POST select_action` does nothing when game is completed
- [ ] `POST end_turn` does nothing when game is completed
- [ ] `POST undo_move` does nothing when game is completed
- [ ] All existing controller tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)