### PR TITLE
Implement Crossroads tile

### DIFF
--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -1194,6 +1194,12 @@ ul li .hex:hover {
     background-image: url("timberland.svg");
 }
 
+.player-card.card-shunned {
+    opacity: 0.35;
+    filter: grayscale(60%);
+    position: relative;
+}
+
 .meeple-popup {
     position: absolute;
     z-index: 100;

--- a/app/models/tiles/barn_tile.rb
+++ b/app/models/tiles/barn_tile.rb
@@ -6,5 +6,6 @@ module Tiles
                   "if possible.".freeze
     def moves_settlement? = true
     def move_terrain(hand:) = hand
+    def uses_played_terrain? = true
   end
 end

--- a/app/models/tiles/crossroads_tile.rb
+++ b/app/models/tiles/crossroads_tile.rb
@@ -2,5 +2,8 @@ module Tiles
   class CrossroadsTile < Tiles::Tile
     CREATOR = "Icon by Gregor Cresnar".freeze
     DESCRIPTION = "Draw an extra card each turn".freeze
+
+    def activatable?(**) = false
+    def crossroads_tile? = true
   end
 end

--- a/app/models/tiles/oracle_tile.rb
+++ b/app/models/tiles/oracle_tile.rb
@@ -4,5 +4,6 @@ module Tiles
     DESCRIPTION = "Build <em>one settlement</em> on a space of the same terrain type as your played <em>terrain card</em>. Build adjacent if possible.".freeze
 
     def builds_settlement? = true
+    def uses_played_terrain? = true
   end
 end

--- a/app/models/tiles/quarry_tile.rb
+++ b/app/models/tiles/quarry_tile.rb
@@ -4,6 +4,7 @@ module Tiles
     DESCRIPTION = "Build 1 or 2 stone walls on empty terrain spaces of the same type as your played terrain card, adjacent to at least one of your settlements.".freeze
 
     def places_wall? = true
+    def uses_played_terrain? = true
 
     def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
       terrain = hand

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -92,6 +92,14 @@ module Tiles
       false
     end
 
+    def crossroads_tile?
+      false
+    end
+
+    def uses_played_terrain?
+      false
+    end
+
     # Returns the terrain key that constrains the move destination, or nil if unconstrained.
     # Subclasses override this (e.g. BarnTile returns hand, HarborTile returns "W").
     def move_terrain(hand:) = nil

--- a/app/services/move_applicator.rb
+++ b/app/services/move_applicator.rb
@@ -7,7 +7,8 @@ module MoveApplicator
     when "select_settlement"
       backend.apply_select_settlement(player_order: player_order, from: move.from)
     when "move_settlement"
-      backend.apply_move_settlement(player_order: player_order, from: move.from, to: move.to, tile_klass: move.payload&.dig("tile_klass"), action_before: move.payload&.dig("action_before"))
+      ct_before = move.payload&.key?("chosen_terrain_before") ? move.payload["chosen_terrain_before"] : :not_provided
+      backend.apply_move_settlement(player_order: player_order, from: move.from, to: move.to, tile_klass: move.payload&.dig("tile_klass"), action_before: move.payload&.dig("action_before"), chosen_terrain_before: ct_before)
     when "activate_fort"
       backend.apply_activate_fort(player_order: player_order)
     when "draw_fort_card"
@@ -19,7 +20,8 @@ module MoveApplicator
       )
     when "build"
       fort_terrain = move.payload&.dig("tile_klass") == "FortTile" ? move.payload&.dig("card") : nil
-      backend.apply_build(player_order: player_order, to: move.to, tile_klass: move.payload&.dig("tile_klass"), remaining_before: move.payload&.dig("remaining_before"), fort_terrain: fort_terrain)
+      ct_before = move.payload&.key?("chosen_terrain_before") ? move.payload["chosen_terrain_before"] : :not_provided
+      backend.apply_build(player_order: player_order, to: move.to, tile_klass: move.payload&.dig("tile_klass"), remaining_before: move.payload&.dig("remaining_before"), fort_terrain: fort_terrain, chosen_terrain_before: ct_before)
     when "pick_up_tile"
       backend.apply_pick_up_tile(player_order: player_order, from: move.from, klass: move.payload["klass"])
     when "grant_meeple"
@@ -50,7 +52,8 @@ module MoveApplicator
         tile_used: move.payload["tile_used"]
       )
     when "place_wall"
-      backend.apply_place_wall(player_order: player_order, to: move.to)
+      ct_before = move.payload&.key?("chosen_terrain_before") ? move.payload["chosen_terrain_before"] : :not_provided
+      backend.apply_place_wall(player_order: player_order, to: move.to, chosen_terrain_before: ct_before)
     when "activate_outpost"
       backend.apply_activate_outpost(player_order: player_order)
     when "place_warrior"
@@ -105,7 +108,7 @@ class MoveApplicator::HashState
     @current_action = @current_action.merge("from" => from)
   end
 
-  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil, fort_terrain: nil)
+  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil, fort_terrain: nil, chosen_terrain_before: :not_provided)
     coord = Coordinate.from_key(to)
     @board.place_settlement(coord.row, coord.col, player_order)
     @players[player_order]["supply"]["settlements"] -= 1
@@ -152,7 +155,7 @@ class MoveApplicator::HashState
     player["tiles"] = (player["tiles"] || []).reject { |t| t["expires_on_turn"] && t["expires_on_turn"] == (@turn_number || 0) }
     @turn_number = (@turn_number || 0) + 1
     next_order = (player_order + 1) % @players.size
-    @discard.push(card_discarded)
+    @discard.push(*Array(card_discarded))
     @players[player_order]["hand"] = card_drawn
     if reshuffled
       @deck = deck_after.dup
@@ -179,7 +182,7 @@ class MoveApplicator::HashState
     @players[owner_order]["supply"]["settlements"] += 1
   end
 
-  def apply_place_wall(player_order:, to:)
+  def apply_place_wall(player_order:, to:, chosen_terrain_before: :not_provided)
     coord = Coordinate.from_key(to)
     @board.place_wall(coord.row, coord.col)
     @stone_walls = (@stone_walls || 0) - 1
@@ -200,7 +203,7 @@ class MoveApplicator::HashState
     @current_action = { "type" => "fort", "klass" => "FortTile", "fort_terrain" => drawn_card }
   end
 
-  def apply_move_settlement(player_order:, from:, to:, tile_klass:, action_before: nil)
+  def apply_move_settlement(player_order:, from:, to:, tile_klass:, action_before: nil, chosen_terrain_before: :not_provided)
     from_coord = Coordinate.from_key(from)
     to_coord = Coordinate.from_key(to)
     @board.move_settlement(from_coord.row, from_coord.col, to_coord.row, to_coord.col)
@@ -325,7 +328,7 @@ class MoveApplicator::LiveState
     @game = game
   end
 
-  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil, fort_terrain: nil)
+  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil, fort_terrain: nil, chosen_terrain_before: :not_provided)
     coord = Coordinate.from_key(to)
     @game.board_contents_will_change!
     @game.board_contents.remove(coord.row, coord.col)
