### PR TITLE
Extract MoveApplicator to eliminate TurnEngine/GameReplayer duplication

### DIFF
--- a/app/models/game_replayer.rb
+++ b/app/models/game_replayer.rb
@@ -1,101 +1,11 @@
 class GameReplayer
   def initialize(game)
-    snap = game.base_snapshot
-    @board = BoardState.load(snap["board_contents"])
-    @boards = snap["boards"]
-    @deck = snap["deck"].dup
-    @discard = snap["discard"].dup
-    @goals = snap["goals"]&.dup
-    @mandatory_count = snap["mandatory_count"]
-    @current_action = snap["current_action"].deep_dup
-    @current_player_order = snap["current_player_order"]
-    @players = snap["players"].to_h { |p| [ p["order"], p.except("order").deep_dup ] }
+    @state = MoveApplicator::HashState.new(game.base_snapshot)
     @moves = game.moves
   end
 
   def replay
-    @moves.order(:order).each { |move| apply(move) }
-    result
-  end
-
-  private
-
-  def apply(move)
-    order = move.game_player.order
-    player = @players[order]
-
-    case move.action
-    when "build"
-      to = Coordinate.from_key(move.to)
-      @board.place_settlement(to.row, to.col, order)
-      player["supply"]["settlements"] -= 1
-      tile_klass = move.payload&.dig("tile_klass")
-      if tile_klass
-        @current_action = { "type" => "mandatory" }
-        mark_tile_used(player, tile_klass)
-      else
-        @mandatory_count -= 1
-      end
-
-    when "end_turn"
-      @discard.push(move.payload["card_discarded"])
-      player["hand"] = move.payload["card_drawn"]
-      if move.payload["reshuffled"]
-        @deck = move.payload["deck_after"].dup
-        @discard = []
-      else
-        @deck.shift
-      end
-      @mandatory_count = Game::MANDATORY_COUNT
-      @current_action = { "type" => "mandatory" }
-      next_order = (order + 1) % @players.size
-      @current_player_order = next_order
-      next_player = @players[next_order]
-      next_player["tiles"] = (next_player["tiles"] || []).map { |t| t.merge("used" => false) }
-
-    when "pick_up_tile"
-      coord = Coordinate.from_key(move.from)
-      @board.decrement_tile(coord.row, coord.col)
-      klass = move.payload["klass"]
-      player["tiles"] = (player["tiles"] || []) + [ { "klass" => klass, "from" => move.from, "used" => true } ]
-
-    when "forfeit_tile"
-      player["tiles"] = (player["tiles"] || []).reject { |t| t["from"] == move.from }
-
-    when "select_action"
-      @current_action = { "type" => move.to }
-
-    when "select_settlement"
-      @current_action = @current_action.merge("from" => move.from)
-
-    when "move_settlement"
-      from = Coordinate.from_key(move.from)
-      to = Coordinate.from_key(move.to)
-      @board.move_settlement(from.row, from.col, to.row, to.col)
-      @current_action = { "type" => "mandatory" }
-      mark_tile_used(player, "PaddockTile")
-    end
-  end
-
-  def mark_tile_used(player, klass)
-    idx = player["tiles"]&.index { |t| t["klass"] == klass && t["used"] == false }
-    return unless idx
-    updated = player["tiles"].dup
-    updated[idx] = updated[idx].merge("used" => true)
-    player["tiles"] = updated
-  end
-
-  def result
-    {
-      "board_contents" => BoardState.dump(@board),
-      "boards" => @boards,
-      "deck" => @deck,
-      "discard" => @discard,
-      "goals" => @goals,
-      "mandatory_count" => @mandatory_count,
-      "current_action" => @current_action,
-      "current_player_order" => @current_player_order,
-      "players" => @players.map { |order, data| { "order" => order }.merge(data) }
-    }
+    @moves.order(:order).each { |move| MoveApplicator.dispatch(@state, move) }
+    @state.result
   end
 end

