### PR TITLE
Fix Sword on meeples returning/restoring wrong supply type

### DIFF
--- a/app/models/board_state.rb
+++ b/app/models/board_state.rb
@@ -65,6 +65,15 @@ class BoardState
     cell && cell["klass"] == "Settlement" && cell["meeple"] == "wagon"
   end
 
+  def restore_piece(meeple, row, col, player)
+    case meeple
+    when "warrior" then place_warrior(row, col, player)
+    when "ship"    then place_ship(row, col, player)
+    when "wagon"   then place_wagon(row, col, player)
+    else                place_settlement(row, col, player)
+    end
+  end
+
   def warrior_blocked?(row, col)
     neighbors(row, col).any? { |nr, nc| warrior_at?(nr, nc) }
   end

--- a/app/models/game_player.rb
+++ b/app/models/game_player.rb
@@ -108,6 +108,24 @@ class GamePlayer < ApplicationRecord
     supply["wagons"] = wagons_remaining + 1
   end
 
+  def return_piece_to_supply!(meeple)
+    case meeple
+    when "warrior" then increment_warrior_supply!
+    when "ship"    then increment_ship_supply!
+    when "wagon"   then increment_wagon_supply!
+    else                increment_supply!
+    end
+  end
+
+  def remove_piece_from_supply!(meeple)
+    case meeple
+    when "warrior" then decrement_warrior_supply!
+    when "ship"    then decrement_ship_supply!
+    when "wagon"   then decrement_wagon_supply!
+    else                decrement_supply!
+    end
+  end
+
   def city_halls_remaining
     supply["city_halls"].to_i
   end

--- a/app/services/move_applicator.rb
+++ b/app/services/move_applicator.rb
@@ -49,7 +49,8 @@ module MoveApplicator
         from: move.from,
         owner_order: move.payload["owner_order"],
         action_before: move.payload["action_before"],
-        tile_used: move.payload["tile_used"]
+        tile_used: move.payload["tile_used"],
+        meeple: move.payload["meeple"]
       )
     when "place_wall"
       ct_before = move.payload&.key?("chosen_terrain_before") ? move.payload["chosen_terrain_before"] : :not_provided
@@ -176,10 +177,11 @@ class MoveApplicator::HashState
     player["bonus_scores"][goal] = (player["bonus_scores"][goal] || 0) - score
   end
 
-  def apply_remove_settlement(player_order:, from:, owner_order:, action_before: nil, tile_used: nil)
+  def apply_remove_settlement(player_order:, from:, owner_order:, action_before: nil, tile_used: nil, meeple: nil)
     coord = Coordinate.from_key(from)
     @board.remove(coord.row, coord.col)
-    @players[owner_order]["supply"]["settlements"] += 1
+    key = meeple ? meeple.pluralize : "settlements"
+    @players[owner_order]["supply"][key] += 1
   end
 
   def apply_place_wall(player_order:, to:, chosen_terrain_before: :not_provided)
@@ -413,12 +415,12 @@ class MoveApplicator::LiveState
     gp.save
   end
 
-  def apply_remove_settlement(player_order:, from:, owner_order:, action_before: nil, tile_used: nil)
+  def apply_remove_settlement(player_order:, from:, owner_order:, action_before: nil, tile_used: nil, meeple: nil)
     coord = Coordinate.from_key(from)
     @game.board_contents_will_change!
-    @game.board_contents.place_settlement(coord.row, coord.col, owner_order)
+    @game.board_contents.restore_piece(meeple, coord.row, coord.col, owner_order)
     owner = player_for(owner_order)
-    owner.decrement_supply!
+    owner.remove_piece_from_supply!(meeple)
     owner.save
     if action_before
       @game.current_action = action_before

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -156,6 +156,7 @@ class TurnEngine
     action_before = @game.current_action.deep_dup
     remaining_orders = pending_orders - [ owner_order ]
     tile_used = remaining_orders.empty?