@@ -347,6 +350,7 @@ class MoveApplicator::LiveState
       @game.current_action_will_change!
       @game.current_action["builds"] = builds
     end
+    restore_chosen_terrain(chosen_terrain_before)
     gp.save
   end
 
@@ -391,10 +395,11 @@ class MoveApplicator::LiveState
     @game.current_action.delete("from")
   end
 
-  def apply_move_settlement(player_order:, from:, to:, tile_klass:, action_before: nil)
+  def apply_move_settlement(player_order:, from:, to:, tile_klass:, action_before: nil, chosen_terrain_before: :not_provided)
     @game.board_contents_will_change!
     @game.board_contents.move_settlement(*Coordinate.from_key(to), *Coordinate.from_key(from))
     @game.current_action = action_before || { "type" => tile_klass.delete_suffix("Tile").downcase, "from" => from }
+    restore_chosen_terrain(chosen_terrain_before)
     gp = player_for(player_order)
     gp.mark_tile_unused!(tile_klass)
     gp.save
@@ -425,11 +430,12 @@ class MoveApplicator::LiveState
     end
   end
 
-  def apply_place_wall(player_order:, to:)
+  def apply_place_wall(player_order:, to:, chosen_terrain_before: :not_provided)
     coord = Coordinate.from_key(to)
     @game.board_contents_will_change!
     @game.board_contents.remove(coord.row, coord.col)
     @game.stone_walls += 1
+    restore_chosen_terrain(chosen_terrain_before)
     @game.save
   end
 
@@ -563,5 +569,15 @@ class MoveApplicator::LiveState
 
   def player_for(order)
     @game.game_players.find { |gp| gp.order == order }
+  end
+
+  def restore_chosen_terrain(chosen_terrain_before)
+    return if chosen_terrain_before == :not_provided
+    @game.current_action_will_change!
+    if chosen_terrain_before.nil?
+      @game.current_action.delete("chosen_terrain")
+    else
+      @game.current_action["chosen_terrain"] = chosen_terrain_before
+    end
   end
 end

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -61,7 +61,10 @@ class TurnEngine
       check_families_goal(game_player) if builds.size == 3
     else
       if card_terrain.nil?
-        card_terrain = game_player.hand.find { |t| available?(game_player.order, t, row, col) }
+        card_terrain = game_player.hand.find { |t|
+          list = available_list(game_player.order, t)
+          list.any? ? list[row][col] : true
+        }
         return "Not available" unless card_terrain
         lock_terrain!(card_terrain, chosen_terrain_before)
       else

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -43,12 +43,15 @@ class TurnEngine
     game_player = @game.current_player
     Rails.logger.debug(" I have #{game_player.settlements_remaining} settlements remaining")
     return "No settlements left" unless game_player.settlements_remaining?
-    card_terrain = game_player.hand
+    chosen_terrain_before = @game.current_action["chosen_terrain"]
+    card_terrain = effective_terrain(game_player)
 
     if @game.current_action["outpost_active"]
+      card_terrain ||= game_player.hand.find { |t| @game.board.terrain_at(row, col) == t }
       # Skip adjacency: just check it's empty and correct terrain
       return "Not available" unless @game.board_contents.available_for_building?(row, col) && @game.board.terrain_at(row, col) == card_terrain
-      build_on_terrain(card_terrain, row, col, game_player)
+      lock_terrain!(card_terrain, chosen_terrain_before) unless chosen_terrain_before
+      build_on_terrain(card_terrain, row, col, game_player, chosen_terrain_before: chosen_terrain_before)
       @game.mandatory_count -= 1
       @game.current_action_will_change!
       @game.current_action.delete("outpost_active")
@@ -57,8 +60,14 @@ class TurnEngine
       @game.current_action["builds"] = builds
       check_families_goal(game_player) if builds.size == 3
     else
-      return "Not available" unless available?(game_player.order, card_terrain, row, col)
-      build_on_terrain(card_terrain, row, col, game_player)
+      if card_terrain.nil?
+        card_terrain = game_player.hand.find { |t| available?(game_player.order, t, row, col) }
+        return "Not available" unless card_terrain
+        lock_terrain!(card_terrain, chosen_terrain_before)
+      else
+        return "Not available" unless available?(game_player.order, card_terrain, row, col)
+      end
+      build_on_terrain(card_terrain, row, col, game_player, chosen_terrain_before: chosen_terrain_before)
       @game.mandatory_count -= 1
       @game.current_action_will_change!
       builds = (@game.current_action["builds"] || []) + [ [ row, col ] ]
@@ -166,7 +175,7 @@ class TurnEngine
     if tile_used
       klass_name = current_action_tile_klass
       game_player.mark_tile_used!(klass_name.demodulize)
-      @game.current_action = { "type" => "mandatory" }
+      reset_to_mandatory
     else
       @game.current_action_will_change!
       @game.current_action["pending_orders"] = remaining_orders
@@ -222,7 +231,7 @@ class TurnEngine
     end
 
     game_player.mark_tile_used!(tile_klass)
-    @game.current_action = { "type" => "mandatory" }
+    reset_to_mandatory
     game_player.save
     @game.save
   end
@@ -248,7 +257,7 @@ class TurnEngine
     end
 
     game_player.mark_tile_used!(tile_klass)
-    @game.current_action = { "type" => "mandatory" }
+    reset_to_mandatory
     game_player.save
     @game.save
   end
@@ -322,7 +331,7 @@ class TurnEngine
     cluster.each { |r, c| @game.board_contents.place_city_hall_hex(r, c, game_player.order) }
     game_player.decrement_city_hall_supply!
     game_player.mark_tile_permanently_used!("CityHallTile")
-    @game.current_action = { "type" => "mandatory" }
+    reset_to_mandatory
     game_player.save
     @game.save
   end
@@ -335,30 +344,47 @@ class TurnEngine
     tile = game_player.find_unused_tile(tile_klass)
     return "Not available" unless tile
     tile_obj = Tiles::Tile.from_hash(tile)
+    chosen_terrain_before = @game.current_action["chosen_terrain"]
     if @game.current_action["outpost_active"]
       return "Not available" unless @game.board_contents.empty?(row, col)
       @game.current_action_will_change!
       @game.current_action.delete("outpost_active")
     else
-      hand = tile_obj.fort_tile? ? @game.current_action["fort_terrain"] : game_player.hand
-      destinations = tile_obj.valid_destinations(
-        board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: hand
-      )
+      if tile_obj.fort_tile?
+        hand = @game.current_action["fort_terrain"]
+        destinations = tile_obj.valid_destinations(
+          board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: hand
+        )
+      elsif tile_obj.uses_played_terrain? && effective_terrain(game_player).nil?
+        destinations = game_player.hand.flat_map { |t|
+          tile_obj.valid_destinations(
+            board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: t
+          )
+        }.uniq
+      else
+        hand = effective_terrain(game_player) || game_player.hand.first
+        destinations = tile_obj.valid_destinations(
+          board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: hand
+        )
+      end
       return "Not available" unless destinations.include?([ row, col ])
     end
