### PR TITLE
Add Oracle board and tile

### DIFF
--- a/app/models/boards/board.rb
+++ b/app/models/boards/board.rb
@@ -18,6 +18,7 @@ module Boards
     BOARD_CLASSES = {
       "Farm"    => Boards::FarmBoard,
       "Oasis"   => Boards::OasisBoard,
+      "Oracle"  => Boards::OracleBoard,
       "Paddock" => Boards::PaddockBoard,
       "Tavern"  => Boards::TavernBoard
     }.freeze
@@ -25,6 +26,7 @@ module Boards
     TILE_CLASSES = {
       "FarmTile"    => Tiles::FarmTile,
       "OasisTile"   => Tiles::OasisTile,
+      "OracleTile"  => Tiles::OracleTile,
       "PaddockTile" => Tiles::PaddockTile,
       "TavernTile"  => Tiles::TavernTile
     }.freeze

--- a/app/models/boards/oracle_board.rb
+++ b/app/models/boards/oracle_board.rb
@@ -1,0 +1,31 @@
+module Boards
+  class OracleBoard < Boards::BoardSection
+    def map
+      [
+        "GGGTTWGTTT",
+        "GGGSTWGTTT",
+        "GFFGTTWGGT",
+        "FFCGTWFLTT",
+        "FFFCCWFFWW",
+        "MMCGGWWWDD",
+        "CCCMGFFFDD",
+        "CCSDMDFFCC",
+        "WWWDDDDMCC",
+        "WWWWDDDDDC"
+      ]
+    end
+
+    def scoring_hexes
+      [
+        { r: 1, c: 3, k: "Castle" },
+        { r: 7, c: 2, k: "Castle" }
+      ]
+    end
+
+    def location_hexes
+      [
+        { r: 3, c: 7, k: "Oracle" }
+      ]
+    end
+  end
+end

--- a/app/models/tiles/farm_tile.rb
+++ b/app/models/tiles/farm_tile.rb
@@ -2,25 +2,5 @@ module Tiles
   class FarmTile < Tiles::Tile
     def build_terrain = "G"
     def builds_settlement? = true
-
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:)
-      adjacent_grass = board_contents.settlements_for(player_order).flat_map do |r, c|
-        board_contents.neighbors_where(r, c) do |nr, nc|
-          board_contents.empty?(nr, nc) && board.terrain_at(nr, nc) == "G"
-        end
-      end.uniq
-
-      return adjacent_grass unless adjacent_grass.empty?
-
-      (0..19).flat_map do |r|
-        (0..19).filter_map do |c|
-          [ r, c ] if board_contents.empty?(r, c) && board.terrain_at(r, c) == "G"
-        end
-      end
-    end
-
-    def activatable?(player_order:, board_contents:, board:)
-      valid_destinations(board_contents:, board:, player_order:).any?
-    end
   end
 end

--- a/app/models/tiles/oasis_tile.rb
+++ b/app/models/tiles/oasis_tile.rb
@@ -2,25 +2,5 @@ module Tiles
   class OasisTile < Tiles::Tile
     def build_terrain = "D"
     def builds_settlement? = true
-
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:)
-      adjacent_desert = board_contents.settlements_for(player_order).flat_map do |r, c|
-        board_contents.neighbors_where(r, c) do |nr, nc|
-          board_contents.empty?(nr, nc) && board.terrain_at(nr, nc) == "D"
-        end
-      end.uniq
-
-      return adjacent_desert unless adjacent_desert.empty?
-
-      (0..19).flat_map do |r|
-        (0..19).filter_map do |c|
-          [ r, c ] if board_contents.empty?(r, c) && board.terrain_at(r, c) == "D"
-        end
-      end
-    end
-
-    def activatable?(player_order:, board_contents:, board:)
-      valid_destinations(board_contents:, board:, player_order:).any?
-    end
   end
 end

