### PR TITLE
Block tile buttons and game actions for non-current players

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -32,6 +32,8 @@ class GamesController < ApplicationController
   # 2. use a tile that I have to build a settlement on the board
   # 3. use a tile that I have to move a piece on the board
   def action
+    return unless @game.game_players.find_by(player: Current.user) == @game.current_player
+
     Rails.logger.debug("TURN ACTION PARAMS: #{action_params.inspect}")
 
     coord = Coordinate.new(action_params[:build_row], action_params[:build_col])
@@ -58,6 +60,8 @@ class GamesController < ApplicationController
   end
 
   def select_action
+    current_gp = @game.game_players.find_by(player: Current.user)
+    return unless current_gp == @game.current_player
     TurnEngine.new(@game).select_action(params[:action_type])
     respond_to do |format|
       format.html { redirect_to @game }

--- a/app/views/games/_game_player.html.erb
+++ b/app/views/games/_game_player.html.erb
@@ -22,5 +22,5 @@ x
 <% if score %>
   <span class="player-score"><%= score %> pts</span>
 <% end %>
-<%= render partial: "games/tiles", locals: { game:, player:, n:, engine: } %>
+<%= render partial: "games/tiles", locals: { game:, player:, n:, engine:, my_turn: } %>
 

--- a/app/views/games/_tiles.html.erb
+++ b/app/views/games/_tiles.html.erb
@@ -1,22 +1,22 @@
 <% (player.tiles || []).each do |tile| %>
   <% type = tile["klass"].delete_suffix("Tile").downcase %>
   <% used = tile["used"] %>
-  <% if n == 0 && tile["klass"] == "PaddockTile" && engine.tile_activatable?(tile) %>
+  <% if my_turn && tile["klass"] == "PaddockTile" && engine.tile_activatable?(tile) %>
     <%= button_to type.capitalize,
           select_action_game_path(game),
           params: { action_type: "paddock" },
           class: "player-tile #{type} tile-available" %>
-  <% elsif n == 0 && tile["klass"] == "OasisTile" && engine.tile_activatable?(tile) %>
+  <% elsif my_turn && tile["klass"] == "OasisTile" && engine.tile_activatable?(tile) %>
     <%= button_to type.capitalize,
           select_action_game_path(game),
           params: { action_type: "oasis" },
           class: "player-tile #{type} tile-available" %>
-  <% elsif n == 0 && tile["klass"] == "FarmTile" && engine.tile_activatable?(tile) %>
+  <% elsif my_turn && tile["klass"] == "FarmTile" && engine.tile_activatable?(tile) %>
     <%= button_to type.capitalize,
           select_action_game_path(game),
           params: { action_type: "farm" },
           class: "player-tile #{type} tile-available" %>
-  <% elsif n == 0 && tile["klass"] == "TavernTile" && engine.tile_activatable?(tile) %>
+  <% elsif my_turn && tile["klass"] == "TavernTile" && engine.tile_activatable?(tile) %>
     <%= button_to type.capitalize,
           select_action_game_path(game),
           params: { action_type: "tavern" },

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -63,6 +63,28 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_select "button[disabled]", text: "End turn"
   end
 
+  test "POST action does nothing when the requesting player is not the current player" do
+    game = games(:game2player)
+    game.boards = [ [ "Tavern", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Oasis", 0 ] ]
+    game.board_contents = BoardState.new
+    game.mandatory_count = 3
+    game.save
+    post session_url, params: { email_address: "paula@example.com", password: "password" }
+
+    post action_game_url(game), params: { build_row: 3, build_col: 6 }
+
+    assert game.reload.board_contents.empty?(3, 6)
+  end
+
+  test "POST select_action does nothing when the requesting player is not the current player" do
+    game = games(:game2player)
+    post session_url, params: { email_address: "paula@example.com", password: "password" }
+
+    post select_action_game_url(game), params: { action_type: "paddock" }
+
+    assert_equal "mandatory", game.reload.current_action["type"]
+  end
+
   test "POST end_turn does nothing when the requesting player is not the current player" do
     game = games(:game2player)
     post session_url, params: { email_address: "paula@example.com", password: "password" }
@@ -106,6 +128,24 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     get game_url(game)
 
     assert_select "form[action='#{select_action_game_path(game)}'] button", minimum: 1
+  end
+
+  test "game show does not render tile action buttons when it is not the viewer's turn" do
+    game = games(:game2player)
+    game.boards = [ [ "Oasis", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    game.mandatory_count = 0
+    game.save
+    paula = game_players(:paula)
+    paula.tiles = [
+      { "klass" => "MandatoryTile", "used" => false },
+      { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false }
+    ]
+    paula.save
+    post session_url, params: { email_address: "paula@example.com", password: "password" }
+
+    get game_url(game)
+
+    assert_select "form[action='#{select_action_game_path(game)}'] button", count: 0
   end
 
   test "game show does not render a button for a used PaddockTile" do


### PR DESCRIPTION
## Summary

- `_tiles.html.erb`: gate tile action buttons on `my_turn` instead of `n == 0` — previously buttons were shown to any viewer whose game state happened to satisfy `tile_activatable?`, even when it wasn't their turn
- `GamesController#action`: guard against non-current-player POSTs — any player could trigger builds on behalf of the current player
- `GamesController#select_action`: same guard added (consistent with `end_turn` which already had it)

## Test plan
- [ ] All 315 tests pass
- [ ] Tile buttons absent on opponent's panel during their turn
- [ ] POSTing action/select_action as non-current player is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)