### PR TITLE
Add Harbor board and tile

### DIFF
--- a/app/models/boards/board.rb
+++ b/app/models/boards/board.rb
@@ -22,7 +22,8 @@ module Boards
       "Oracle"  => Boards::OracleBoard,
       "Paddock" => Boards::PaddockBoard,
       "Tavern"  => Boards::TavernBoard,
-      "Tower"   => Boards::TowerBoard
+      "Tower"   => Boards::TowerBoard,
+      "Harbor"  => Boards::HarborBoard
     }.freeze
 
     TILE_CLASSES = {
@@ -32,7 +33,8 @@ module Boards
       "OracleTile"  => Tiles::OracleTile,
       "PaddockTile" => Tiles::PaddockTile,
       "TavernTile"  => Tiles::TavernTile,
-      "TowerTile"   => Tiles::TowerTile
+      "TowerTile"   => Tiles::TowerTile,
+      "HarborTile"  => Tiles::HarborTile
     }.freeze
 
     def initialize(game)

--- a/app/models/boards/harbor_board.rb
+++ b/app/models/boards/harbor_board.rb
@@ -1,0 +1,31 @@
+module Boards
+  class HarborBoard < Boards::BoardSection
+    def map
+      [
+        "GGTTTWGTTF",
+        "GFTTWGTTFF",
+        "GFFTWGGFFF",
+        "FFTTWGMFDD",
+        "CFSTWGDDDD",
+        "CCTWGGMMDD",
+        "CCWWWGDDDC",
+        "WWGGWWLCMC",
+        "WDSGWMWCCC",
+        "WDDWWWWCCC"
+      ]
+    end
+
+    def scoring_hexes
+      [
+        { r: 4, c: 2, k: "Castle" },
+        { r: 8, c: 2, k: "Castle" }
+      ]
+    end
+
+    def location_hexes
+      [
+        { r: 7, c: 6, k: "Harbor" }
+      ]
+    end
+  end
+end

--- a/app/models/tiles/barn_tile.rb
+++ b/app/models/tiles/barn_tile.rb
@@ -1,10 +1,5 @@
 module Tiles
   class BarnTile < Tiles::Tile
     def moves_settlement? = true
-
-    def selectable_settlements(player_order:, board_contents:, board:, hand: nil)
-      return [] unless valid_destinations(board_contents:, board:, player_order:, hand:).any?
-      board_contents.settlements_for(player_order)
-    end
   end
 end

--- a/app/models/tiles/harbor_tile.rb
+++ b/app/models/tiles/harbor_tile.rb
@@ -1,0 +1,23 @@
+module Tiles
+  class HarborTile < Tiles::Tile
+    def moves_settlement? = true
+
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
+      other_settlements = board_contents.settlements_for(player_order).reject { |r, c| r == from_row && c == from_col }
+
+      adjacent = other_settlements.flat_map do |r, c|
+        board_contents.neighbors_where(r, c) do |nr, nc|
+          board_contents.empty?(nr, nc) && board.terrain_at(nr, nc) == "W"
+        end
+      end.uniq
+
+      return adjacent unless adjacent.empty?
+
+      (0..19).flat_map do |r|
+        (0..19).filter_map do |c|
+          [ r, c ] if board_contents.empty?(r, c) && board.terrain_at(r, c) == "W"
+        end
+      end
+    end
+  end
+end

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -30,7 +30,9 @@ module Tiles
     end
 
     def selectable_settlements(player_order:, board_contents:, board:, hand: nil)
-      []
+      return [] unless moves_settlement?
+      return [] unless valid_destinations(board_contents:, board:, player_order:, hand:).any?
+      board_contents.settlements_for(player_order)
     end
 
     def activatable?(player_order:, board_contents:, board:, hand: nil)

