### PR TITLE
Add Tower board and tile

### DIFF
--- a/app/models/boards/board.rb
+++ b/app/models/boards/board.rb
@@ -21,7 +21,8 @@ module Boards
       "Oasis"   => Boards::OasisBoard,
       "Oracle"  => Boards::OracleBoard,
       "Paddock" => Boards::PaddockBoard,
-      "Tavern"  => Boards::TavernBoard
+      "Tavern"  => Boards::TavernBoard,
+      "Tower"   => Boards::TowerBoard
     }.freeze
 
     TILE_CLASSES = {
@@ -30,7 +31,8 @@ module Boards
       "OasisTile"   => Tiles::OasisTile,
       "OracleTile"  => Tiles::OracleTile,
       "PaddockTile" => Tiles::PaddockTile,
-      "TavernTile"  => Tiles::TavernTile
+      "TavernTile"  => Tiles::TavernTile,
+      "TowerTile"   => Tiles::TowerTile
     }.freeze
 
     def initialize(game)

--- a/app/models/boards/tower_board.rb
+++ b/app/models/boards/tower_board.rb
@@ -1,0 +1,31 @@
+module Boards
+  class TowerBoard < BoardSection
+    def map
+      [
+        "TTTTMMGMCC",
+        "TMTTFGMMMC",
+        "FFTFFFGGWM",
+        "DFFFWLGWMM",
+        "DDDDFWGWCC",
+        "DCDDDWWCGC",
+        "DDCDDWFSGC",
+        "CCLDWFFFGG",
+        "DCWWWTTFGG",
+        "DCCWTTTGGG"
+      ]
+    end
+
+    def scoring_hexes
+      [
+        { r: 6, c: 7, k: "Castle" }
+      ]
+    end
+
+    def location_hexes
+      [
+        { r: 3, c: 5, k: "Tower" },
+        { r: 7, c: 2, k: "Tower" }
+      ]
+    end
+  end
+end

--- a/app/models/tiles/paddock_tile.rb
+++ b/app/models/tiles/paddock_tile.rb
@@ -1,6 +1,5 @@
 module Tiles
   class PaddockTile < Tiles::Tile
