### PR TITLE
Block building tiles from activating when player has no settlements left

### DIFF
--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -129,7 +129,7 @@ class TurnEngine
     return false if tile["used"]
     return false unless "Tiles::#{tile["klass"]}".safe_constantize
     return false unless @game.current_action["type"] == "mandatory" &&
-      (@game.mandatory_count == Game::MANDATORY_COUNT || @game.mandatory_count <= 0)
+      (@game.mandatory_count == Game::MANDATORY_COUNT || @game.mandatory_count <= 0 || !@game.current_player.settlements_remaining?)
     @game.instantiate
     tile_obj = Tiles::Tile.from_hash(tile)
     return false if tile_obj.builds_settlement? && !@game.current_player.settlements_remaining?


### PR DESCRIPTION
## Summary

- Adds `builds_settlement?` to the `Tile` base class (returns `false` by default)
- `FarmTile`, `OasisTile`, and `TavernTile` override to return `true` (they place settlements); `PaddockTile` inherits `false` (it moves them)
- `tile_activatable?` in `TurnEngine` now blocks activation of building tiles when the player has no settlements remaining — even mid-turn when `mandatory_count > 0`
- Also fixes the activatable check to allow tile activation when out of settlements regardless of `mandatory_count`

## Test plan

- [ ] `Tile#builds_settlement?` returns false by default
- [ ] Building tiles (Farm, Oasis, Tavern) return true; movement tiles (Paddock) return false
- [ ] `tile_activatable?` returns false for building tiles when supply is 0
- [ ] `tile_activatable?` returns true for Paddock when supply is 0 (can still move)
- [ ] `tile_activatable?` is true when supply is 0 regardless of mandatory_count (for movement tiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)