### PR TITLE
Refactor dashboard views and broadcast (#102 follow-up)

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class DashboardController < ApplicationController
   def index
-    @my_games = Current.user.my_games
-    @waiting_games = Current.user.waiting_games
-    @completed_games = Current.user.completed_games
+    @my_games = Current.user.my_games.includes(game_players: :player)
+    @waiting_games = Current.user.waiting_games.includes(game_players: :player)
+    @completed_games = Current.user.completed_games.includes(game_players: :player)
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -107,6 +107,10 @@ class Game < ApplicationRecord
     TurnEngine.new(self).turn_state
   end
 
+  def player_handles
+    game_players.map { |gp| gp.player.handle }.join(", ")
+  end
+
   def live_scores
     Scoring.new(self).compute
   end
@@ -147,11 +151,11 @@ class Game < ApplicationRecord
     game_players.each do |gp|
       user = gp.player
       broadcast_update_to("user_#{user.id}", target: "dashboard-my-games",
-        partial: "dashboard/my_games", locals: { games: user.my_games })
+        partial: "dashboard/my_games", locals: { games: user.my_games.includes(game_players: :player) })
       broadcast_update_to("user_#{user.id}", target: "dashboard-waiting-games",
-        partial: "dashboard/waiting_games", locals: { games: user.waiting_games, current_user: user })
+        partial: "dashboard/waiting_games", locals: { games: user.waiting_games.includes(game_players: :player) })
       broadcast_update_to("user_#{user.id}", target: "dashboard-completed-games",
-        partial: "dashboard/completed_games", locals: { games: user.completed_games })
+        partial: "dashboard/completed_games", locals: { games: user.completed_games.includes(game_players: :player) })
     end
   end
 

--- a/app/views/dashboard/_completed_games.html.erb
+++ b/app/views/dashboard/_completed_games.html.erb
@@ -1,7 +1,7 @@
 <h2>Completed Games</h2>
 <% games.each do |game| %>
   <%= link_to game_path(game), class: "game-row" do %>
-    <div>Game <%= game.id %> &mdash; <%= game.game_players.map { |gp| gp.player.handle }.join(", ") %></div>
+    <div>Game <%= game.id %> &mdash; <%= game.player_handles %></div>
     <% if game.scores.present? %>
       <div class="scores"><%= game.game_players.map { |gp| "#{gp.player.handle}: #{game.scores.dig(gp.order.to_s, "total")}" }.join(", ") %></div>
     <% end %>

--- a/app/views/dashboard/_my_games.html.erb
+++ b/app/views/dashboard/_my_games.html.erb
@@ -3,18 +3,12 @@
   <% if game.playing? %>
     <%= link_to game_path(game), class: "game-row" do %>
       <div>Game <%= game.id %> &mdash; <%= game.turn_state %></div>
-      <div class="player-handles">
-        Players:
-        <%= game.game_players.map { |gp| gp.player.handle }.join(", ") %>
-      </div>
+      <div class="player-handles">Players: <%= game.player_handles %></div>
     <% end %>
   <% else %>
     <div class="game-row">
-      <div>Game <%= game.id %> &mdash; Waiting for players</div>
-      <div class="player-handles">
-        Players:
-        <%= game.game_players.map { |gp| gp.player.handle }.join(", ") %>
-      </div>
+      <div>Game <%= game.id %> &mdash; <%= game.turn_state %></div>
+      <div class="player-handles">Players: <%= game.player_handles %></div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/dashboard/_waiting_games.html.erb
+++ b/app/views/dashboard/_waiting_games.html.erb
@@ -3,7 +3,7 @@
   <table>
     <% games.each do |game| %>
       <tr>
-        <td>Game <%= game.id %> &mdash; <%= game.game_players.map { |gp| gp.player.handle }.join(", ") %></td>
+        <td>Game <%= game.id %> &mdash; <%= game.player_handles %></td>
         <td><%= button_to "Join", join_game_path(game) %></td>
       </tr>
     <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <div id="dashboard-waiting-games" class="fancy-section">
-    <%= render "dashboard/waiting_games", games: @waiting_games, current_user: current_user %>
+    <%= render "dashboard/waiting_games", games: @waiting_games %>
   </div>
 
   <div id="dashboard-completed-games" class="fancy-section">


### PR DESCRIPTION
## Summary

Follow-up refactor to the real-time dashboard (#105).

- **`Game#player_handles`** — extracts repeated `game_players.map { |gp| gp.player.handle }.join(", ")` pattern from three partials into a single model method
- **N+1 prevention** — adds `.includes(game_players: :player)` to all three game list queries in both the controller and `broadcast_dashboard_update`
- **Hardcoded string removed** — `_my_games` waiting branch now calls `game.turn_state` (which already returns `"Waiting for players"`) instead of duplicating the string
- **Unused local removed** — `current_user` was passed to `_waiting_games` but never used

🤖 Generated with [Claude Code](https://claude.com/claude-code)