-    BUILDABLE_TERRAIN = %w[C D F T G].freeze
     # Each entry is [even_row_step, odd_row_step] for one of the 6 straight-line directions.
     STRAIGHT_LINES = [
       [ [ 0, -1 ], [ 0, -1 ] ],   # W

--- a/app/models/tiles/tavern_tile.rb
+++ b/app/models/tiles/tavern_tile.rb
@@ -1,6 +1,5 @@
 module Tiles
   class TavernTile < Tiles::Tile
-    BUILDABLE_TERRAIN = %w[C D F G T].freeze
     def builds_settlement? = true
 
     # Each pair is [forward_dir, backward_dir]; each dir is [even_row_step, odd_row_step].

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -1,5 +1,7 @@
 module Tiles
   class Tile
+    BUILDABLE_TERRAIN = %w[C D F G T].freeze
+
     attr_accessor :qty
 
     def initialize(qty)

--- a/app/models/tiles/tower_tile.rb
+++ b/app/models/tiles/tower_tile.rb
@@ -1,0 +1,24 @@
+module Tiles
+  class TowerTile < Tiles::Tile
+    def builds_settlement? = true
+
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
+      border = ->(r, c) { r == 0 || r == 19 || c == 0 || c == 19 }
+      buildable = ->(r, c) { BUILDABLE_TERRAIN.include?(board.terrain_at(r, c)) }
+
+      adjacent = board_contents.settlements_for(player_order).flat_map do |r, c|
+        board_contents.neighbors_where(r, c) do |nr, nc|
+          border.(nr, nc) && board_contents.empty?(nr, nc) && buildable.(nr, nc)
+        end
+      end.uniq
+
+      return adjacent unless adjacent.empty?
+
+      (0..19).flat_map do |r|
+        (0..19).filter_map do |c|
+          [ r, c ] if border.(r, c) && board_contents.empty?(r, c) && buildable.(r, c)
+        end
+      end
+    end
+  end
+end

--- a/test/models/tiles/tower_tile_test.rb
+++ b/test/models/tiles/tower_tile_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class Tiles::TowerTileTest < ActiveSupport::TestCase
+  # Tower board at index 0, rows 0-9 cols 0-9:
+  #   row 0: T T T T M M G M C C
+  #   row 1: T M T T F G M M M C
+  # Settlement at (1,1): odd-row neighbors are (1,0),(1,2),(0,1),(0,2),(2,1),(2,2).
+  # Border neighbors: (1,0)=T, (0,1)=T, (0,2)=T — all buildable.
+  def setup_board
+    game = games(:game2player)
+    @chris = game_players(:chris)
+    game.boards = [ [ "Tower", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    state = BoardState.new.tap { |s| s.place_settlement(1, 1, @chris.order) }
+    yield state if block_given?
+    game.board_contents = state
+    game.save
+    game.instantiate
+    @ctx = { board_contents: game.board_contents, board: game.board }
+  end
+
+  test "builds_settlement? returns true" do
+    assert Tiles::TowerTile.new(0).builds_settlement?
+  end
+
+  test "valid_destinations returns adjacent buildable border hexes" do
+    setup_board
+    tile = Tiles::TowerTile.new(0)
+
+    result = tile.valid_destinations(**@ctx, player_order: @chris.order)
+
+    assert_includes result, [ 1, 0 ]
+    assert_includes result, [ 0, 1 ]
+    assert_includes result, [ 0, 2 ]
+    # (0,4) and (0,5) are on the border but not adjacent to the settlement
+    assert_not_includes result, [ 0, 4 ]
+    assert_not_includes result, [ 0, 5 ]
+  end
+
+  test "valid_destinations falls back to any buildable border hex when no adjacent border hex exists" do
+    # Settlement at (5,5) — interior, no neighbors on the border
+    game = games(:game2player)
+    chris = game_players(:chris)
+    game.boards = [ [ "Tower", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    game.board_contents = BoardState.new.tap { |s| s.place_settlement(5, 5, chris.order) }
+    game.save
+    game.instantiate
+    ctx = { board_contents: game.board_contents, board: game.board }
+    tile = Tiles::TowerTile.new(0)
+
+    result = tile.valid_destinations(**ctx, player_order: chris.order)
+
+    assert result.any?
+    result.each { |r, c| assert(r == 0 || r == 19 || c == 0 || c == 19, "#{[ r, c ]} is not a border hex") }
+    result.each { |r, c| assert_includes %w[C D F G T], ctx[:board].terrain_at(r, c) }
+  end
+
+  test "valid_destinations excludes occupied border hexes" do
+    setup_board { |s| s.place_settlement(0, 1, 1) }
+    tile = Tiles::TowerTile.new(0)
+
+    result = tile.valid_destinations(**@ctx, player_order: @chris.order)
+
+    assert_not_includes result, [ 0, 1 ]
+  end
+
+  test "from_hash returns a TowerTile" do
+    assert_instance_of Tiles::TowerTile, Tiles::Tile.from_hash("klass" => "TowerTile")
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `TowerBoard` with terrain layout and two Tower tile spawn locations
- Adds `TowerTile`: builds a settlement on any empty, buildable border hex of the full 20×20 kingdom; prefers hexes adjacent to own settlements, falls back to any border hex
- Registers `Tower`/`TowerTile` in `Boards::Board` class maps
- Consolidates `BUILDABLE_TERRAIN` constant into `Tile` base class (was duplicated in `PaddockTile` and `TavernTile`)

## Test plan
- [ ] `TowerTile#builds_settlement?` returns true
- [ ] `valid_destinations` returns adjacent buildable border hexes when available
- [ ] `valid_destinations` excludes non-adjacent border hexes when adjacent ones exist
- [ ] `valid_destinations` falls back to any buildable border hex when no adjacent border hex exists
- [ ] `valid_destinations` excludes occupied border hexes
- [ ] `Tile.from_hash` correctly instantiates a `TowerTile`
- [ ] Full test suite passes (335 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)