--- a/app/services/move_applicator.rb
+++ b/app/services/move_applicator.rb
@@ -1,0 +1,191 @@
+module MoveApplicator
+  def self.dispatch(backend, move)
+    player_order = move.game_player.order
+    case move.action
+    when "select_action"
+      backend.apply_select_action(player_order: player_order, type: move.to)
+    when "select_settlement"
+      backend.apply_select_settlement(player_order: player_order, from: move.from)
+    when "move_settlement"
+      backend.apply_move_settlement(player_order: player_order, from: move.from, to: move.to)
+    when "build"
+      backend.apply_build(player_order: player_order, to: move.to, tile_klass: move.payload&.dig("tile_klass"))
+    when "pick_up_tile"
+      backend.apply_pick_up_tile(player_order: player_order, from: move.from, klass: move.payload["klass"])
+    when "forfeit_tile"
+      backend.apply_forfeit_tile(
+        player_order: player_order,
+        from: move.from,
+        klass: move.payload["klass"],
+        used: move.to == "true"
+      )
+    when "end_turn"
+      backend.apply_end_turn(
+        player_order: player_order,
+        card_discarded: move.payload["card_discarded"],
+        card_drawn: move.payload["card_drawn"],
+        reshuffled: move.payload["reshuffled"],
+        deck_after: move.payload["deck_after"]
+      )
+    end
+  end
+end
+
+class MoveApplicator::HashState
+  attr_reader :board, :players, :deck, :discard, :mandatory_count, :current_action, :current_player_order
+
+  def initialize(snapshot)
+    @board = BoardState.load(snapshot["board_contents"])
+    @players = snapshot["players"].to_h { |p| [ p["order"], p.except("order").deep_dup ] }
+    @deck = snapshot["deck"].dup
+    @discard = snapshot["discard"].dup
+    @goals = snapshot["goals"]&.dup
+    @boards = snapshot["boards"]
+    @mandatory_count = snapshot["mandatory_count"]
+    @current_action = snapshot["current_action"].deep_dup
+    @current_player_order = snapshot["current_player_order"]
+  end
+
+  def apply_select_action(player_order:, type:)
+    @current_action = { "type" => type }
+  end
+
+  def apply_select_settlement(player_order:, from:)
+    @current_action = @current_action.merge("from" => from)
+  end
+
+  def apply_build(player_order:, to:, tile_klass:)
+    coord = Coordinate.from_key(to)
+    @board.place_settlement(coord.row, coord.col, player_order)
+    @players[player_order]["supply"]["settlements"] -= 1
+    if tile_klass
+      mark_tile_used(@players[player_order], tile_klass)
+      @current_action = { "type" => "mandatory" }
+    else
+      @mandatory_count -= 1
+    end
+  end
+
+  def apply_pick_up_tile(player_order:, from:, klass:)
+    coord = Coordinate.from_key(from)
+    @board.decrement_tile(coord.row, coord.col)
+    player = @players[player_order]
+    player["tiles"] = (player["tiles"] || []) + [ { "klass" => klass, "from" => from, "used" => true } ]
+  end
+
+  def apply_forfeit_tile(player_order:, from:, klass:, used:)
+    player = @players[player_order]
+    player["tiles"] = (player["tiles"] || []).reject { |t| t["from"] == from }
+  end
+
+  def apply_end_turn(player_order:, card_discarded:, card_drawn:, reshuffled:, deck_after:)
+    next_order = (player_order + 1) % @players.size
+    @discard.push(card_discarded)
+    @players[player_order]["hand"] = card_drawn
+    if reshuffled
+      @deck = deck_after.dup
+      @discard = []
+    else
+      @deck.shift
+    end
+    @mandatory_count = Game::MANDATORY_COUNT
+    @current_action = { "type" => "mandatory" }
+    @current_player_order = next_order
+    next_player = @players[next_order]
+    next_player["tiles"] = (next_player["tiles"] || []).map { |t| t.merge("used" => false) }
+  end
+
+  def apply_move_settlement(player_order:, from:, to:)
+    from_coord = Coordinate.from_key(from)
+    to_coord = Coordinate.from_key(to)
+    @board.move_settlement(from_coord.row, from_coord.col, to_coord.row, to_coord.col)
+    @current_action = { "type" => "mandatory" }
+    mark_tile_used(@players[player_order], "PaddockTile")
+  end
+
+  private
+
+  def mark_tile_used(player, klass)
+    idx = player["tiles"]&.index { |t| t["klass"] == klass && t["used"] == false }
+    return unless idx
+    updated = player["tiles"].dup
+    updated[idx] = updated[idx].merge("used" => true)
+    player["tiles"] = updated
+  end
+
+  public
+
+  def result
+    {
+      "board_contents" => BoardState.dump(@board),
+      "boards" => @boards,
+      "deck" => @deck,
+      "discard" => @discard,
+      "goals" => @goals,
+      "mandatory_count" => @mandatory_count,
+      "current_action" => @current_action,
+      "current_player_order" => @current_player_order,
+      "players" => @players.map { |order, data| { "order" => order }.merge(data) }
+    }
+  end
+end
+
+class MoveApplicator::LiveState
+  def initialize(game)
+    @game = game
+  end
+
+  def apply_build(player_order:, to:, tile_klass:)
+    coord = Coordinate.from_key(to)
+    @game.board_contents_will_change!
+    @game.board_contents.remove(coord.row, coord.col)
+    gp = player_for(player_order)
+    gp.increment_supply!
+    @game.ending = false
+    if tile_klass
+      gp.mark_tile_unused!(tile_klass)
+      @game.current_action = { "type" => tile_klass.delete_suffix("Tile").downcase }
+    else
+      @game.mandatory_count += 1
+    end
+    gp.save
+  end
+
+  def apply_pick_up_tile(player_order:, from:, klass:)
+    coord = Coordinate.from_key(from)
+    @game.board_contents_will_change!
+    @game.board_contents.increment_tile(coord.row, coord.col)
+    player_for(player_order).remove_tile_from!(from)
+    player_for(player_order).save
+  end
+
+  def apply_forfeit_tile(player_order:, from:, klass:, used:)
+    gp = player_for(player_order)
+    gp.restore_tile!(klass, from: from, used: used)
+    gp.save
+  end
+
+  def apply_select_action(player_order:, type:)
+    @game.current_action = { "type" => "mandatory" }
+  end
+
+  def apply_select_settlement(player_order:, from:)
+    @game.current_action_will_change!
+    @game.current_action.delete("from")
+  end
+
+  def apply_move_settlement(player_order:, from:, to:)
+    @game.board_contents_will_change!
+    @game.board_contents.move_settlement(*Coordinate.from_key(to), *Coordinate.from_key(from))
+    @game.current_action = { "type" => "paddock", "from" => from }
+    gp = player_for(player_order)
+    gp.mark_tile_unused!("PaddockTile")
+    gp.save
+  end
+
+  private
+
+  def player_for(order)
+    @game.game_players.find { |gp| gp.order == order }
+  end
+end

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -226,44 +226,11 @@ class TurnEngine
     return unless last_deliberate
     Rails.logger.debug("UNDOING back to deliberate move #{last_deliberate.inspect}")
     @game.instantiate