--- a/app/models/tiles/oracle_tile.rb
+++ b/app/models/tiles/oracle_tile.rb
@@ -1,0 +1,5 @@
+module Tiles
+  class OracleTile < Tiles::Tile
+    def builds_settlement? = true
+  end
+end

--- a/app/models/tiles/paddock_tile.rb
+++ b/app/models/tiles/paddock_tile.rb
@@ -28,6 +28,10 @@ module Tiles
       end
     end
 
+    def activatable?(player_order:, board_contents:, board:, hand: nil)
+      selectable_settlements(player_order:, board_contents:, board:).any?
+    end
+
     def selectable_settlements(player_order:, board_contents:, board:)
       board_contents.settlements_for(player_order).filter_map do |r, c|
         [ r, c ] if valid_destinations(from_row: r, from_col: c, board_contents:, board:).any?

--- a/app/models/tiles/tavern_tile.rb
+++ b/app/models/tiles/tavern_tile.rb
@@ -10,7 +10,7 @@ module Tiles
       [ [ [ -1, 0 ], [ -1, 1 ] ], [ [ 1, -1 ], [ 1, 0 ] ] ]    # NE / SW
     ].freeze
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
       settlements = board_contents.settlements_for(player_order).to_set
       candidates = []
 
@@ -40,7 +40,7 @@ module Tiles
       candidates.uniq
     end
 
-    def activatable?(player_order:, board_contents:, board:)
+    def activatable?(player_order:, board_contents:, board:, hand: nil)
       valid_destinations(board_contents:, board:, player_order:).any?
     end
 

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -6,16 +6,33 @@ module Tiles
       @qty = qty
     end
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:)
-      []
+    def build_terrain = nil
+
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
+      terrain = build_terrain || hand
+      return [] unless terrain
+
+      adjacent = board_contents.settlements_for(player_order).flat_map do |r, c|
+        board_contents.neighbors_where(r, c) do |nr, nc|
+          board_contents.empty?(nr, nc) && board.terrain_at(nr, nc) == terrain
+        end
+      end.uniq
+
+      return adjacent unless adjacent.empty?
+
+      (0..19).flat_map do |r|
+        (0..19).filter_map do |c|
+          [ r, c ] if board_contents.empty?(r, c) && board.terrain_at(r, c) == terrain
+        end
+      end
     end
 
     def selectable_settlements(player_order:, board_contents:, board:)
       []
     end
 
-    def activatable?(player_order:, board_contents:, board:)
-      true
+    def activatable?(player_order:, board_contents:, board:, hand: nil)
+      valid_destinations(board_contents:, board:, player_order:, hand:).any?
     end
 
     def builds_settlement?

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -60,7 +60,7 @@ class TurnEngine
     return "Not available" unless tile
     tile_obj = Tiles::Tile.from_hash(tile)
     destinations = tile_obj.valid_destinations(
-      board_contents: @game.board_contents, board: @game.board, player_order: game_player.order
+      board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: game_player.hand
     )
     return "Not available" unless destinations.include?([ row, col ])
     game_player.mark_tile_used!(tile_klass)
@@ -133,7 +133,7 @@ class TurnEngine
     @game.instantiate
     tile_obj = Tiles::Tile.from_hash(tile)
     return false if tile_obj.builds_settlement? && !@game.current_player.settlements_remaining?
-    ctx = { player_order: @game.current_player.order, board_contents: @game.board_contents, board: @game.board }
+    ctx = { player_order: @game.current_player.order, board_contents: @game.board_contents, board: @game.board, hand: @game.current_player.hand }
     tile_obj.activatable?(**ctx)
   end
 
@@ -158,6 +158,8 @@ class TurnEngine
       "#{@game.current_player.player.handle} must build on a Grass space"
     when "tavern"
       "#{@game.current_player.player.handle} must build at the end of a row"
