### PR TITLE
Fix 500 error when joining a game via Turbo navigation

### DIFF
--- a/app/views/games/show.turbo_stream.erb
+++ b/app/views/games/show.turbo_stream.erb
@@ -1,2 +1,2 @@
-<%= render partial: "games/game", locals: { game: game } %>
+<%= render partial: "games/game", locals: { game:, my_player:, engine: TurnEngine.new(game), scores: game.live_scores } %>
 <%= javascript_include_tag "gameboard" %>

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -207,6 +207,12 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_equal chris.order, game.reload.board_contents.player_at(0, 1)
   end
 
+  test "GET show as turbo_stream renders without error" do
+    get game_url(games(:game2player)), as: :turbo_stream
+
+    assert_response :success
+  end
+
   test "POST join adds the current user to the game" do
     game = Game.create!(state: "waiting")
     game.add_player(users(:chris))


### PR DESCRIPTION
## Summary

Fixes the 500 error on join. `show.turbo_stream.erb` was missing `engine`, `my_player`, and `scores` locals that `_game.html.erb` requires. These are present in `show.html.erb` but were never added to the turbo_stream variant, so any Turbo-driven navigation to the game page (e.g. following the join redirect) would blow up.

## Test plan
- [ ] All 317 tests pass
- [ ] Join a game — game page loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)