+    if tile_obj.uses_played_terrain? && chosen_terrain_before.nil? && game_player.hand.size > 1
+      lock_terrain!(@game.board.terrain_at(row, col), chosen_terrain_before)
+    end
     remaining_before = @game.current_action["remaining"]
-    build_on_terrain(@game.board.terrain_at(row, col), row, col, game_player, tile_klass: tile_klass, remaining_before: remaining_before)
+    build_on_terrain(@game.board.terrain_at(row, col), row, col, game_player, tile_klass: tile_klass, remaining_before: remaining_before, chosen_terrain_before: chosen_terrain_before)
     if tile_obj.is_a?(Tiles::Nomad::DonationTile)
       remaining = @game.current_action["remaining"].to_i - 1
       if remaining > 0
         @game.current_action = @game.current_action.merge("remaining" => remaining)
       else
         game_player.mark_tile_used!(tile_klass)
-        @game.current_action = { "type" => "mandatory" }
+        reset_to_mandatory
       end
     else
       game_player.mark_tile_used!(tile_klass)
-      @game.current_action = { "type" => "mandatory" }
+      reset_to_mandatory
     end
     game_player.save
     @game.save
@@ -422,7 +448,12 @@ class TurnEngine
     from_coord = Coordinate.from_key(from)
     tile_klass_name = current_action_tile_klass
     tile_obj = Tiles::Tile.for_klass(tile_klass_name)&.new(0)
+    chosen_terrain_before = @game.current_action["chosen_terrain"]
+    if tile_obj&.uses_played_terrain? && chosen_terrain_before.nil? && @game.current_player.hand.size > 1
+      lock_terrain!(@game.board.terrain_at(row, col), chosen_terrain_before)
+    end
     action_before = @game.current_action.slice("type", "klass", "budget", "vacated", "moves", "from")
+    payload = { "tile_klass" => tile_klass_name, "action_before" => action_before, "chosen_terrain_before" => chosen_terrain_before }
     @game.move_count += 1
     @game.moves.create(
       order: @game.move_count,
@@ -432,7 +463,7 @@ class TurnEngine
       from: from,
       to: Coordinate.new(row, col).to_key,
       reversible: true,
-      payload: { "tile_klass" => tile_klass_name, "action_before" => action_before },
+      payload: payload,
       message: "#{@game.current_player.player.handle} moved a settlement to [#{row}, #{col}]"
     )
     if tile_obj&.is_a?(Tiles::Nomad::ResettlementTile)
@@ -458,14 +489,14 @@ class TurnEngine
       apply_tile_pickup(@game.current_player, row, col)
       if budget <= 0
         @game.current_player.mark_tile_used!(tile_klass_name.demodulize)
-        @game.current_action = { "type" => "mandatory" }
+        reset_to_mandatory
       else
         @game.current_action = @game.current_action.except("from").merge(
           "budget" => budget, "vacated" => vacated, "moves" => moves
         )
       end
     else
-      @game.current_action = { "type" => "mandatory" }
+      reset_to_mandatory
       @game.current_player.mark_tile_used!(tile_klass_name)
       apply_tile_forfeit(@game.current_player)
       apply_tile_pickup(@game.current_player, row, col)
@@ -484,7 +515,7 @@ class TurnEngine
     return "Not allowed" unless moves_made >= 1 || walls_placed >= 1
 
     game_player.mark_tile_used!(tile_klass_name.demodulize)
-    @game.current_action = { "type" => "mandatory" }
+    reset_to_mandatory
     game_player.save
     @game.save
   end
@@ -492,18 +523,30 @@ class TurnEngine
   def place_wall(row, col)
     @game.instantiate
     game_player = @game.current_player
+    chosen_terrain_before = @game.current_action["chosen_terrain"]
 
     tile_obj = Tiles::QuarryTile.new(0)
-    destinations = tile_obj.valid_destinations(
-      board_contents: @game.board_contents, board: @game.board,
-      player_order: game_player.order, hand: game_player.hand
-    )
+    wall_terrain = effective_terrain(game_player)
+    if wall_terrain.nil?
+      destinations = game_player.hand.flat_map { |t|
+        tile_obj.valid_destinations(board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: t)
+      }.uniq
+    else
+      destinations = tile_obj.valid_destinations(board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: wall_terrain)
+    end
     return "Not available" unless destinations.include?([ row, col ])
     return "No stone walls left" if @game.stone_walls <= 0
+
+    if chosen_terrain_before.nil? && game_player.hand.size > 1
+      hex_terrain = @game.board.terrain_at(row, col)
+      lock_terrain!(hex_terrain, chosen_terrain_before)
+    end
+    wall_terrain = effective_terrain(game_player)
 
     walls_placed = @game.current_action["walls_placed"].to_i + 1
 
     @game.move_count += 1
+    payload = { "chosen_terrain_before" => chosen_terrain_before }
     @game.moves.create(
       order: @game.move_count,
       game_player: game_player,
@@ -511,6 +554,7 @@ class TurnEngine
       action: "place_wall",
       to: "[#{row}, #{col}]",
       reversible: true,
+      payload: payload,
       message: "#{game_player.player.handle} placed a stone wall at [#{row}, #{col}]"
     )
 
@@ -520,11 +564,11 @@ class TurnEngine
 
     remaining = tile_obj.valid_destinations(
       board_contents: @game.board_contents, board: @game.board,
-      player_order: game_player.order, hand: game_player.hand
+      player_order: game_player.order, hand: wall_terrain || game_player.hand.first
     )
     if walls_placed >= 2 || remaining.empty?
       game_player.mark_tile_used!("QuarryTile")
-      @game.current_action = { "type" => "mandatory" }
+      reset_to_mandatory
     else
       @game.current_action_will_change!
       @game.current_action["walls_placed"] = walls_placed
@@ -543,7 +587,7 @@ class TurnEngine
     tile_obj = Tiles::Tile.from_hash(tile)
     return false if tile_obj.places_wall? && @game.stone_walls <= 0
     return false if tile_obj.builds_settlement? && !@game.current_player.settlements_remaining?
-    ctx = { player_order: @game.current_player.order, board_contents: @game.board_contents, board: @game.board, hand: @game.current_player.hand, supply: @game.current_player.supply_hash }
+    ctx = { player_order: @game.current_player.order, board_contents: @game.board_contents, board: @game.board, hand: @game.current_player.hand.first, supply: @game.current_player.supply_hash }
     tile_obj.activatable?(**ctx)
   end
 
@@ -582,7 +626,7 @@ class TurnEngine
     tile_klass = Tiles::Tile.for_klass(current_action_tile_klass) if action_type != "mandatory"
     if tile_klass
       tile_for_msg = tile_klass.new(0)
