### PR TITLE
Fort tile: draw a card and build on that terrain

### DIFF
--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -1200,3 +1200,11 @@ ul li .hex:hover {
     background: #333;
     color: #aaa;
 }
+
+.popup-warning {
+    color: #f90;
+    font-size: 10px;
+    padding: 2px 4px;
+    display: block;
+    text-align: center;
+}

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,5 +1,5 @@
 class GamesController < ApplicationController
-  before_action :require_game_playing, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_settlement, :place_wall, :remove_meeple, :select_meeple ]
+  before_action :require_game_playing, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_settlement, :place_wall, :remove_meeple, :select_meeple, :activate_fort ]
 
   def new
     @game = Game.new
@@ -139,6 +139,16 @@ class GamesController < ApplicationController
     TurnEngine.new(@game).activate_outpost
     respond_to do |format|
       format.html { redirect_to @game }
+      format.turbo_stream { head :no_content }
+    end
+    @game.broadcast_game_update
+  end
+
+  def activate_fort
+    return unless @game.game_players.find_by(player: Current.user) == @game.current_player
+    TurnEngine.new(@game).activate_fort_tile
+    respond_to do |format|
+      format.html { head :no_content }
       format.turbo_stream { head :no_content }
     end
     @game.broadcast_game_update

--- a/app/models/tiles/fort_tile.rb
+++ b/app/models/tiles/fort_tile.rb
@@ -4,5 +4,10 @@ module Tiles
     DESCRIPTION = "CANNOT be undone! Draw a card and build on that terrain".freeze
 
     def builds_settlement? = true
+    def fort_tile? = true
+
+    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
+      true
+    end
   end
 end

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -84,6 +84,10 @@ module Tiles
       false
     end
 
+    def fort_tile?
+      false
+    end
+
     # Returns the terrain key that constrains the move destination, or nil if unconstrained.
     # Subclasses override this (e.g. BarnTile returns hand, HarborTile returns "W").
     def move_terrain(hand:) = nil

--- a/app/services/move_applicator.rb
+++ b/app/services/move_applicator.rb
@@ -8,8 +8,18 @@ module MoveApplicator
       backend.apply_select_settlement(player_order: player_order, from: move.from)
     when "move_settlement"
       backend.apply_move_settlement(player_order: player_order, from: move.from, to: move.to, tile_klass: move.payload&.dig("tile_klass"), action_before: move.payload&.dig("action_before"))
+    when "activate_fort"
+      backend.apply_activate_fort(player_order: player_order)
+    when "draw_fort_card"
+      backend.apply_draw_fort_card(
+        player_order: player_order,
+        drawn_card: move.payload["card"],
+        deck_after: move.payload["deck_after"],
+        discard_after: move.payload["discard_after"]
+      )
     when "build"
-      backend.apply_build(player_order: player_order, to: move.to, tile_klass: move.payload&.dig("tile_klass"), remaining_before: move.payload&.dig("remaining_before"))
+      fort_terrain = move.payload&.dig("tile_klass") == "FortTile" ? move.payload&.dig("card") : nil
+      backend.apply_build(player_order: player_order, to: move.to, tile_klass: move.payload&.dig("tile_klass"), remaining_before: move.payload&.dig("remaining_before"), fort_terrain: fort_terrain)
     when "pick_up_tile"
       backend.apply_pick_up_tile(player_order: player_order, from: move.from, klass: move.payload["klass"])
     when "grant_meeple"
@@ -93,11 +103,14 @@ class MoveApplicator::HashState
     @current_action = @current_action.merge("from" => from)
   end
 
-  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil)
+  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil, fort_terrain: nil)
     coord = Coordinate.from_key(to)
     @board.place_settlement(coord.row, coord.col, player_order)
     @players[player_order]["supply"]["settlements"] -= 1
