### PR TITLE
Fix board overflow on first load via Turbo navigation

### DIFF
--- a/app/javascript/gameboard.js
+++ b/app/javascript/gameboard.js
@@ -138,6 +138,10 @@ function initBoardZoom() {
   }, { passive: false });
 
   fitBoard();
+  // On first load (especially via Turbo nav), the sync fitBoard call above
+  // can read viewport dimensions before layout has fully settled. Re-fit
+  // after the next frame to pick up correct measurements.
+  requestAnimationFrame(fitBoard);
   new ResizeObserver(fitBoard).observe(viewport);
 }
 


### PR DESCRIPTION
## Summary
- The `#board` div overflowed the viewport on first load; resizing or full-page refresh sized it correctly.
- Root cause: on first Turbo navigation to the game page, the sync `fitBoard()` call at script-execution time can read viewport dimensions before layout has fully settled. The `ResizeObserver` fallback doesn't re-fire if the measured size is unchanged, so the wrong scale sticks.
- Fix: add a `requestAnimationFrame(fitBoard)` right after the sync call. The sync call still prevents a full-size flash; the rAF call re-measures after the next layout pass.

## Test plan
- [x] Navigate to a game from the dashboard — board fits on first load
- [x] Hard-refresh an in-progress game — still sizes correctly
- [x] Resize the window — ResizeObserver still re-fits as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)