-      hand_for_msg = tile_for_msg.fort_tile? ? @game.current_action["fort_terrain"] : @game.current_player.hand
+      hand_for_msg = tile_for_msg.fort_tile? ? @game.current_action["fort_terrain"] : @game.current_player.hand.first
       msg = tile_for_msg.action_message(
         player_handle: @game.current_player.player.handle,
         terrain_names: Boards::Board::TERRAIN_NAMES,
@@ -593,9 +637,14 @@ class TurnEngine
     else
       has_activatable = (@game.current_player.tiles || []).any? { |t| tile_activatable?(t) }
       if @game.mandatory_count > 0 && @game.current_player.settlements_remaining?
+        terrain_name = if (ct = effective_terrain(@game.current_player))
+          Boards::Board::TERRAIN_NAMES[ct]
+        else
+          @game.current_player.hand.map { |t| Boards::Board::TERRAIN_NAMES[t] }.join(" or ")
+        end
         "#{@game.current_player.player.handle} must build " \
         "#{ActionController::Base.helpers.pluralize(@game.mandatory_count, "settlement")} on " \
-        "#{Boards::Board::TERRAIN_NAMES[@game.current_player.hand]}" \
+        "#{terrain_name}" \
         "#{" or select a tile" if has_activatable}"
       else
         "#{@game.current_player.player.handle} must end their turn" \
@@ -610,8 +659,10 @@ class TurnEngine
     @game.instantiate
     game_player = @game.current_player
     card_discarded = game_player.hand
-    @game.discard.push(game_player.hand)
-    game_player.hand = next_card
+    @game.discard.push(*game_player.hand)
+    new_cards = [ next_card ]
+    new_cards << next_card if has_crossroads_tile?(game_player)
+    game_player.hand = new_cards
     card_drawn = game_player.hand
     reshuffled = @game.discard.empty?
     @game.mandatory_count = Game::MANDATORY_COUNT
@@ -669,13 +720,16 @@ class TurnEngine
       if action == "mandatory"
         if player.settlements_remaining? && @game.mandatory_count > 0
           if @game.current_action["outpost_active"]
-            terrain = player.hand
+            terrain = effective_terrain(player)
             (0..19).flat_map do |r|
               (0..19).filter_map { |c| [ r, c ] if @game.board_contents.empty?(r, c) && @game.board.terrain_at(r, c) == terrain }
             end
           else
-            list = available_list(player.order, player.hand)
-            (0..19).flat_map { |r| (0..19).filter_map { |c| [ r, c ] if list[r][c] } }
+            terrains = effective_terrain(player) ? [ effective_terrain(player) ] : player.hand
+            terrains.flat_map { |t|
+              list = available_list(player.order, t)
+              (0..19).flat_map { |r| (0..19).filter_map { |c| [ r, c ] if list[r][c] } }
+            }.uniq
           end
         else
           []
@@ -704,11 +758,18 @@ class TurnEngine
               )
             end
           elsif tile_obj.places_wall?
-            tile_obj.valid_destinations(
-              board_contents: @game.board_contents, board: @game.board,
-              player_order: player.order, hand: player.hand
-            )
+            if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
+              player.hand.flat_map { |t|
+                tile_obj.valid_destinations(board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: t)
+              }.uniq
+            else
+              tile_obj.valid_destinations(
+                board_contents: @game.board_contents, board: @game.board,
+                player_order: player.order, hand: effective_terrain(player) || player.hand.first
+              )
+            end
           elsif tile_obj.moves_settlement?
+            hand_arg = effective_terrain(player) || player.hand.first
             if @game.current_action["from"]
               from = Coordinate.from_key(@game.current_action["from"])
               extra_kwargs = {}
@@ -718,11 +779,17 @@ class TurnEngine
                   vacated: @game.current_action["vacated"] || []
                 }
               end
-              tile_obj.valid_destinations(
-                from_row: from.row, from_col: from.col,
-                board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: player.hand,
-                **extra_kwargs
-              )
+              if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
+                player.hand.flat_map { |t|
+                  tile_obj.valid_destinations(from_row: from.row, from_col: from.col, board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: t, **extra_kwargs)
+                }.uniq
+              else
+                tile_obj.valid_destinations(
+                  from_row: from.row, from_col: from.col,
+                  board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: hand_arg,
+                  **extra_kwargs
+                )
+              end
             else
               extra_kwargs = {}
               if tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
@@ -731,20 +798,39 @@ class TurnEngine
                   vacated: @game.current_action["vacated"] || []
                 }
               end
-              tile_obj.selectable_settlements(
-                player_order: player.order, board_contents: @game.board_contents, board: @game.board, hand: player.hand,
-                **extra_kwargs
-              )
+              if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
+                player.hand.flat_map { |t|
+                  tile_obj.selectable_settlements(player_order: player.order, board_contents: @game.board_contents, board: @game.board, hand: t, **extra_kwargs)
+                }.uniq
+              else
+                tile_obj.selectable_settlements(
+                  player_order: player.order, board_contents: @game.board_contents, board: @game.board, hand: hand_arg,
+                  **extra_kwargs
+                )
+              end
             end
           elsif tile_obj.places_city_hall?
             tile_obj.valid_destinations(
               board_contents: @game.board_contents, board: @game.board, player_order: player.order, supply: player.supply_hash
             )
           else
-            hand = tile_obj.fort_tile? ? @game.current_action["fort_terrain"] : player.hand
-            tile_obj.valid_destinations(
-              board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: hand
-            )
+            if tile_obj.fort_tile?
+              hand = @game.current_action["fort_terrain"]
+              tile_obj.valid_destinations(
+                board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: hand
+              )
+            elsif tile_obj.uses_played_terrain? && effective_terrain(player).nil?
+              player.hand.flat_map { |t|
+                tile_obj.valid_destinations(
+                  board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: t
+                )
+              }.uniq
+            else
+              hand = effective_terrain(player) || player.hand.first
+              tile_obj.valid_destinations(
+                board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: hand
+              )
+            end
           end
         else
           []
@@ -807,10 +893,11 @@ class TurnEngine
     tile&.dig("klass") || "#{type.capitalize}Tile"
   end
 
-  def build_on_terrain(terrain, row, col, game_player, tile_klass: nil, remaining_before: nil)
+  def build_on_terrain(terrain, row, col, game_player, tile_klass: nil, remaining_before: nil, chosen_terrain_before: :not_provided)
     payload = { "card" => terrain }
     payload["tile_klass"] = tile_klass if tile_klass
     payload["remaining_before"] = remaining_before if remaining_before