-    if tile_klass
+    if fort_terrain
+      mark_tile_used(@players[player_order], tile_klass)
+      @current_action = { "type" => "mandatory" }
+    elsif tile_klass
       mark_tile_used(@players[player_order], tile_klass)
       remaining_after = remaining_before ? remaining_before - 1 : nil
       if remaining_after && remaining_after > 0
@@ -173,6 +186,16 @@ class MoveApplicator::HashState
   def apply_activate_outpost(player_order:)
     mark_tile_used(@players[player_order], "OutpostTile")
     @current_action = @current_action.merge("outpost_active" => true)
+  end
+
+  def apply_activate_fort(player_order:)
+    # No state change — tile is marked used on build, current_action updated by draw_fort_card
+  end
+
+  def apply_draw_fort_card(player_order:, drawn_card:, deck_after:, discard_after:)
+    @deck = deck_after.dup
+    @discard = discard_after.dup
+    @current_action = { "type" => "fort", "klass" => "FortTile", "fort_terrain" => drawn_card }
   end
 
   def apply_move_settlement(player_order:, from:, to:, tile_klass:, action_before: nil)
@@ -283,14 +306,17 @@ class MoveApplicator::LiveState
     @game = game
   end
 
-  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil)
+  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil, fort_terrain: nil)
     coord = Coordinate.from_key(to)
     @game.board_contents_will_change!
     @game.board_contents.remove(coord.row, coord.col)
     gp = player_for(player_order)
     gp.increment_supply!
     @game.ending = false
-    if tile_klass
+    if fort_terrain
+      gp.mark_tile_unused!(tile_klass)
+      @game.current_action = { "type" => "fort", "klass" => "FortTile", "fort_terrain" => fort_terrain }
+    elsif tile_klass
       gp.mark_tile_unused!(tile_klass)
       action = { "type" => tile_klass.delete_suffix("Tile").downcase }
       action["klass"] = tile_klass if remaining_before
@@ -393,6 +419,14 @@ class MoveApplicator::LiveState
     @game.current_action_will_change!
     @game.current_action.delete("outpost_active")
     gp.save
+  end
+
+  def apply_activate_fort(player_order:)
+    # Non-reversible — never called during undo
+  end
+
+  def apply_draw_fort_card(player_order:, drawn_card:, deck_after:, discard_after:)
+    # Non-reversible — never called during undo
   end
 
   def apply_place_warrior(player_order:, to:, action_before: nil)

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -92,6 +92,39 @@ class TurnEngine
     @game.save
   end
 
+  def activate_fort_tile
+    @game.instantiate
+    game_player = @game.current_player
+    return "Not available" unless game_player.find_unused_tile("FortTile")
+    return "No settlements left" unless game_player.settlements_remaining?
+
+    @game.move_count += 1
+    @game.moves.create!(
+      order: @game.move_count,
+      game_player: game_player,
+      deliberate: true,
+      action: "activate_fort",
+      reversible: false,
+      message: "#{game_player.player.handle} activated the Fort tile"
+    )
+
+    drawn_card = next_card
+    @game.discard.push(drawn_card)
+    @game.move_count += 1
+    @game.moves.create!(
+      order: @game.move_count,
+      game_player: game_player,
+      deliberate: false,
+      action: "draw_fort_card",
+      reversible: false,
+      payload: { "card" => drawn_card, "deck_after" => @game.deck.dup, "discard_after" => @game.discard.dup },
+      message: "#{game_player.player.handle} drew a #{Boards::Board::TERRAIN_NAMES[drawn_card]} card"
+    )
+
+    @game.current_action = { "type" => "fort", "klass" => "FortTile", "fort_terrain" => drawn_card }
+    @game.save
+  end
+
   def remove_settlement(row, col)
     @game.instantiate
     game_player = @game.current_player

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -95,6 +95,7 @@ class TurnEngine
   def activate_fort_tile
     @game.instantiate
     game_player = @game.current_player
