### PR TITLE
Fix Outpost tile showing no selectable hexes with 2-card hand

### DIFF
--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -723,10 +723,10 @@ class TurnEngine
       if action == "mandatory"
         if player.settlements_remaining? && @game.mandatory_count > 0
           if @game.current_action["outpost_active"]
-            terrain = effective_terrain(player)
+            terrains = effective_terrain(player) ? [ effective_terrain(player) ] : player.hand
             (0..19).flat_map do |r|
-              (0..19).filter_map { |c| [ r, c ] if @game.board_contents.empty?(r, c) && @game.board.terrain_at(r, c) == terrain }
-            end
+              (0..19).filter_map { |c| [ r, c ] if @game.board_contents.available_for_building?(r, c) && terrains.include?(@game.board.terrain_at(r, c)) }
+            end.uniq
           else
             terrains = effective_terrain(player) ? [ effective_terrain(player) ] : player.hand
             terrains.flat_map { |t|

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -1312,6 +1312,25 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_equal all_empty_grass.sort, cells.sort
   end
 
+  test "buildable_cells with outpost_active and 2-card hand returns cells for both terrains" do
+    @game.boards = [ [ 2, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    @game.current_player.update!(hand: [ "G", "D" ], tiles: [
+      { "klass" => "MandatoryTile", "used" => false },
+      { "klass" => "OutpostTile", "from" => "[3, 3]", "used" => false }
+    ])
+    @game.reload
+    @engine.activate_outpost
+    @game.reload
+
+    cells = TurnEngine.new(@game).buildable_cells
+
+    @game.instantiate
+    terrains = cells.map { |r, c| @game.board.terrain_at(r, c) }.uniq.sort
+    assert_includes terrains, "G"
+    assert_includes terrains, "D"
+    assert cells.any?, "expected selectable hexes but got none"
+  end
+
   test "undo of activate_outpost clears outpost_active and marks tile unused" do
     force_hand("G")
     player = @game.current_player


### PR DESCRIPTION
## Summary

- `buildable_cells` called `effective_terrain(player)` which returns `nil` when the player holds 2 terrain cards and hasn't locked a terrain yet — causing every `terrain_at(r,c) == nil` comparison to fail, so nothing was selectable
- Fix mirrors the non-outpost path: fall back to `player.hand` (both terrains) when `effective_terrain` returns nil
- Also tightens `empty?` → `available_for_building?` to exclude warrior-blocked hexes, matching `build_settlement`'s validation

## Test plan

- [x] New test: `buildable_cells with outpost_active and 2-card hand returns cells for both terrains`
- [x] Existing outpost tests still pass
- [x] Full `turn_engine_test.rb` suite passes (106 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)