+    payload["chosen_terrain_before"] = chosen_terrain_before unless chosen_terrain_before == :not_provided
     @game.move_count += 1
     @game.moves.create(
       order: @game.move_count,
@@ -1011,6 +1098,26 @@ class TurnEngine
     @game.deck = @game.discard.shuffle
     @game.discard.clear
     @game.save
+  end
+
+  def lock_terrain!(terrain, before)
+    return if @game.current_action["chosen_terrain"]
+    @game.current_action_will_change!
+    @game.current_action["chosen_terrain"] = terrain
+  end
+
+  def reset_to_mandatory
+    ct = @game.current_action["chosen_terrain"]
+    @game.current_action = { "type" => "mandatory" }
+    @game.current_action["chosen_terrain"] = ct if ct
+  end
+
+  def has_crossroads_tile?(game_player)
+    (game_player.tiles || []).any? { |t| t["klass"] == "CrossroadsTile" }
+  end
+
+  def effective_terrain(player)
+    @game.current_action["chosen_terrain"] || (player.hand.size == 1 ? player.hand.first : nil)
   end
 
   def place_warrior(row, col, game_player, tile_klass:)

--- a/app/views/games/_game_player.html.erb
+++ b/app/views/games/_game_player.html.erb
@@ -17,8 +17,12 @@
     <% end %>
   </div>
   <div class="player-stats">
-    <% display_card = (n == 0 || (game.current_player_id == player.id)) ? player.hand : "B" %>
-    <%= content_tag :span, display_card, class: "player-card card-#{display_card}" %>
+    <% display_cards = (n == 0 || game.current_player_id == player.id) ? Array(player.hand) : Array(player.hand).map { "B" } %>
+    <% chosen = (game.current_player_id == player.id) ? game.current_action["chosen_terrain"] : nil %>
+    <% display_cards.each do |card| %>
+      <% shunned = chosen && card != chosen %>
+      <%= content_tag :span, card, class: "player-card card-#{card}#{" card-shunned" if shunned}" %>
+    <% end %>
     <div class="supply-display">
       <%= content_tag :span, player.supply["settlements"], class: "settlement-count" %>
       <%= render "games/settlement", color: player_color(player.order), css_class: "settlement-icon" %>

--- a/test/fixtures/game_players.yml
+++ b/test/fixtures/game_players.yml
@@ -28,7 +28,7 @@
 chris:
   player: chris
   game: game2player
-  hand: "T"
+  hand: <%= ["T"].to_json %>
   supply: <%= { "settlements" => 40 }.to_json %>
   tiles: <%= [].to_json %>
   order: 0
@@ -36,7 +36,7 @@ chris:
 paula:
   player: paula
   game: game2player
-  hand: "D"
+  hand: <%= ["D"].to_json %>
   supply: <%= { "settlements" => 40 }.to_json %>
   tiles: <%= [].to_json %>
   order: 1
@@ -44,7 +44,7 @@ paula:
 chris_in_paula_turn_game:
   player: chris
   game: paula_turn_game
-  hand: "T"
+  hand: <%= ["T"].to_json %>
   supply: <%= { "settlements" => 40 }.to_json %>
   tiles: <%= [].to_json %>
   order: 0
@@ -52,7 +52,7 @@ chris_in_paula_turn_game:
 paula_in_paula_turn_game:
   player: paula
   game: paula_turn_game
-  hand: "D"
+  hand: <%= ["D"].to_json %>
   supply: <%= { "settlements" => 40 }.to_json %>
   tiles: <%= [].to_json %>
   order: 1

--- a/test/models/game_lifecycle_test.rb
+++ b/test/models/game_lifecycle_test.rb
@@ -59,7 +59,8 @@ class GameLifecycleTest < ActiveSupport::TestCase
     # Both players have full supply and a terrain card
     @game.game_players.each do |gp|
       assert_equal 40, gp.supply["settlements"]
-      assert_includes %w[C D F G T], gp.hand
+      assert_equal 1, gp.hand.size
+      assert_includes %w[C D F G T], gp.hand.first
     end
   end
 

--- a/test/models/game_player_test.rb
+++ b/test/models/game_player_test.rb
@@ -28,7 +28,20 @@ require "test_helper"
 
 class GamePlayerTest < ActiveSupport::TestCase
   setup do
-    @gp = game_players(:chris)  # supply: { "settlements" => 40 }, hand: "T"
+    @gp = game_players(:chris)  # supply: { "settlements" => 40 }, hand: ["T"]
+  end
+
+  # --- Hand ---
+
+  test "hand is an array" do
+    assert_instance_of Array, @gp.hand
+  end
+
+  test "hand stores and retrieves as array" do
+    @gp.hand = [ "G", "F" ]
+    @gp.save!
+    @gp.reload
+    assert_equal [ "G", "F" ], @gp.hand
   end
 
   # --- Supply ---

--- a/test/models/game_replayer_test.rb
+++ b/test/models/game_replayer_test.rb
@@ -45,7 +45,7 @@ class GameReplayerTest < ActiveSupport::TestCase
     snap = game.capture_snapshot
     chris_snap = snap["players"].find { |p| p["order"] == game_players(:chris).order }
 
-    assert_equal "T", chris_snap["hand"]
+    assert_equal [ "T" ], chris_snap["hand"]
     assert_equal 40, chris_snap["supply"]["settlements"]
   end
 

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -811,7 +811,7 @@ class GameTest < ActiveSupport::TestCase
   test "end_turn stores card_discarded and card_drawn in payload" do
     game = games(:game2player)
     chris = game_players(:chris)
-    chris.hand = "G"
+    chris.hand = [ "G" ]
     chris.save
     game.deck = [ "C", "D", "F" ]
     game.discard = []
@@ -820,15 +820,15 @@ class GameTest < ActiveSupport::TestCase
     engine(game).end_turn
 
     move = game.moves.find_by(action: "end_turn")
-    assert_equal "G", move.payload["card_discarded"]
-    assert_equal "C", move.payload["card_drawn"]
+    assert_equal [ "G" ], move.payload["card_discarded"]
+    assert_equal [ "C" ], move.payload["card_drawn"]
     assert_equal false, move.payload["reshuffled"]
   end
 
   test "end_turn stores reshuffled true and deck_after when deck runs out mid-draw" do
     game = games(:game2player)
     chris = game_players(:chris)
-    chris.hand = "G"
+    chris.hand = [ "G" ]
     chris.save
     game.deck = [ "C" ]
     game.discard = [ "D", "F", "T" ]
@@ -837,8 +837,8 @@ class GameTest < ActiveSupport::TestCase
     engine(game).end_turn
 
     move = game.moves.find_by(action: "end_turn")
-    assert_equal "G", move.payload["card_discarded"]
-    assert_equal "C", move.payload["card_drawn"]
+    assert_equal [ "G" ], move.payload["card_discarded"]
+    assert_equal [ "C" ], move.payload["card_drawn"]
     assert_equal true, move.payload["reshuffled"]
     assert_not_empty move.payload["deck_after"]
   end
@@ -989,7 +989,7 @@ class GameTest < ActiveSupport::TestCase
     game.mandatory_count = 1
     game.save
     chris = game_players(:chris)
-    chris.update!(supply: { "settlements" => 1 }, hand: "G")
+    chris.update!(supply: { "settlements" => 1 }, hand: [ "G" ])
 
     engine(game).build_settlement(0, 7)  # OasisBoard (0,7)=G
     game.reload
@@ -1003,7 +1003,7 @@ class GameTest < ActiveSupport::TestCase
     game.mandatory_count = 1
     game.save
     chris = game_players(:chris)
-    chris.update!(supply: { "settlements" => 2 }, hand: "G")
+    chris.update!(supply: { "settlements" => 2 }, hand: [ "G" ])
 
     engine(game).build_settlement(0, 7)
     game.reload
@@ -1051,7 +1051,7 @@ class GameTest < ActiveSupport::TestCase
     game.mandatory_count = 1
     game.save
     chris = game_players(:chris)
-    chris.update!(supply: { "settlements" => 1 }, hand: "G")
+    chris.update!(supply: { "settlements" => 1 }, hand: [ "G" ])
 
     engine(game).build_settlement(0, 7)
     game.reload

--- a/test/models/tiles/crossroads_tile_test.rb
+++ b/test/models/tiles/crossroads_tile_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class CrossroadsTileTest < ActiveSupport::TestCase
+  test "CrossroadsTile is not activatable" do
+    assert_not Tiles::CrossroadsTile.new(1).activatable?(player_order: 0, board_contents: nil, board: nil)
+  end
+
+  test "CrossroadsTile has crossroads_tile? true" do
+    assert Tiles::CrossroadsTile.new(1).crossroads_tile?
+  end
+
+  test "base Tile returns false for crossroads_tile?" do
+    assert_not Tiles::FarmTile.new(1).crossroads_tile?
+  end
+end

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -212,7 +212,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.save
 
     game2 = Game.find(@game.id)
-    game2.current_player.update!(hand: "C")
+    game2.current_player.update!(hand: [ "C" ])
     engine2 = TurnEngine.new(game2)
 
     # (5,1) is Canyon on Tavern board row 5 ("FCCWGTTCCC"), not adjacent to (0,7)
@@ -233,7 +233,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.save
 
     game2 = Game.find(@game.id)
-    game2.current_player.update!(hand: "C")
+    game2.current_player.update!(hand: [ "C" ])
     engine2 = TurnEngine.new(game2)
 
     # (0,8) is Canyon and adjacent to (0,7) on even row (offset: [0,+1])
@@ -495,6 +495,29 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_equal paula, end_game_move.game_player
   end
 
+  test "end_turn draws 1 card when player does not hold CrossroadsTile" do
+    player = @game.current_player
+    @engine.end_turn
+    assert_equal 1, player.reload.hand.size
+  end
+
+  test "end_turn draws 2 cards when player holds CrossroadsTile" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "CrossroadsTile", "from" => "[4, 7]", "used" => false } ])
+    @engine.end_turn
+    player.reload
+    assert_equal 2, player.hand.size
+    player.hand.each { |card| assert_includes %w[C D F G T], card }
+  end
+
+  test "player acquires CrossroadsTile mid-turn and draws 2 cards at end of that turn" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "CrossroadsTile", "from" => "[4, 7]", "used" => false } ])
+    @game.update!(mandatory_count: 0)
+    @engine.end_turn
+    assert_equal 2, player.reload.hand.size
+  end
+
   test "tile_activatable? returns false for a used tile" do
     tile = { "klass" => "OasisTile", "from" => "[2, 7]", "used" => true }
 