+    return "Not available" unless @game.current_action["type"] == "mandatory"
     return "Not available" unless game_player.find_unused_tile("FortTile")
     return "No settlements left" unless game_player.settlements_remaining?
 
@@ -108,7 +109,11 @@ class TurnEngine
       message: "#{game_player.player.handle} activated the Fort tile"
     )
 
-    drawn_card = next_card
+    drawn_card = @game.deck.shift
+    if @game.deck.empty?
+      @game.deck = @game.discard.shuffle
+      @game.discard.clear
+    end
     @game.discard.push(drawn_card)
     @game.move_count += 1
     @game.moves.create!(

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -298,8 +298,9 @@ class TurnEngine
       @game.current_action_will_change!
       @game.current_action.delete("outpost_active")
     else
+      hand = tile_obj.fort_tile? ? @game.current_action["fort_terrain"] : game_player.hand
       destinations = tile_obj.valid_destinations(
-        board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: game_player.hand
+        board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: hand
       )
       return "Not available" unless destinations.include?([ row, col ])
     end
@@ -538,10 +539,12 @@ class TurnEngine
     action_type = @game.current_action["type"]
     tile_klass = Tiles::Tile.for_klass(current_action_tile_klass) if action_type != "mandatory"
     if tile_klass
-      msg = tile_klass.new(0).action_message(
+      tile_for_msg = tile_klass.new(0)
+      hand_for_msg = tile_for_msg.fort_tile? ? @game.current_action["fort_terrain"] : @game.current_player.hand
+      msg = tile_for_msg.action_message(
         player_handle: @game.current_player.player.handle,
         terrain_names: Boards::Board::TERRAIN_NAMES,
-        hand: @game.current_player.hand
+        hand: hand_for_msg
       )
       remaining = @game.current_action["remaining"]
       remaining ? "#{msg} (#{remaining} remaining)" : msg
@@ -692,8 +695,9 @@ class TurnEngine
               )
             end
           else
+            hand = tile_obj.fort_tile? ? @game.current_action["fort_terrain"] : player.hand
             tile_obj.valid_destinations(
-              board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: player.hand
+              board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: hand
             )
           end
         else

--- a/app/views/games/_tiles.html.erb
+++ b/app/views/games/_tiles.html.erb
@@ -22,7 +22,7 @@
         </div>
         <div data-meeple-popup-target="popup" class="meeple-popup hidden">
           <span class="popup-warning">Cannot be undone!</span>
-          <%= button_to "Draw &amp; Build".html_safe, activate_fort_game_path(game),
+          <%= button_to "Draw & Build", activate_fort_game_path(game),
                 class: "popup-btn", data: { turbo_stream: true } %>
           <button data-action="click->meeple-popup#cancel" class="popup-btn popup-btn-cancel">Cancel</button>
         </div>

--- a/app/views/games/_tiles.html.erb
+++ b/app/views/games/_tiles.html.erb
@@ -12,7 +12,22 @@
     <% activatable = my_turn && engine.tile_activatable?(tile) %>
     <% state = active ? "tile-active" : used ? "tile-used" : activatable ? "tile-activatable" : "tile-inactive" %>
 
-    <% if activatable %>
+    <% tile_obj_check = Tiles::Tile.for_klass(tile["klass"])&.new(0) %>
+    <% if activatable && tile_obj_check&.fort_tile? %>
+      <div data-controller="meeple-popup">
+        <div class="player-tile <%= state %> selectable"
+             title="<%= description %>"
+             data-action="click->meeple-popup#toggle">
+          <div class="tile-container <%= type %>"></div>
+        </div>
+        <div data-meeple-popup-target="popup" class="meeple-popup hidden">
+          <span class="popup-warning">Cannot be undone!</span>
+          <%= button_to "Draw &amp; Build".html_safe, activate_fort_game_path(game),
+                class: "popup-btn", data: { turbo_stream: true } %>
+          <button data-action="click->meeple-popup#cancel" class="popup-btn popup-btn-cancel">Cancel</button>
+        </div>
+      </div>
+    <% elsif activatable %>
       <%= button_to select_action_game_path(game), params: { action_type: type } do %>
         <div class="player-tile <%= state %>" title="<%= description %>">
           <div class="tile-container <%= type %>"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
       post :place_wall
       post :remove_meeple
       post :select_meeple
+      post :activate_fort
     end
   end
 

--- a/test/models/tiles/fort_tile_test.rb
+++ b/test/models/tiles/fort_tile_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class Tiles::FortTileTest < ActiveSupport::TestCase
+  def tile = Tiles::FortTile.new(0)
+
+  test "fort_tile? is true" do
+    assert tile.fort_tile?
+  end
+
+  test "builds_settlement? is true" do
+    assert tile.builds_settlement?
+  end
+
+  test "activatable? returns true regardless of board state" do
+    state = BoardState.new
+    board = Struct.new(:terrain).new({})
+    assert tile.activatable?(player_order: 0, board_contents: state, board: board)
+  end
+
+  test "activatable? returns true even with no valid destinations for hand terrain" do
+    # Fort doesn't check hand — it draws a new card
+    state = BoardState.new
+    board = Struct.new(:terrain).new({})
+    assert tile.activatable?(player_order: 0, board_contents: state, board: board, hand: "G")
+  end
+end

--- a/test/services/move_applicator_test.rb
+++ b/test/services/move_applicator_test.rb
@@ -175,6 +175,55 @@ class MoveApplicatorTest < ActiveSupport::TestCase
   end
 
   # ---------------------------------------------------------------------------
+  # activate_fort
+  # ---------------------------------------------------------------------------
+
+  test "dispatch activate_fort calls apply_activate_fort" do
+    state = minimal_state("current_action" => { "type" => "mandatory" })
+    move = fake_move(action: "activate_fort")
+
+    MoveApplicator.dispatch(state, move)
+
+    # apply_activate_fort is a no-op in HashState; just confirm no error raised
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+  end
+
+  test "dispatch draw_fort_card sets fort_terrain in current_action and updates deck" do
+    state = minimal_state(
+      "current_action" => { "type" => "mandatory" },
+      "deck" => %w[G D F],
+      "discard" => []
+    )
+    move = fake_move(
+      action: "draw_fort_card",
+      payload: { "card" => "D", "deck_after" => %w[G F], "discard_after" => [] }
+    )
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal "fort", state.current_action["type"]
+    assert_equal "FortTile", state.current_action["klass"]
+    assert_equal "D", state.current_action["fort_terrain"]
+    assert_equal %w[G F], state.deck
+  end
+
+  test "dispatch build with FortTile fort_terrain places settlement and resets current_action to mandatory" do
+    state = minimal_state(
+      "current_action" => { "type" => "fort", "klass" => "FortTile", "fort_terrain" => "D" },
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40 },
+                       "tiles" => [ { "klass" => "FortTile", "from" => "[3, 3]", "used" => false } ] } ]
+    )
+    move = fake_move(action: "build", to: "[5, 5]", payload: { "card" => "D", "tile_klass" => "FortTile" })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+    assert_equal 39, state.players[0]["supply"]["settlements"]
+    fort = state.players[0]["tiles"].find { |t| t["klass"] == "FortTile" }
+    assert fort["used"]
+  end
+
+  # ---------------------------------------------------------------------------
   # select_settlement
   # ---------------------------------------------------------------------------
 

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -1143,6 +1143,99 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_not TurnEngine.new(@game).undo_allowed?
   end
 