+    backend = MoveApplicator::LiveState.new(@game)
     @game.moves.where("id >= ?", last_deliberate.id).order(id: :desc).each do |move|
       Rails.logger.debug("  undoing #{move.action} (order #{move.order})")
       @game.move_count -= 1
-      case move.action
-      when "build"
-        @game.board_contents_will_change!
-        @game.board_contents.remove(*Coordinate.from_key(move.to))
-        move.game_player.increment_supply!
-        @game.ending = false
-        tile_klass = move.payload&.dig("tile_klass")
-        if tile_klass
-          move.game_player.mark_tile_unused!(tile_klass)
-          @game.current_action = { "type" => tile_klass.delete_suffix("Tile").downcase }
-        else
-          @game.mandatory_count += 1
-        end
-        move.game_player.save
-      when "move_settlement"
-        @game.board_contents_will_change!
-        @game.board_contents.move_settlement(*Coordinate.from_key(move.to), *Coordinate.from_key(move.from))
-        @game.current_action = { "type" => "paddock", "from" => move.from }
-        move.game_player.mark_tile_unused!("PaddockTile")
-        move.game_player.save
-      when "select_action"
-        @game.current_action = { "type" => "mandatory" }
-      when "select_settlement"
-        @game.current_action_will_change!
-        @game.current_action.delete("from")
-      when "pick_up_tile"
-        @game.board_contents_will_change!
-        @game.board_contents.increment_tile(*Coordinate.from_key(move.from))
-        move.game_player.remove_tile_from!(move.from)
-        move.game_player.save
-      when "forfeit_tile"
-        klass = move.payload["klass"]
-        move.game_player.restore_tile!(klass, from: move.from, used: move.to == "true")
-        move.game_player.save
-      end
+      MoveApplicator.dispatch(backend, move)
       move.destroy
     end
     @game.save