--- a/test/models/tiles/harbor_tile_test.rb
+++ b/test/models/tiles/harbor_tile_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class Tiles::HarborTileTest < ActiveSupport::TestCase
+  # Harbor board at index 0, rows 0-9 cols 0-9:
+  #   row 0: G G T T T W G T T F   (col 5 = W)
+  #   row 1: G F T T W G T T F F   (col 4 = W)
+  # Settlement A at (2,0): being moved; no water adjacent to it.
+  # Settlement B at (0,4)=T: even-row neighbors (0,5)=W and (1,4)=W are water.
+  # When moving A, valid destinations = water hexes adjacent to B = [(0,5), (1,4)].
+  def setup_board
+    game = games(:game2player)
+    @chris = game_players(:chris)
+    game.boards = [ [ "Harbor", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    state = BoardState.new.tap do |s|
+      s.place_settlement(2, 0, @chris.order)
+      s.place_settlement(0, 4, @chris.order)
+    end
+    yield state if block_given?
+    game.board_contents = state
+    game.save
+    game.instantiate
+    @ctx = { board_contents: game.board_contents, board: game.board }
+  end
+
+  test "moves_settlement? returns true" do
+    assert Tiles::HarborTile.new(0).moves_settlement?
+  end
+
+  test "valid_destinations returns water hexes adjacent to other settlements" do
+    setup_board
+    tile = Tiles::HarborTile.new(0)
+
+    result = tile.valid_destinations(from_row: 2, from_col: 0, **@ctx, player_order: @chris.order)
+
+    assert_includes result, [ 0, 5 ]
+    assert_includes result, [ 1, 4 ]
+    # Water hexes not adjacent to any other settlement should be excluded
+    assert_not_includes result, [ 9, 0 ]
+  end
+
+  test "valid_destinations falls back to any water hex when no other settlements are adjacent to water" do
+    # Only one settlement — no other settlements to check adjacency against
+    game = games(:game2player)
+    chris = game_players(:chris)
+    game.boards = [ [ "Harbor", 0 ], [ "Paddock", 0 ], [ "Farm", 0 ], [ "Tavern", 0 ] ]
+    game.board_contents = BoardState.new.tap { |s| s.place_settlement(2, 0, chris.order) }
+    game.save
+    game.instantiate
+    ctx = { board_contents: game.board_contents, board: game.board }
+    tile = Tiles::HarborTile.new(0)
+
+    result = tile.valid_destinations(from_row: 2, from_col: 0, **ctx, player_order: chris.order)
+
+    assert result.any?
+    result.each { |r, c| assert_equal "W", ctx[:board].terrain_at(r, c) }
+  end
+
+  test "selectable_settlements returns all settlements when empty water exists" do
+    setup_board
+    tile = Tiles::HarborTile.new(0)
+
+    result = tile.selectable_settlements(**@ctx, player_order: @chris.order)
+
+    assert_includes result, [ 2, 0 ]
+    assert_includes result, [ 0, 4 ]
+  end
+
+  test "from_hash returns a HarborTile" do
+    assert_instance_of Tiles::HarborTile, Tiles::Tile.from_hash("klass" => "HarborTile")
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `HarborBoard` with terrain layout and one Harbor tile spawn location
- Adds `HarborTile`: moves a settlement to a water hex adjacent to another of the player's settlements if possible, otherwise any empty water hex
- Registers `Harbor`/`HarborTile` in `Boards::Board` class maps
- Lifts `selectable_settlements` (return all settlements when valid destinations exist) into `Tile` base class, removing duplication from `BarnTile` and `HarborTile`

## Test plan
- [ ] `moves_settlement?` returns true
- [ ] `valid_destinations` returns water hexes adjacent to other settlements
- [ ] `valid_destinations` excludes non-adjacent water hexes when adjacent ones exist
- [ ] `valid_destinations` falls back to any water hex when no other settlements are adjacent to water
- [ ] `selectable_settlements` returns all settlements when empty water exists
- [ ] `Tile.from_hash` correctly instantiates a `HarborTile`
- [ ] Full test suite passes (340 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)