+    meeple = @game.board_contents.meeple_at(row, col)
 
     @game.move_count += 1
     @game.moves.create(
@@ -166,13 +167,13 @@ class TurnEngine
       from: "[#{row}, #{col}]",
       to: "player_#{owner_order}_supply",
       reversible: true,
-      payload: { "owner_order" => owner_order, "action_before" => action_before, "tile_used" => tile_used },
-      message: "#{game_player.player.handle} removed #{owner.player.handle}'s settlement"
+      payload: { "owner_order" => owner_order, "action_before" => action_before, "tile_used" => tile_used, "meeple" => meeple },
+      message: "#{game_player.player.handle} removed #{owner.player.handle}'s #{meeple || 'settlement'}"
     )
 
     @game.board_contents_will_change!
     @game.board_contents.remove(row, col)
-    owner.increment_supply!
+    owner.return_piece_to_supply!(meeple)
     apply_tile_forfeit(owner)
 
     if tile_used

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -1407,6 +1407,52 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_equal false, sword["used"], "SwordTile must be unused after undo"
   end
 
+  test "remove_settlement on a warrior returns warrior to supply, not settlement supply" do
+    opponent = @game.game_players.find { |gp| gp != @game.current_player }
+    opponent.reload.add_warriors!(2)
+    @game.current_player.update!(tiles: [ { "klass" => "SwordTile", "from" => "[0, 0]", "used" => false } ])
+    hex = empty_hexes_of("G", 1).first
+    @game.instantiate
+    @game.board_contents.place_warrior(*hex, opponent.order)
+    @game.update!(current_action: {
+      "type" => "sword", "klass" => "SwordTile", "pending_orders" => [ opponent.order ]
+    })
+    @game.save!
+    @game.reload
+    warriors_before = opponent.reload.warriors_remaining
+    settlements_before = opponent.reload.settlements_remaining
+
+    @engine.remove_settlement(*hex)
+    @game.reload
+
+    assert_equal warriors_before + 1, opponent.reload.warriors_remaining, "warrior should return to supply"
+    assert_equal settlements_before, opponent.reload.settlements_remaining, "settlement supply must not change"
+  end
+
+  test "undo of remove_settlement on a warrior restores warrior to board, not a settlement" do
+    opponent = @game.game_players.find { |gp| gp != @game.current_player }
+    opponent.reload.add_warriors!(2)
+    @game.current_player.update!(tiles: [ { "klass" => "SwordTile", "from" => "[0, 0]", "used" => false } ])
+    hex = empty_hexes_of("G", 1).first
+    @game.instantiate
+    @game.board_contents.place_warrior(*hex, opponent.order)
+    @game.update!(current_action: {
+      "type" => "sword", "klass" => "SwordTile", "pending_orders" => [ opponent.order ]
+    })
+    @game.save!
+    @game.reload
+
+    @engine.remove_settlement(*hex)
+    @game.reload
+    @engine.undo_last_move
+    @game.reload
+    @game.instantiate
+
+    assert @game.board_contents.warrior_at?(*hex), "warrior should be restored to board"
+    assert_not @game.board_contents.player_at(*hex) && !@game.board_contents.warrior_at?(*hex),
+      "a plain settlement must not appear"
+  end
+
   test "undo of place_warrior restores current_action to barracks tile state" do
     player = @game.current_player
     player.update!(tiles: [ { "klass" => "BarracksTile", "from" => "[0, 0]", "used" => false } ])


### PR DESCRIPTION
## Summary

- `remove_settlement` always called `increment_supply!` (settlements) regardless of what was targeted — a warrior Sworded away would return to settlement supply, not warrior supply
- On undo, `apply_remove_settlement` always called `place_settlement` + `decrement_supply!`, so undoing a Sword on a warrior put a plain settlement on the board instead of a warrior
- Same bug applies to ships and wagons

## Approach

Record `"meeple"` in the move payload (nil for plain settlements). Add dispatch methods on the models:
- `GamePlayer#return_piece_to_supply!(meeple)` / `#remove_piece_from_supply!(meeple)`
- `BoardState#restore_piece(meeple, row, col, player)`

The service layer stays ignorant of specific meeple kinds — any future meeple type just needs these two methods updated.

## Test plan

- [x] New test: Sword on warrior returns warrior to supply, not settlement supply
- [x] New test: Undo of Sword on warrior restores warrior to board, not a settlement
- [x] Full `turn_engine_test.rb` + `move_applicator_test.rb` suite passes (115 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)