--- a/test/services/move_applicator_test.rb
+++ b/test/services/move_applicator_test.rb
@@ -1,0 +1,192 @@
+require "test_helper"
+
+class MoveApplicatorTest < ActiveSupport::TestCase
+  # ---------------------------------------------------------------------------
+  # select_action
+  # ---------------------------------------------------------------------------
+
+  test "dispatch select_action sets current_action" do
+    state = minimal_state
+    move = fake_move(action: "select_action", to: "oasis")
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "oasis" }, state.current_action)
+  end
+
+  # ---------------------------------------------------------------------------
+  # move_settlement
+  # ---------------------------------------------------------------------------
+
+  test "dispatch move_settlement moves settlement on board and resets current_action" do
+    board = BoardState.new
+    board.place_settlement(5, 5, 0)
+    snap_board = BoardState.dump(board)
+
+    state = minimal_state(
+      "board_contents" => snap_board,
+      "current_action" => { "type" => "paddock", "from" => "[5, 5]" },
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40 },
+                       "tiles" => [ { "klass" => "PaddockTile", "from" => "[2, 0]", "used" => false } ] } ]
+    )
+    move = fake_move(action: "move_settlement", from: "[5, 5]", to: "[5, 7]")
+
+    MoveApplicator.dispatch(state, move)
+
+    assert state.board.empty?(5, 5)
+    assert_equal 0, state.board.player_at(5, 7)
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+    used_tile = state.players[0]["tiles"].find { |t| t["klass"] == "PaddockTile" }
+    assert used_tile["used"]
+  end
+
+  # ---------------------------------------------------------------------------
+  # pick_up_tile
+  # ---------------------------------------------------------------------------
+
+  test "dispatch pick_up_tile decrements tile qty and gives tile to player" do
+    board = BoardState.new
+    board.place_tile(2, 7, "OasisTile", 2)
+    state = minimal_state("board_contents" => BoardState.dump(board))
+    move = fake_move(action: "pick_up_tile", from: "[2, 7]", payload: { "klass" => "OasisTile", "qty_before" => 2 })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal 1, state.board.tile_qty(2, 7)
+    tiles = state.players[0]["tiles"]
+    assert_equal 1, tiles.size
+    assert_equal "OasisTile", tiles.first["klass"]
+    assert_equal "[2, 7]", tiles.first["from"]
+    assert tiles.first["used"], "tile picked up mid-turn should be marked used (unavailable until next turn)"
+  end
+
+  # ---------------------------------------------------------------------------
+  # forfeit_tile
+  # ---------------------------------------------------------------------------
+
+  test "dispatch forfeit_tile removes tile from player" do
+    state = minimal_state(
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40 },
+                       "tiles" => [ { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false } ] } ]
+    )
+    move = fake_move(action: "forfeit_tile", from: "[2, 7]", to: "false", payload: { "klass" => "OasisTile" })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_empty state.players[0]["tiles"]
+  end
+
+  # ---------------------------------------------------------------------------
+  # build
+  # ---------------------------------------------------------------------------
+
+  test "dispatch build places settlement, decrements supply, decrements mandatory_count" do
+    state = minimal_state
+    move = fake_move(action: "build", to: "[3, 4]", payload: { "card" => "G" })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal 0, state.board.player_at(3, 4)
+    assert_equal 39, state.players[0]["supply"]["settlements"]
+    assert_equal 2, state.mandatory_count
+  end
+
+  test "dispatch build with tile_klass marks tile used and resets current_action" do
+    state = minimal_state(
+      "current_action" => { "type" => "oasis" },
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40 },
+                       "tiles" => [ { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false } ] } ]
+    )
+    move = fake_move(action: "build", to: "[0, 1]", payload: { "card" => "D", "tile_klass" => "OasisTile" })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal 0, state.board.player_at(0, 1)
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+    assert state.players[0]["tiles"].first["used"]
+  end
+
+  # ---------------------------------------------------------------------------
+  # end_turn
+  # ---------------------------------------------------------------------------
+
+  test "dispatch end_turn advances player order and resets next player's tiles" do
+    # Player 1's used tile should be reset when player 0 ends their turn.
+    state = minimal_state(
+      "deck" => [ "T", "G" ],
+      "current_player_order" => 0,
+      "players" => [
+        { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40 }, "tiles" => [] },
+        { "order" => 1, "hand" => "T", "supply" => { "settlements" => 40 },
+          "tiles" => [ { "klass" => "FarmTile", "from" => "[0, 0]", "used" => true } ] }
+      ]
+    )
+    move = fake_move(action: "end_turn", payload: {
+      "card_discarded" => "G", "card_drawn" => "T", "reshuffled" => false, "deck_after" => [ "T", "G" ]
+    })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal 1, state.current_player_order
+    assert_equal 3, state.mandatory_count
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+    assert_equal false, state.players[1]["tiles"].first["used"]
+  end
+
+  test "dispatch end_turn with reshuffle rebuilds deck from payload" do
+    # discard=["D","F"], player discards "G" → discard becomes ["D","F","G"] before reshuffle.
+    # reshuffle moves all of discard into the new deck, so "G" is included.
+    state = minimal_state(
+      "deck" => [ "C" ],
+      "discard" => [ "D", "F" ],
+      "current_player_order" => 0,
+      "players" => [
+        { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40 }, "tiles" => [] },
+        { "order" => 1, "hand" => "T", "supply" => { "settlements" => 40 }, "tiles" => [] }
+      ]
+    )
+    move = fake_move(action: "end_turn", payload: {
+      "card_discarded" => "G", "card_drawn" => "C", "reshuffled" => true, "deck_after" => [ "F", "G", "D" ]
+    })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal [ "F", "G", "D" ], state.deck
+    assert_empty state.discard
+  end
+
+  # ---------------------------------------------------------------------------
+  # select_settlement
+  # ---------------------------------------------------------------------------
+
+  test "dispatch select_settlement merges from into current_action" do
+    state = minimal_state("current_action" => { "type" => "paddock" })
+    move = fake_move(action: "select_settlement", from: "[5, 5]")
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "paddock", "from" => "[5, 5]" }, state.current_action)
+  end
+
+  private
+
+  def minimal_state(overrides = {})
+    snap = {
+      "board_contents" => [],
+      "boards" => [],
+      "deck" => [],
+      "discard" => [],
+      "goals" => [],
+      "mandatory_count" => 3,
+      "current_action" => { "type" => "mandatory" },
+      "current_player_order" => 0,
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40 }, "tiles" => [] } ]
+    }.merge(overrides)
+    MoveApplicator::HashState.new(snap)
+  end
+
+  def fake_move(action:, player_order: 0, from: nil, to: nil, payload: nil)
+    gp = Struct.new(:order).new(player_order)
+    Struct.new(:action, :from, :to, :payload, :game_player).new(action, from, to, payload, gp)
+  end
+end


### PR DESCRIPTION
Closes #108

## Summary

- Introduces `MoveApplicator` with a single `dispatch(backend, move)` entry point — the `case move.action` switch now lives in exactly one place
- `HashState` backend: used by `GameReplayer` for pure hash-based forward replay (no AR dependencies)
- `LiveState` backend: used by `TurnEngine#undo_last_move` for AR-backed undo

## Impact

| File | Before | After |
|---|---|---|
| `game_replayer.rb` | 101 lines | 9 lines |
| `turn_engine.rb#undo_last_move` | 46 lines | 13 lines |
| `move_applicator.rb` | — | new (183 lines) |
| `move_applicator_test.rb` | — | new (9 tests) |

Adding a new action type now means updating `dispatch` and both backends once, instead of two separate files with no shared contract.

## Test plan

- [ ] All 307 existing tests pass
- [ ] 9 new `MoveApplicatorTest` tests cover each action type through `HashState`
- [ ] `GameReplayerTest` (14 tests) confirms forward replay correctness end-to-end
- [ ] Undo tests in `game_test.rb` confirm `LiveState` correctness end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)