### PR TITLE
Fortress task (Crossroads #2)

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -328,7 +328,7 @@ class Game < ApplicationRecord
   end
 
   OPTIONAL_GOALS = %w[ambassadors citizens discoverers families farmers fishermen hermits knights merchants miners shepherds workers].freeze
-  TASKS = %w[home_country].freeze
+  TASKS = %w[fortress home_country].freeze
 
   def select_goals
     instantiate_board

--- a/app/models/scoring/tasks/fortress.rb
+++ b/app/models/scoring/tasks/fortress.rb
@@ -1,0 +1,16 @@
+class Scoring
+  module Tasks
+    class Fortress < Task
+      DESCRIPTION = "6 points if one of your settlements is surrounded by 6 of your settlements."
+      POINTS = 6
+
+      def arrangement_met?(game_player)
+        player_hexes = settlements_for(game_player.order).to_set
+        player_hexes.any? do |r, c|
+          ns = neighbors(r, c)
+          ns.size == 6 && ns.all? { |n| player_hexes.include?(n) }
+        end
+      end
+    end
+  end
+end

--- a/app/services/scoring.rb
+++ b/app/services/scoring.rb
@@ -16,6 +16,7 @@ class Scoring
   }.freeze
 
   TASK_CLASSES = {
+    "fortress"     => Scoring::Tasks::Fortress,
     "home_country" => Scoring::Tasks::HomeCountry
   }.freeze
 

--- a/test/models/scoring/tasks/fortress_test.rb
+++ b/test/models/scoring/tasks/fortress_test.rb
@@ -1,0 +1,53 @@
+require_relative "../goals/goal_test_case"
+
+class Scoring::Tasks::FortressTest < Scoring::Goals::GoalTestCase
+  CENTER = [ 5, 5 ].freeze
+  # (5, 5) is on an odd row, so its six neighbors are:
+  RING = [ [ 5, 4 ], [ 5, 6 ], [ 4, 5 ], [ 4, 6 ], [ 6, 5 ], [ 6, 6 ] ].freeze
+
+  test "6 points when a settlement is surrounded by 6 of your settlements" do
+    chris_settlements = [ CENTER ] + RING
+    ctx = build_game(chris_settlements: chris_settlements, goals: [ "fortress" ])
+    result = Scoring::Tasks::Fortress.new(ctx[:game]).score_for(ctx[:chris])
+    assert_equal 6, result[:score]
+  end
+
+  test "0 points when no settlements are placed" do
+    ctx = build_game(chris_settlements: [], goals: [ "fortress" ])
+    result = Scoring::Tasks::Fortress.new(ctx[:game]).score_for(ctx[:chris])
+    assert_equal 0, result[:score]
+  end
+
+  test "0 points when only 5 of 6 neighbors are own settlements" do
+    chris_settlements = [ CENTER ] + RING.first(5)
+    ctx = build_game(chris_settlements: chris_settlements, goals: [ "fortress" ])
+    result = Scoring::Tasks::Fortress.new(ctx[:game]).score_for(ctx[:chris])
+    assert_equal 0, result[:score]
+  end
+
+  test "0 points when one neighbor is an opponent's settlement" do
+    chris_settlements = [ CENTER ] + RING.first(5)
+    paula_settlements = [ RING.last ]
+    ctx = build_game(chris_settlements: chris_settlements, paula_settlements: paula_settlements, goals: [ "fortress" ])
+    result = Scoring::Tasks::Fortress.new(ctx[:game]).score_for(ctx[:chris])
+    assert_equal 0, result[:score]
+  end
+
+  test "0 points for an edge settlement that cannot have 6 neighbors" do
+    # (0, 5) is on row 0 so two of its six offsets land at row -1 and are dropped.
+    edge_center = [ 0, 5 ]
+    edge_ring = [ [ 0, 4 ], [ 0, 6 ], [ 1, 4 ], [ 1, 5 ] ]
+    ctx = build_game(chris_settlements: [ edge_center ] + edge_ring, goals: [ "fortress" ])
+    result = Scoring::Tasks::Fortress.new(ctx[:game]).score_for(ctx[:chris])
+    assert_equal 0, result[:score]
+  end
+
+  test "flat 6 when multiple fortresses qualify" do
+    second_center = [ 15, 15 ]
+    second_ring = [ [ 15, 14 ], [ 15, 16 ], [ 14, 15 ], [ 14, 16 ], [ 16, 15 ], [ 16, 16 ] ]
+    chris_settlements = [ CENTER ] + RING + [ second_center ] + second_ring
+    ctx = build_game(chris_settlements: chris_settlements, goals: [ "fortress" ])
+    result = Scoring::Tasks::Fortress.new(ctx[:game]).score_for(ctx[:chris])
+    assert_equal 6, result[:score]
+  end
+end


### PR DESCRIPTION
## Summary
- Second Task in the Crossroads expansion, landing one at a time per the agreed rollout.
- `Scoring::Tasks::Fortress`: flat 6 points if any of your settlements has all 6 hex neighbors also occupied by your own settlements.
- Registered in `Scoring::TASK_CLASSES` and the `Game::TASKS` draw pool.

## Test plan
- [x] `bin/rails test test/models/scoring/tasks/fortress_test.rb` — 6 new cases: fully surrounded, empty, 5-of-6, opponent-in-ring, edge row, multiple fortresses.
- [x] Full suite `bin/rails test` — 499 runs, 0 failures.
- [x] `bin/rubocop` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)