@@ -552,6 +575,73 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.update!(mandatory_count: 0)
 
     assert_empty @engine.buildable_cells
+  end
+
+  test "first mandatory build with 2 cards locks chosen_terrain" do
+    @game.instantiate
+    g_hex = empty_hexes_of("G", 1).first
+    other_terrain = (@game.board.terrain_at(g_hex[0], g_hex[1]) == "G") ? "D" : "G"
+    @game.current_player.update!(hand: [ "G", other_terrain ])
+
+    TurnEngine.new(@game.reload).build_settlement(*g_hex)
+
+    @game.reload
+    assert_equal "G", @game.current_action["chosen_terrain"]
+    assert_equal [ "G", other_terrain ], @game.current_player.reload.hand
+  end
+
+  test "second mandatory build uses locked terrain and rejects other terrain" do
+    @game.instantiate
+    d_hexes = empty_hexes_of("D", 1)
+    skip "No D hexes on this board" if d_hexes.empty?
+    d_hex = d_hexes.first
+    @game.update!(current_action: { "type" => "mandatory", "chosen_terrain" => "G" })
+    @game.current_player.update!(hand: [ "G", "D" ])
+
+    result = TurnEngine.new(@game.reload).build_settlement(*d_hex)
+    assert_equal "Not available", result
+  end
+
+  test "undo of first mandatory build clears chosen_terrain" do
+    @game.instantiate
+    g_hex = empty_hexes_of("G", 1).first
+    other_terrain = "D"
+    @game.current_player.update!(hand: [ "G", other_terrain ])
+    engine = TurnEngine.new(@game.reload)
+    engine.build_settlement(*g_hex)
+    @game.reload
+
+    TurnEngine.new(@game).undo_last_move
+    @game.reload
+
+    assert_nil @game.current_action["chosen_terrain"]
+    assert_equal [ "G", other_terrain ], @game.current_player.reload.hand
+  end
+
+  test "buildable_cells with 2-card hand and no chosen_terrain returns union of both terrains" do
+    @game.boards = [ [ 2, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    # OasisBoard row 0 = "DDCWWTTGGG"; hand cards G and D
+    @game.current_player.update!(hand: [ "G", "D" ])
+    @game.reload
+
+    cells = TurnEngine.new(@game).buildable_cells
+
+    @game.instantiate
+    terrains = cells.map { |r, c| @game.board.terrain_at(r, c) }.uniq.sort
+    assert_includes terrains, "G"
+    assert_includes terrains, "D"
+  end
+
+  test "buildable_cells with 2-card hand and chosen_terrain uses only that terrain" do
+    @game.boards = [ [ 2, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    @game.current_player.update!(hand: [ "G", "D" ])
+    @game.update!(current_action: { "type" => "mandatory", "chosen_terrain" => "G" })
+    @game.reload
+
+    cells = TurnEngine.new(@game).buildable_cells
+
+    @game.instantiate
+    cells.each { |r, c| assert_equal "G", @game.board.terrain_at(r, c) }
   end
 
   test "buildable_cells for paddock with from returns valid move destinations" do
@@ -614,7 +704,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.boards = [ [ 6, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
     @game.update!(current_action: { "type" => "barn" }, mandatory_count: 0)
     @game.current_player.update!(
-      hand: "F",
+      hand: [ "F" ],
       tiles: [ { "klass" => "BarnTile", "from" => "[2, 6]", "used" => false } ]
     )
     # Place a settlement on F terrain with adjacent F terrain available
@@ -635,7 +725,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.boards = [ [ 6, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
     @game.update!(current_action: { "type" => "barn", "from" => "[0, 0]" })
     @game.current_player.update!(
-      hand: "F",
+      hand: [ "F" ],
       tiles: [ { "klass" => "BarnTile", "from" => "[2, 6]", "used" => false } ]
     )
     @game.instantiate
@@ -657,7 +747,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.boards = [ [ 6, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
     @game.update!(current_action: { "type" => "barn", "from" => "[0, 0]" }, mandatory_count: 0)
     @game.current_player.update!(
-      hand: "F",
+      hand: [ "F" ],
       tiles: [ { "klass" => "BarnTile", "from" => "[2, 6]", "used" => false } ]
     )
     @game.instantiate
@@ -677,14 +767,14 @@ class TurnEngineTest < ActiveSupport::TestCase
 
   test "turn_state returns barn message when current_action is barn" do
     @game.update!(current_action: { "type" => "barn" })
-    @game.current_player.update!(hand: "G")
+    @game.current_player.update!(hand: [ "G" ])
 
     assert_match(/must move a settlement to a Grass space/, @engine.turn_state)
   end
 
   test "turn_state returns oracle message when current_action is oracle" do
     @game.update!(current_action: { "type" => "oracle" })
-    @game.current_player.update!(hand: "G")
+    @game.current_player.update!(hand: [ "G" ])
 
     assert_match(/must build on a Grass space/, @engine.turn_state)
   end
@@ -693,7 +783,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.boards = [ [ 2, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
     @game.update!(current_action: { "type" => "oracle" }, mandatory_count: 0)
     @game.current_player.update!(
-      hand: "G",
+      hand: [ "G" ],
       tiles: [ { "klass" => "OracleTile", "from" => "[3, 7]", "used" => false } ]
     )
     @game.reload
@@ -706,6 +796,97 @@ class TurnEngineTest < ActiveSupport::TestCase
       assert_equal "G", @game.board.terrain_at(r, c)
       assert @game.board_contents.empty?(r, c)
     end
+  end
+
+  test "buildable_cells for oracle with 2-card hand returns union of both terrains" do
+    @game.update!(current_action: { "type" => "oracle" }, mandatory_count: 0)
+    @game.current_player.update!(
+      hand: [ "G", "D" ],
+      tiles: [ { "klass" => "OracleTile", "from" => "[3, 7]", "used" => false } ]
+    )
+    @game.reload
+
+    cells = TurnEngine.new(@game).buildable_cells
+
+    @game.instantiate
+    terrains = cells.map { |r, c| @game.board.terrain_at(r, c) }.uniq.sort
+    assert_includes terrains, "G"
+    assert_includes terrains, "D"
+  end
+
+  test "activate_tile_build for oracle with 2-card hand locks chosen_terrain" do
+    @game.instantiate
+    g_hex = empty_hexes_of("G", 1).first
+    other_terrain = "D"
+    @game.update!(current_action: { "type" => "oracle" }, mandatory_count: 1)
+    @game.current_player.update!(
+      hand: [ "G", other_terrain ],
+      tiles: [ { "klass" => "OracleTile", "from" => "[3, 7]", "used" => false } ]
+    )
+
+    TurnEngine.new(@game.reload).activate_tile_build(*g_hex)
+
+    @game.reload
+    assert_equal "G", @game.current_action["chosen_terrain"]
+  end
+
+  test "undo of oracle build with 2-card hand clears chosen_terrain" do
+    @game.instantiate
+    g_hex = empty_hexes_of("G", 1).first
+    other_terrain = "D"
+    @game.update!(current_action: { "type" => "oracle" }, mandatory_count: 1)
+    @game.current_player.update!(
+      hand: [ "G", other_terrain ],
+      tiles: [ { "klass" => "OracleTile", "from" => "[3, 7]", "used" => false } ]
+    )
+    TurnEngine.new(@game.reload).activate_tile_build(*g_hex)
+    @game.reload
+
+    TurnEngine.new(@game).undo_last_move
+    @game.reload
+
+    assert_nil @game.current_action["chosen_terrain"]
+  end
+
+  test "place_wall for quarry with 2-card hand locks chosen_terrain" do
+    @game.instantiate
+    # Find a G hex and an adjacent non-G hex to place a settlement (QuarryTile only targets G hexes adjacent to settlements)
+    g_hexes = empty_hexes_of("G", 2)
+    skip "Not enough G hexes" if g_hexes.size < 2
+    # Place a settlement adjacent to the first G hex by finding a non-G neighbor
+    g_hex = g_hexes.first
+    neighbor = @game.board_contents.neighbors(g_hex[0], g_hex[1]).find { |r, c|
+      @game.board_contents.available_for_building?(r, c) && @game.board.terrain_at(r, c) != nil
+    }
+    skip "No buildable neighbor" unless neighbor
+    @game.board_contents.place_settlement(*neighbor, @game.current_player.order)
+    @game.save!
+    @game.update!(current_action: { "type" => "quarry", "klass" => "QuarryTile", "walls_placed" => 0 })
+    @game.current_player.update!(
+      hand: [ "G", "D" ],
+      tiles: [ { "klass" => "QuarryTile", "from" => "[0, 0]", "used" => false } ]
+    )
+
+    TurnEngine.new(@game.reload).place_wall(*g_hex)
+
+    @game.reload
+    assert_equal "G", @game.current_action["chosen_terrain"]
+  end
+
+  test "buildable_cells for barn with 2-card hand and no from returns union settlements" do
+    @game.update!(current_action: { "type" => "barn" }, mandatory_count: 0)
+    @game.instantiate
+    g_hex = empty_hexes_of("G", 1).first
+    @game.board_contents.place_settlement(*g_hex, @game.current_player.order)
+    @game.save!
+    @game.current_player.update!(
+      hand: [ "G", "D" ],
+      tiles: [ { "klass" => "BarnTile", "from" => "[2, 6]", "used" => false } ]
+    )
+
+    cells = TurnEngine.new(@game.reload).buildable_cells
+
+    assert cells.any?
   end
 
   # ── Real-time goals ─────────────────────────────────────────────────────────
@@ -729,7 +910,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     game.board_contents.place_settlement(0, 0, opponent.order)
     game.save!
     game2 = Game.find(game.id)
-    game2.current_player.update!(hand: "D")
+    game2.current_player.update!(hand: [ "D" ])
     engine = TurnEngine.new(game2)
 
     engine.build_settlement(0, 1)
@@ -742,7 +923,7 @@ class TurnEngineTest < ActiveSupport::TestCase
   test "Ambassadors: does not score when building with no adjacent opponent" do
     # (0,0)=D on OasisBoard; no opponent neighbors
     game = fresh_oasis_game(goals: [ "ambassadors" ])
-    game.current_player.update!(hand: "D")
+    game.current_player.update!(hand: [ "D" ])
     engine = TurnEngine.new(game)
 
     engine.build_settlement(0, 0)
@@ -758,7 +939,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     game.board_contents.place_settlement(0, 0, opponent.order)
     game.save!
     game2 = Game.find(game.id)
-    game2.current_player.update!(hand: "D")
+    game2.current_player.update!(hand: [ "D" ])
     engine = TurnEngine.new(game2)
 
     engine.build_settlement(0, 1)
@@ -780,7 +961,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     game.board_contents.place_settlement(9, 1, player_order)
     game.save!
     game2 = Game.find(game.id)
-    game2.current_player.update!(hand: "W", supply: { "settlements" => 40 })
+    game2.current_player.update!(hand: [ "W" ], supply: { "settlements" => 40 })
     engine = TurnEngine.new(game2)
 
     engine.build_settlement(9, 0)
@@ -792,7 +973,7 @@ class TurnEngineTest < ActiveSupport::TestCase
   test "Shepherds: does not score when adjacent empty same-terrain exists" do
     # (0,0)=D on OasisBoard; (0,1)=D is adjacent and empty
     game = fresh_oasis_game(goals: [ "shepherds" ])
-    game.current_player.update!(hand: "D")
+    game.current_player.update!(hand: [ "D" ])
     engine = TurnEngine.new(game)
 
     engine.build_settlement(0, 0)
@@ -805,16 +986,16 @@ class TurnEngineTest < ActiveSupport::TestCase
     # OasisBoard row 0: "DDCWWTTGGG" — G at (0,7),(0,8),(0,9)
     # Even-row E direction: (0,7)->(0,8)->(0,9) is a straight line.
     game = fresh_oasis_game(goals: [ "families" ], mandatory_count: 3)
-    game.current_player.update!(hand: "G")
+    game.current_player.update!(hand: [ "G" ])
     engine = TurnEngine.new(game)
 
     engine.build_settlement(0, 7)
     game2 = Game.find(game.id)
-    game2.current_player.update!(hand: "G")
+    game2.current_player.update!(hand: [ "G" ])
     engine2 = TurnEngine.new(game2)
     engine2.build_settlement(0, 8)
     game3 = Game.find(game.id)
-    game3.current_player.update!(hand: "G")
+    game3.current_player.update!(hand: [ "G" ])
     engine3 = TurnEngine.new(game3)
     engine3.build_settlement(0, 9)
 
@@ -826,16 +1007,16 @@ class TurnEngineTest < ActiveSupport::TestCase
     # OasisBoard row 0: "DDCWWTTGGG", row 1: "DCWFFTTTGG"
     # (0,7)=G, (0,8)=G, (1,8)=G — (1,8) is SE of (0,8), not E, so (0,7),(0,8),(1,8) is not a line.
     game = fresh_oasis_game(goals: [ "families" ], mandatory_count: 3)
-    game.current_player.update!(hand: "G")
+    game.current_player.update!(hand: [ "G" ])
     engine = TurnEngine.new(game)
 
     engine.build_settlement(0, 7)
     game2 = Game.find(game.id)
-    game2.current_player.update!(hand: "G")
+    game2.current_player.update!(hand: [ "G" ])
     engine2 = TurnEngine.new(game2)
     engine2.build_settlement(0, 8)
     game3 = Game.find(game.id)
-    game3.current_player.update!(hand: "G")
+    game3.current_player.update!(hand: [ "G" ])
     engine3 = TurnEngine.new(game3)
     engine3.build_settlement(1, 8)
 
@@ -846,16 +1027,16 @@ class TurnEngineTest < ActiveSupport::TestCase
   test "Families: does not score when goal is not active" do
     # Same positions as the straight-line test but no families goal
     game = fresh_oasis_game(goals: [], mandatory_count: 3)
-    game.current_player.update!(hand: "G")
+    game.current_player.update!(hand: [ "G" ])
     engine = TurnEngine.new(game)
 
     engine.build_settlement(0, 7)
     game2 = Game.find(game.id)
-    game2.current_player.update!(hand: "G")
+    game2.current_player.update!(hand: [ "G" ])
     engine2 = TurnEngine.new(game2)
     engine2.build_settlement(0, 8)
     game3 = Game.find(game.id)
-    game3.current_player.update!(hand: "G")
+    game3.current_player.update!(hand: [ "G" ])
     engine3 = TurnEngine.new(game3)
     engine3.build_settlement(0, 9)
 
@@ -1354,7 +1535,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     ])
 
     # Force a known fort terrain that differs from hand
-    drawn = (@game.current_player.hand == "G") ? "D" : "G"
+    drawn = (@game.current_player.hand.first == "G") ? "D" : "G"
     @game.update!(
       mandatory_count: 0,
       current_action: { "type" => "fort", "klass" => "FortTile", "fort_terrain" => drawn }
@@ -1380,7 +1561,7 @@ class TurnEngineTest < ActiveSupport::TestCase
       { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
     ])
 
-    drawn = (@game.current_player.hand == "D") ? "G" : "D"
+    drawn = (@game.current_player.hand.first == "D") ? "G" : "D"
     fort_spot = empty_hexes_of(drawn, 1).first
     @game.update!(
       mandatory_count: 0,
@@ -1407,7 +1588,7 @@ class TurnEngineTest < ActiveSupport::TestCase
       { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
     ])
 
-    drawn = (@game.current_player.hand == "D") ? "G" : "D"
+    drawn = (@game.current_player.hand.first == "D") ? "G" : "D"
     fort_spot = empty_hexes_of(drawn, 1).first
     @game.update!(
       mandatory_count: 0,
@@ -1432,7 +1613,7 @@ class TurnEngineTest < ActiveSupport::TestCase
   end
 
   def force_hand(terrain)
-    @game.current_player.update!(hand: terrain)
+    @game.current_player.update!(hand: [ terrain ])
   end
 
   def empty_hexes_of(terrain, n)

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -577,6 +577,20 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_empty @engine.buildable_cells
   end
 
+  test "building on the second card's terrain works and locks to that terrain" do
+    @game.instantiate
+    second_terrain = (empty_hexes_of("G", 1).any? && empty_hexes_of("D", 1).any?) ? "D" : nil
+    skip "Need both G and D hexes" unless second_terrain
+    d_hex = empty_hexes_of("D", 1).first
+    @game.current_player.update!(hand: [ "G", "D" ])
+
+    result = TurnEngine.new(@game.reload).build_settlement(*d_hex)
+
+    assert_not_equal "Not available", result
+    @game.reload
+    assert_equal "D", @game.current_action["chosen_terrain"]
+  end
+
   test "first mandatory build with 2 cards locks chosen_terrain" do
     @game.instantiate
     g_hex = empty_hexes_of("G", 1).first


### PR DESCRIPTION
## Summary

- **`game_player.hand` is now a JSON array** (`["G"]` single card, `["G", "F"]` with Crossroads) — all existing usages updated throughout the engine, applicator, views, and tests
- **Two-card draw**: `end_turn` checks `has_crossroads_tile?` and draws a second card; takes effect at the end of the turn the tile is acquired
- **Terrain lock**: the player's first terrain-requiring action (mandatory build, BarnTile, OracleTile, QuarryTile) locks `chosen_terrain` into `current_action`; all subsequent terrain checks for that turn use it
- **Union of valid hexes**: before terrain is locked, `buildable_cells` and terrain-sensitive tile destinations are the union of both cards' independent adjacency results
- **Undo support**: `chosen_terrain_before` is stored in each Move payload; `LiveState` restores it on undo, returning both cards to active
- **Display**: `_game_player.html.erb` iterates `hand` array; shunned card gets `card-shunned` CSS (opacity + grayscale)
- **Predicates**: `crossroads_tile?` and `uses_played_terrain?` added to tile base class; overridden in CrossroadsTile, BarnTile, OracleTile, QuarryTile

## Test plan

- [x] `bin/rails test` — 713 tests, 0 failures
- [x] `bin/rubocop` — 0 offenses
- [x] Manual: start a game with board 13 (Barracks/Crossroads), pick up the Crossroads tile, end turn → two cards drawn
- [x] Manual: with two cards, first build locks terrain and grays the other card
- [x] Manual: undo the first build → both cards active again
- [x] Manual: use OracleTile before any mandatory build → destinations include both terrains; picking one locks it
- [x] Manual: end turn → two fresh cards drawn (tile still held)
- [x] Manual: move away from Crossroads tile location → forfeit fires; next turn draws only one card

🤖 Generated with [Claude Code](https://claude.com/claude-code)