### PR TITLE
Broadcast waiting games to all users when a new game is created

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -152,10 +152,12 @@ class Game < ApplicationRecord
       user = gp.player
       broadcast_update_to("user_#{user.id}", target: "dashboard-my-games",
         partial: "dashboard/my_games", locals: { games: user.my_games.includes(game_players: :player) })
-      broadcast_update_to("user_#{user.id}", target: "dashboard-waiting-games",
-        partial: "dashboard/waiting_games", locals: { games: user.waiting_games.includes(game_players: :player) })
       broadcast_update_to("user_#{user.id}", target: "dashboard-completed-games",
         partial: "dashboard/completed_games", locals: { games: user.completed_games.includes(game_players: :player) })
+    end
+    User.where(approved: true).each do |user|
+      broadcast_update_to("user_#{user.id}", target: "dashboard-waiting-games",
+        partial: "dashboard/waiting_games", locals: { games: user.waiting_games.includes(game_players: :player) })
     end
   end
 

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -273,6 +273,14 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_equal move_count_before, game.moves.count
   end
 
+  test "POST create broadcasts dashboard update to non-participating users" do
+    paula = users(:paula)
+
+    assert_turbo_stream_broadcasts("user_#{paula.id}") do
+      post games_url
+    end
+  end
+
   test "join broadcasts dashboard update to the joining user" do
     post session_url, params: { email_address: "paula@example.com", password: "password" }
     paula = users(:paula)


### PR DESCRIPTION
## Summary

Fixes #113. `broadcast_dashboard_update` previously only broadcast to existing game players, so newly created (waiting) games were invisible to other users' dashboards until they refreshed.

- Split `broadcast_dashboard_update`: `my_games`/`completed_games` still go only to game players; `waiting_games` now broadcasts to all approved users since it's relevant to everyone not already in the game

## Test plan
- [ ] All 316 tests pass
- [ ] Open a new table as one user — other users' dashboards update in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)