### PR TITLE
Randomly select 4 boards with random orientation on game start

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -251,9 +251,8 @@ class Game < ApplicationRecord
 
   private
 
-  # MVP: Always boards from "First Game"
   def select_boards
-    self.boards = [ [ "Tavern", 0 ], [ "Paddock", 0 ], [ "Oasis", 0 ], [ "Farm", 0 ] ]
+    self.boards = Boards::Board::BOARD_CLASSES.keys.sample(4).map { |name| [ name, rand(2) ] }
     save
   end
 

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -972,6 +972,60 @@ class GameTest < ActiveSupport::TestCase
     assert_not game.ending, "ending must be cleared after undoing the last-settlement build"
   end
 
+  test "turn_state returns the same message as TurnEngine for playing games" do
+    game = games(:game2player)
+    assert_equal TurnEngine.new(game).turn_state, game.turn_state
+  end
+
+  test "turn_state returns 'Waiting for players' for waiting games" do
+    assert_equal "Waiting for players", games(:chris_waiting_game).turn_state
+  end
+
+  test "broadcast_dashboard_update sends to each participant's user channel" do
+    game = games(:game2player)
+    chris = users(:chris)
+    paula = users(:paula)
+
+    assert_turbo_stream_broadcasts("user_#{chris.id}") do
+      assert_turbo_stream_broadcasts("user_#{paula.id}") do
+        game.broadcast_dashboard_update
+      end
+    end
+  end
+
+  test "complete! broadcasts dashboard update to participants" do
+    game = games(:game2player)
+    chris = users(:chris)
+
+    assert_turbo_stream_broadcasts("user_#{chris.id}") do
+      game.complete!
+    end
+  end
+
+  # Board selection tests
+
+  test "start selects 4 unique boards from the known pool" do
+    game = new_started_game
+    board_names = game.boards.map(&:first)
+    assert_equal 4, board_names.size
+    assert_equal board_names.uniq, board_names
+    assert (board_names - Boards::Board::BOARD_CLASSES.keys).empty?
+  end
+
+  test "start randomizes board selection across games" do
+    boards_seen = 10.times.map { new_started_game.boards.map(&:first) }
+    assert boards_seen.uniq.size > 1, "expected varied board selection, got always #{boards_seen.first}"
+  end
+
+  test "broadcast_game_update broadcasts dashboard update to participants" do
+    game = games(:game2player)
+    chris = users(:chris)
+
+    assert_turbo_stream_broadcasts("user_#{chris.id}") do
+      game.broadcast_game_update
+    end
+  end
+
   private
 
   def new_started_game
@@ -1011,44 +1065,5 @@ class GameTest < ActiveSupport::TestCase
     chris.tiles = [ { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false } ]
     chris.save
     game
-  end
-
-  test "turn_state returns the same message as TurnEngine for playing games" do
-    game = games(:game2player)
-    assert_equal TurnEngine.new(game).turn_state, game.turn_state
-  end
-
-  test "turn_state returns 'Waiting for players' for waiting games" do
-    assert_equal "Waiting for players", games(:chris_waiting_game).turn_state
-  end
-
-  test "broadcast_dashboard_update sends to each participant's user channel" do
-    game = games(:game2player)
-    chris = users(:chris)
-    paula = users(:paula)
-
-    assert_turbo_stream_broadcasts("user_#{chris.id}") do
-      assert_turbo_stream_broadcasts("user_#{paula.id}") do
-        game.broadcast_dashboard_update
-      end
-    end
-  end
-
-  test "complete! broadcasts dashboard update to participants" do
-    game = games(:game2player)
-    chris = users(:chris)
-
-    assert_turbo_stream_broadcasts("user_#{chris.id}") do
-      game.complete!
-    end
-  end
-
-  test "broadcast_game_update broadcasts dashboard update to participants" do
-    game = games(:game2player)
-    chris = users(:chris)
-
-    assert_turbo_stream_broadcasts("user_#{chris.id}") do
-      game.broadcast_game_update
-    end
   end
 end

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -123,6 +123,9 @@ class TurnEngineTest < ActiveSupport::TestCase
 
   test "build_settlement uses neighbor adjacency when player has an existing settlement" do
     # Place a settlement at a Canyon hex, then build on an adjacent Canyon hex
+    # Tavern board has Canyon at (0,7) and (0,8) — pin it to quadrant 0
+    @game.boards = [ [ "Tavern", 0 ], [ "Paddock", 0 ], [ "Oasis", 0 ], [ "Farm", 0 ] ]
+    @game.save
     @game.instantiate
     player = @game.current_player
     @game.board_contents_will_change!


### PR DESCRIPTION
## Summary
- Replaces the hardcoded "First Game" board selection (Tavern/Paddock/Oasis/Farm) with random selection of 4 boards from all 8 available, each with a random flip (0 or 1)
- Fixes one existing test that assumed Tavern was always in quadrant 0

## Test plan
- [ ] New test verifies board selection varies across games
- [ ] Full test suite passes (342 tests)
- [ ] Start a few games and confirm different board combinations appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)