### PR TITLE
Fix: undo of meeple-tile pickup revokes granted meeples

### DIFF
--- a/app/services/move_applicator.rb
+++ b/app/services/move_applicator.rb
@@ -12,6 +12,8 @@ module MoveApplicator
       backend.apply_build(player_order: player_order, to: move.to, tile_klass: move.payload&.dig("tile_klass"), remaining_before: move.payload&.dig("remaining_before"))
     when "pick_up_tile"
       backend.apply_pick_up_tile(player_order: player_order, from: move.from, klass: move.payload["klass"])
+    when "grant_meeple"
+      backend.apply_grant_meeple(player_order: player_order, kind: move.payload["kind"], qty: move.payload["qty"])
     when "forfeit_tile"
       backend.apply_forfeit_tile(
         player_order: player_order,
@@ -117,6 +119,11 @@ class MoveApplicator::HashState
     player = @players[player_order]
     player["tiles"] = (player["tiles"] || []) + [ { "klass" => klass, "from" => from, "used" => true } ]
     player["taken_from"] = (player["taken_from"] || []) + [ from ]
+  end
+
+  def apply_grant_meeple(player_order:, kind:, qty:)
+    key = kind.pluralize
+    @players[player_order]["supply"][key] = (@players[player_order]["supply"][key] || 0) + qty
   end
 
   def apply_forfeit_tile(player_order:, from:, klass:, used:)
@@ -305,6 +312,16 @@ class MoveApplicator::LiveState
     gp = player_for(player_order)
     gp.remove_tile_from!(from)
     gp.taken_from = (gp.taken_from || []) - [ from ]
+    gp.save
+  end
+
+  def apply_grant_meeple(player_order:, kind:, qty:)
+    gp = player_for(player_order)
+    case kind
+    when "warrior" then gp.add_warriors!(-qty)
+    when "ship"    then gp.add_ships!(-qty)
+    when "wagon"   then gp.add_wagons!(-qty)
+    end
     gp.save
   end
 

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -803,7 +803,22 @@ class TurnEngine
     game_player.receive_tile!(tile[:klass], from: tile[:key])
     game_player.taken_from = (game_player.taken_from || []) + [ tile[:key] ]
     tile_obj = Tiles::Tile.for_klass(tile[:klass])&.new(0)
+    supply_before = game_player.supply_hash.dup
     tile_obj&.on_pickup(game_player:)
+    game_player.supply_hash.each do |kind, qty_after|
+      granted = qty_after - supply_before[kind].to_i
+      next unless granted > 0
+      @game.move_count += 1
+      @game.moves.create(
+        order: @game.move_count,
+        game_player: game_player,
+        deliberate: false,
+        action: "grant_meeple",
+        reversible: true,
+        payload: { "kind" => kind, "qty" => granted },
+        message: "#{game_player.player.handle} acquires #{ActionController::Base.helpers.pluralize(granted, kind)}"
+      )
+    end
     if tile_obj&.nomad_tile?
       if tile_obj.is_a?(Tiles::Nomad::TreasureTile)
         # Score 3 points immediately and remove the tile

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -106,6 +106,30 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_includes player.reload.taken_from || [], "[#{tile_row}, #{tile_col}]"
   end
 
+  test "undo of a meeple-granting tile pickup revokes the meeples" do
+    tile_row, tile_col, trigger_row, trigger_col = find_meeple_tile_trigger_pair
+    skip "No meeple tile trigger position found" unless tile_row
+
+    board = @game.instantiate
+    klass = @game.board_contents.tile_klass(tile_row, tile_col)
+    kind = Tiles::Tile.for_klass(klass).new(0).meeple_kind
+    player = @game.current_player
+    supply_before = player.reload.supply_hash[kind]
+
+    force_hand(board.terrain_at(trigger_row, trigger_col))
+    @engine.build_settlement(trigger_row, trigger_col)
+    @game.reload
+
+    assert @game.moves.exists?(action: "grant_meeple"), "expected a grant_meeple move after pickup"
+    assert_operator player.reload.supply_hash[kind], :>, supply_before
+
+    TurnEngine.new(@game).undo_last_move
+    @game.reload
+
+    assert_equal supply_before, player.reload.supply_hash[kind]
+    assert_not @game.moves.exists?(action: "grant_meeple")
+  end
+
   test "undo of a pickup removes the location from taken_from" do
     tile_row, tile_col, trigger_row, trigger_col = find_tile_trigger_pair
     skip "No valid trigger position found" unless tile_row
@@ -838,6 +862,22 @@ class TurnEngineTest < ActiveSupport::TestCase
   end
 
   private
+
+  def find_meeple_tile_trigger_pair
+    meeple_klasses = %w[BarracksTile LighthouseTile WagonTile]
+    board = @game.instantiate
+    @game.board_contents.locations_with_remaining_tiles.each do |t_row, t_col|
+      klass = @game.board_contents.tile_klass(t_row, t_col)
+      next unless meeple_klasses.include?(klass)
+      @game.board_contents.neighbors(t_row, t_col).each do |nr, nc|
+        terrain = board.terrain_at(nr, nc)
+        if @game.board_contents.empty?(nr, nc) && %w[C D F G T].include?(terrain)
+          return [ t_row, t_col, nr, nc ]
+        end
+      end
+    end
+    nil
+  end
 
   def find_tile_trigger_pair
     board = @game.instantiate


### PR DESCRIPTION
## Summary

- Picking up a BarracksTile, LighthouseTile, or WagonTile calls `on_pickup` which grants meeples to supply — but undo only reversed the tile token, leaving the supply inflated
- Now `apply_tile_pickup` compares `supply_hash` before/after `on_pickup` and records a `grant_meeple` Move (deliberate: false, reversible: true) for any delta
- Undo destroys this Move via `LiveState#apply_grant_meeple`, which removes the granted meeples
- `HashState#apply_grant_meeple` handles forward replay; uses `kind.pluralize` (ActiveSupport) for the supply key

## Test plan

- [ ] New test: `undo of a meeple-granting tile pickup revokes the meeples` — finds a Barracks/Lighthouse/Wagon tile trigger, builds to pick it up, verifies `grant_meeple` Move created and supply increased, undoes and verifies supply restored
- [ ] Full suite: 636 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)