### PR TITLE
Fix Fort tile activation popup

### DIFF
--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -991,6 +991,12 @@ ul li .hex:hover {
     flex-wrap: wrap;
 }
 
+.player-tile-popup {
+    position: relative;
+    display: inline-block;
+    color: var(--clr-g-text);
+}
+
 .player-tile {
     width: 44px;
     height: 44px;

--- a/app/javascript/controllers/meeple_popup_controller.js
+++ b/app/javascript/controllers/meeple_popup_controller.js
@@ -17,7 +17,8 @@ export default class extends Controller {
   }
 
   toggle(event) {
-    if (!this.element.closest(".hex")?.classList.contains("selectable")) return
+    const hex = this.element.closest(".hex")
+    if (hex && !hex.classList.contains("selectable")) return
     event.stopPropagation()
     this.popupTarget.classList.toggle("hidden")
   }

--- a/app/views/games/_tiles.html.erb
+++ b/app/views/games/_tiles.html.erb
@@ -14,10 +14,11 @@
 
     <% tile_obj_check = Tiles::Tile.for_klass(tile["klass"])&.new(0) %>
     <% if activatable && tile_obj_check&.fort_tile? %>
-      <div data-controller="meeple-popup">
-        <div class="player-tile <%= state %> selectable"
-             title="<%= description %>"
-             data-action="click->meeple-popup#toggle">
+      <div class="player-tile-popup"
+           data-controller="meeple-popup"
+           data-action="click->meeple-popup#toggle">
+        <div class="player-tile <%= state %>"
+             title="<%= description %>">
           <div class="tile-container <%= type %>"></div>
         </div>
         <div data-meeple-popup-target="popup" class="meeple-popup hidden">


### PR DESCRIPTION
## Summary
- allow the shared popup controller to open player tile popups outside board hexes
- wrap the Fort tile popup in a positioned player tile container so the warning appears under the tile
- bind the Fort tile click action on the popup wrapper so Draw & Build can be reached

## Tests
- bin/rails test test/system/fort_tile_test.rb
- bin/rails test test/controllers/games_controller_test.rb test/services/turn_engine_test.rb:1261 test/services/turn_engine_test.rb:1285 test/services/turn_engine_test.rb:1299