+    when "oracle"
+      "#{@game.current_player.player.handle} must build on a #{Boards::Board::TERRAIN_NAMES[@game.current_player.hand]} space"
     else
       has_activatable = (@game.current_player.tiles || []).any? { |t| tile_activatable?(t) }
       if @game.mandatory_count > 0 && @game.current_player.settlements_remaining?
@@ -253,7 +255,7 @@ class TurnEngine
             end
           else
             tile_obj.valid_destinations(
-              board_contents: @game.board_contents, board: @game.board, player_order: player.order
+              board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: player.hand
             )
           end
         else

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -118,6 +118,10 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
 
   test "game show renders a button for an activatable PaddockTile" do
     game = games(:game2player)
+    game.boards = [ [ "Paddock", 0 ], [ "Oasis", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    state = BoardState.new.tap { |s| s.place_settlement(0, 0, game.current_player.order) }
+    game.board_contents = state
+    game.save!
     chris = game_players(:chris)
     chris.tiles = [
       { "klass" => "MandatoryTile", "used" => false },

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -317,7 +317,10 @@ class GameTest < ActiveSupport::TestCase
 
   test "tile_activatable? is true when tile is unused and mandatory_count equals MANDATORY_COUNT" do
     game = games(:game2player)
-    # mandatory_count starts at 3 = MANDATORY_COUNT in fixture
+    game.mandatory_count = Game::MANDATORY_COUNT
+    game.boards = [ [ "Paddock", 0 ], [ "Oasis", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    state = BoardState.new.tap { |s| s.place_settlement(0, 0, game.current_player.order) }
+    game.board_contents = state
     tile = { "klass" => "PaddockTile", "from" => "[2, 18]", "used" => false }
     assert engine(game).tile_activatable?(tile)
   end
@@ -332,6 +335,9 @@ class GameTest < ActiveSupport::TestCase
   test "tile_activatable? is true when mandatory_count is 0" do
     game = games(:game2player)
     game.mandatory_count = 0
+    game.boards = [ [ "Paddock", 0 ], [ "Oasis", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    state = BoardState.new.tap { |s| s.place_settlement(0, 0, game.current_player.order) }
+    game.board_contents = state
     tile = { "klass" => "PaddockTile", "from" => "[2, 18]", "used" => false }
     assert engine(game).tile_activatable?(tile)
   end
@@ -340,6 +346,9 @@ class GameTest < ActiveSupport::TestCase
     game = games(:game2player)
     game.mandatory_count = 1
     game.current_player.supply["settlements"] = 0
+    game.boards = [ [ "Paddock", 0 ], [ "Oasis", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    state = BoardState.new.tap { |s| s.place_settlement(0, 0, game.current_player.order) }
+    game.board_contents = state
     tile = { "klass" => "PaddockTile", "from" => "[2, 18]", "used" => false }
     assert engine(game).tile_activatable?(tile)
   end

--- a/test/models/tiles/oracle_tile_test.rb
+++ b/test/models/tiles/oracle_tile_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class Tiles::OracleTileTest < ActiveSupport::TestCase
+  # Oracle board at index 0, rows 0-9 cols 0-9:
+  #   row 0: G G G T T W G T T T
+  # Settlement at (0,3)=T, hand "G":
+  #   even-row neighbor (0,2)=G → adjacent Grass available
+
+  def setup_board(row, col)
+    game = games(:game2player)
+    @chris = game_players(:chris)
+    game.boards = [ [ "Oracle", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    state = BoardState.new.tap { |s| s.place_settlement(row, col, @chris.order) }
+    yield state if block_given?
+    game.board_contents = state
+    game.save
+    game.instantiate
+    @ctx = { board_contents: game.board_contents, board: game.board }
+  end
+
+  # row 8: W W W D D D D M C C — neighbors of (8,0) are all W/C, no Grass
+  test "valid_destinations falls back to any empty hand-terrain hex when no adjacent match" do
+    setup_board(8, 0)
+    tile = Tiles::OracleTile.new(0)
+
+    result = tile.valid_destinations(**@ctx, player_order: @chris.order, hand: "G")
+
+    assert result.any?
+    result.each { |r, c| assert_equal "G", @ctx[:board].terrain_at(r, c) }
+  end
+
+  test "valid_destinations uses hand to determine terrain" do
+    setup_board(8, 0)
+    tile = Tiles::OracleTile.new(0)
+
+    result = tile.valid_destinations(**@ctx, player_order: @chris.order, hand: "D")
+
+    assert result.any?
+    result.each { |r, c| assert_equal "D", @ctx[:board].terrain_at(r, c) }
+  end
+
+  test "valid_destinations excludes occupied hexes" do
+    setup_board(0, 3) { |s| s.place_settlement(0, 2, 1) }
+    tile = Tiles::OracleTile.new(0)
+
+    result = tile.valid_destinations(**@ctx, player_order: @chris.order, hand: "G")
+
+    assert_not_includes result, [ 0, 2 ]
+  end
+
+  test "valid_destinations returns adjacent hand-terrain hexes" do
+    setup_board(0, 3)
+    tile = Tiles::OracleTile.new(0)
+
+    result = tile.valid_destinations(**@ctx, player_order: @chris.order, hand: "G")
+
+    assert_includes result, [ 0, 2 ]
+    result.each { |r, c| assert_equal "G", @ctx[:board].terrain_at(r, c) }
+  end
+end

--- a/test/models/tiles/tile_test.rb
+++ b/test/models/tiles/tile_test.rb
@@ -12,8 +12,8 @@ class Tiles::TileTest < ActiveSupport::TestCase
     assert_equal [], Tiles::Tile.new(0).selectable_settlements(player_order: 0, board_contents: BoardState.new, board: nil)
   end
 
-  test "activatable? returns true" do
-    assert Tiles::Tile.new(0).activatable?(player_order: 0, board_contents: BoardState.new, board: nil)
+  test "activatable? returns false when no terrain defined" do
+    assert_not Tiles::Tile.new(0).activatable?(player_order: 0, board_contents: BoardState.new, board: nil)
   end
 
   test "builds_settlement? returns false" do

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -352,6 +352,32 @@ class TurnEngineTest < ActiveSupport::TestCase
     end
   end
 
+  test "turn_state returns oracle message when current_action is oracle" do
+    @game.update!(current_action: { "type" => "oracle" })
+    @game.current_player.update!(hand: "G")
+
+    assert_match(/must build on a Grass space/, @engine.turn_state)
+  end
+
+  test "buildable_cells for oracle action returns hand-terrain hexes" do
+    @game.boards = [ [ "Oracle", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    @game.update!(current_action: { "type" => "oracle" }, mandatory_count: 0)
+    @game.current_player.update!(
+      hand: "G",
+      tiles: [ { "klass" => "OracleTile", "from" => "[3, 7]", "used" => false } ]
+    )
+    @game.reload
+
+    cells = @engine.buildable_cells
+
+    assert cells.any?
+    @game.instantiate
+    cells.each do |r, c|
+      assert_equal "G", @game.board.terrain_at(r, c)
+      assert @game.board_contents.empty?(r, c)
+    end
+  end
+
   private
 
   def find_tile_trigger_pair


### PR DESCRIPTION
## Summary
- Adds the Oracle board (second of four new boards) with its terrain map, castle hexes, and location hex
- Adds OracleTile: builds one settlement on a hex matching the player's played terrain card, adjacent when possible
- Refactors terrain-building logic from FarmTile/OasisTile into the Tile base class using a `build_terrain || hand` pattern, so OracleTile inherits it for free

## Test plan
- [ ] OracleTile tests: adjacent placement, fallback to any matching terrain, hand-driven terrain, occupied hex exclusion
- [ ] TurnEngine tests: turn_state for oracle action, buildable_cells for oracle action
- [ ] All 323 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)