+  # ---------------------------------------------------------------------------
+  # Fort tile build
+  # ---------------------------------------------------------------------------
+
+  test "buildable_cells during fort action returns cells of drawn terrain, not player hand" do
+    force_hand("G")
+    spot = empty_hexes_of("G", 1).first
+    @engine.build_settlement(*spot)
+    @game.reload
+
+    @game.current_player.update!(tiles: [
+      { "klass" => "MandatoryTile", "used" => false },
+      { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
+    ])
+
+    # Force a known fort terrain that differs from hand
+    drawn = (@game.current_player.hand == "G") ? "D" : "G"
+    @game.update!(
+      mandatory_count: 0,
+      current_action: { "type" => "fort", "klass" => "FortTile", "fort_terrain" => drawn }
+    )
+
+    cells = TurnEngine.new(@game).buildable_cells
+
+    @game.instantiate
+    cells.each do |r, c|
+      assert_equal drawn, @game.board.terrain_at(r, c),
+        "Expected all buildable cells to be #{drawn} terrain, got #{@game.board.terrain_at(r, c)} at [#{r},#{c}]"
+    end
+  end
+
+  test "activate_tile_build on fort terrain places settlement, marks tile used, resets action" do
+    force_hand("G")
+    spot = empty_hexes_of("G", 1).first
+    @engine.build_settlement(*spot)
+    @game.reload
+
+    @game.current_player.update!(tiles: [
+      { "klass" => "MandatoryTile", "used" => false },
+      { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
+    ])
+
+    drawn = (@game.current_player.hand == "D") ? "G" : "D"
+    fort_spot = empty_hexes_of(drawn, 1).first
+    @game.update!(
+      mandatory_count: 0,
+      current_action: { "type" => "fort", "klass" => "FortTile", "fort_terrain" => drawn }
+    )
+
+    TurnEngine.new(@game).activate_tile_build(*fort_spot)
+    @game.reload
+
+    assert_equal({ "type" => "mandatory" }, @game.current_action)
+    assert_not @game.board_contents.empty?(*fort_spot)
+    fort = @game.current_player.tiles.find { |t| t["klass"] == "FortTile" }
+    assert fort["used"]
+  end
+
+  test "undo of fort build restores settlement, restores supply, returns to fort current_action with fort_terrain" do
+    force_hand("G")
+    spot = empty_hexes_of("G", 1).first
+    @engine.build_settlement(*spot)
+    @game.reload
+
+    @game.current_player.update!(tiles: [
+      { "klass" => "MandatoryTile", "used" => false },
+      { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
+    ])
+
+    drawn = (@game.current_player.hand == "D") ? "G" : "D"
+    fort_spot = empty_hexes_of(drawn, 1).first
+    @game.update!(
+      mandatory_count: 0,
+      current_action: { "type" => "fort", "klass" => "FortTile", "fort_terrain" => drawn }
+    )
+    supply_before = @game.current_player.supply["settlements"]
+
+    TurnEngine.new(@game).activate_tile_build(*fort_spot)
+    @game.reload
+    assert TurnEngine.new(@game).undo_allowed?
+
+    TurnEngine.new(@game).undo_last_move
+    @game.reload
+
+    assert @game.board_contents.empty?(*fort_spot)
+    assert_equal supply_before, @game.current_player.reload.supply["settlements"]
+    assert_equal "fort", @game.current_action["type"]
+    assert_equal "FortTile", @game.current_action["klass"]
+    assert_equal drawn, @game.current_action["fort_terrain"]
+    fort = @game.current_player.tiles.find { |t| t["klass"] == "FortTile" }
+    assert_equal false, fort["used"]
+  end
+
   def force_hand(terrain)
     @game.current_player.update!(hand: terrain)
   end

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -1143,6 +1143,19 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_not TurnEngine.new(@game).undo_allowed?
   end
 
+  test "activate_fort_tile returns Not available if action is not mandatory" do
+    @game.current_player.update!(tiles: [
+      { "klass" => "MandatoryTile", "used" => false },
+      { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
+    ])
+    @game.update!(current_action: { "type" => "fort", "klass" => "FortTile", "fort_terrain" => "G" })
+
+    result = @engine.activate_fort_tile
+
+    assert_equal "Not available", result
+    assert_equal 0, @game.reload.moves.count
+  end
+
   # ---------------------------------------------------------------------------
   # Fort tile build
   # ---------------------------------------------------------------------------

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -1072,6 +1072,77 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert @game.board_contents.warrior_at?(*hex)
   end
 
+  # ---------------------------------------------------------------------------
+  # activate_fort_tile
+  # ---------------------------------------------------------------------------
+
+  test "activate_fort_tile records activate_fort (non-reversible deliberate) and draw_fort_card (non-reversible non-deliberate)" do
+    @game.current_player.update!(tiles: [
+      { "klass" => "MandatoryTile", "used" => false },
+      { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
+    ])
+
+    @engine.activate_fort_tile
+    @game.reload
+
+    moves = @game.moves.order(:order)
+    assert_equal 2, moves.count
+
+    fort_move = moves.first
+    assert_equal "activate_fort", fort_move.action
+    assert fort_move.deliberate
+    assert_not fort_move.reversible
+
+    draw_move = moves.last
+    assert_equal "draw_fort_card", draw_move.action
+    assert_not draw_move.deliberate
+    assert_not draw_move.reversible
+    assert_includes %w[C D F G T], draw_move.payload["card"]
+  end
+
+  test "activate_fort_tile sets current_action to fort with fort_terrain" do
+    @game.current_player.update!(tiles: [
+      { "klass" => "MandatoryTile", "used" => false },
+      { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
+    ])
+
+    @engine.activate_fort_tile
+    @game.reload
+
+    assert_equal "fort", @game.current_action["type"]
+    assert_equal "FortTile", @game.current_action["klass"]
+    assert_includes %w[C D F G T], @game.current_action["fort_terrain"]
+  end
+
+  test "activate_fort_tile removes the drawn card from the deck and adds it to discard" do
+    @game.current_player.update!(tiles: [
+      { "klass" => "MandatoryTile", "used" => false },
+      { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
+    ])
+    deck_size_before = @game.deck.size
+    discard_size_before = @game.discard.size
+
+    @engine.activate_fort_tile
+    @game.reload
+
+    assert_equal deck_size_before - 1, @game.deck.size
+    assert_equal discard_size_before + 1, @game.discard.size
+    drawn = @game.current_action["fort_terrain"]
+    assert_includes @game.discard, drawn
+  end
+
+  test "undo_allowed? is false after activate_fort_tile (card draw blocks undo)" do
+    @game.current_player.update!(tiles: [
+      { "klass" => "MandatoryTile", "used" => false },
+      { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
+    ])
+
+    @engine.activate_fort_tile
+    @game.reload
+
+    assert_not TurnEngine.new(@game).undo_allowed?
+  end
+
   def force_hand(terrain)
     @game.current_player.update!(hand: terrain)
   end


### PR DESCRIPTION
## Summary

- Implements the Fort tile — player confirms an irreversible popup, draws a terrain card (immediately discarded), then must build one settlement on that terrain using normal adjacency rules
- Build is undoable; undo past the card draw is blocked by non-reversible moves
- Reuses the existing `meeple-popup` Stimulus controller for the confirmation popup

## Test Plan
- [ ] Fort tile shows as activatable when player has supply; inactive when supply is 0
- [ ] Clicking Fort tile shows "Cannot be undone!" popup with "Draw & Build" and "Cancel"
- [ ] Cancel closes the popup without changing game state
- [ ] Draw & Build: game log shows drawn terrain, board highlights matching hexes
- [ ] Build a settlement on the drawn terrain; tile marked used, action resets to mandatory
- [ ] Undo removes the settlement and returns to fort build state (same terrain highlighted)
- [ ] Undo button disabled after undoing the build (card draw blocks further undo)
- [ ] `bin/rails test` — 651 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)