### PR TITLE
Add end_game move when game completes

### DIFF
--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -206,7 +206,19 @@ class TurnEngine
       @game.save
     end
     max_order = @game.game_players.count - 1
-    @game.complete! if @game.ending? && game_player.order == max_order
+    if @game.ending? && game_player.order == max_order
+      @game.move_count += 1
+      @game.moves.create(
+        order: @game.move_count,
+        game_player: game_player,
+        deliberate: false,
+        action: "end_game",
+        reversible: false,
+        message: "Game over!"
+      )
+      @game.save
+      @game.complete!
+    end
   end
 
   def undo_last_move

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -230,6 +230,19 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_equal 0, @game.moves.count
   end
 
+  test "end_turn creates an end_game move when the last player ends and game is ending" do
+    paula = @game.game_players.find { |gp| gp.order == 1 }
+    @game.update!(current_player: paula, ending: true, mandatory_count: 0)
+
+    @engine.end_turn
+
+    end_game_move = @game.moves.find_by(action: "end_game")
+    assert end_game_move, "expected an end_game move to be created"
+    assert_not end_game_move.deliberate
+    assert_not end_game_move.reversible
+    assert_equal paula, end_game_move.game_player
+  end
+
   test "tile_activatable? returns false for a used tile" do
     tile = { "klass" => "OasisTile", "from" => "[2, 7]", "used" => true }
 


### PR DESCRIPTION
## Summary
- When the last player ends their turn and the game is in the `ending` state, a move with `action: "end_game"`, `deliberate: false`, `reversible: false` is created before `complete!` is called
- The move is associated with the last player (the one who triggered the end)

## Test plan
- [ ] `end_turn` creates an `end_game` move when the last player ends and `ending` is true
- [ ] Move has `deliberate: false` and `reversible: false`
- [ ] Move is associated with the last player

🤖 Generated with [Claude Code](https://claude.com/claude-code)