### PR TITLE
Deepen turn phase refactor

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -122,6 +122,14 @@ class Game < ApplicationRecord
     TurnEngine.new(self).turn_state
   end
 
+  def turn_phase
+    TurnPhase.deserialize(current_action)
+  end
+
+  def turn_phase=(phase)
+    self.current_action = phase.serialize
+  end
+
   def my_turn?(user)
     playing? && current_player&.player == user
   end

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -1,0 +1,593 @@
+class TurnPhase
+  class InvalidTransition < StandardError; end
+
+  TransitionResult = Struct.new(
+    :next_phase,
+    :terrain_lock,
+    :action_completed,
+    :source_cleared,
+    keyword_init: true
+  )
+
+  module Events
+    BuildChosen = Struct.new(:coordinate, keyword_init: true)
+    TileActionSelected = Struct.new(keyword_init: true)
+    SourceSelected = Struct.new(:coordinate_key, keyword_init: true)
+    DestinationChosen = Struct.new(keyword_init: true)
+  end
+
+  module Facts
+    BuildChoice = Struct.new(:locked_terrain, keyword_init: true)
+    TileActionSelection = Struct.new(:selected_phase, keyword_init: true)
+    DestinationChoice = Struct.new(:next_phase, keyword_init: true)
+  end
+
+  def self.deserialize(data)
+    hash = (data || { "type" => "mandatory" }).deep_stringify_keys
+    type = hash["type"] || "mandatory"
+
+    return MandatoryBuildPhase.from_hash(hash) if type == "mandatory"
+
+    klass_name = hash["klass"] || "#{type.capitalize}Tile"
+    tile_class = Tiles::Tile.for_klass(klass_name)
+    tile = tile_class&.new(0)
+
+    if tile&.fort_tile?
+      FortPhase.from_hash(hash)
+    elsif tile&.is_a?(Tiles::Nomad::ResettlementTile)
+      ResettlementPhase.from_hash(hash)
+    elsif tile && (tile.builds_settlement? || tile.places_wall?)
+      TileBuildPhase.from_hash(hash)
+    elsif tile&.sword_tile?
+      TargetedRemovalPhase.from_hash(hash)
+    elsif tile && tile.places_meeple? && tile.meeple_kind == "warrior"
+      MeepleActionPhase.from_hash(hash)
+    elsif tile&.places_city_hall?
+      CityHallPhase.from_hash(hash)
+    elsif tile && tile.places_meeple? && %w[ship wagon].include?(tile.meeple_kind)
+      MeepleMovementPhase.from_hash(hash)
+    elsif tile && tile.moves_settlement?
+      SettlementMovePhase.from_hash(hash)
+    else
+      LegacyPhase.new(hash)
+    end
+  end
+
+  def type
+    serialize.fetch("type")
+  end
+
+  def klass_name
+    serialize["klass"]
+  end
+
+  def chosen_terrain
+    serialize["chosen_terrain"]
+  end
+
+  def from
+    serialize["from"]
+  end
+
+  def transition(_event, _facts)
+    raise InvalidTransition, "#{self.class.name} does not accept that event"
+  end
+end
+
+class TurnPhase::MandatoryBuildPhase < TurnPhase
+  attr_reader :chosen_terrain_value, :builds, :outpost_active_value
+
+  def self.from_hash(hash)
+    new(
+      chosen_terrain: hash["chosen_terrain"],
+      builds: Array(hash["builds"]),
+      outpost_active: hash["outpost_active"] == true
+    )
+  end
+
+  def initialize(chosen_terrain: nil, builds: [], outpost_active: false)
+    @chosen_terrain_value = chosen_terrain
+    @builds = builds
+    @outpost_active_value = outpost_active
+  end
+
+  def chosen_terrain
+    @chosen_terrain_value
+  end
+
+  def outpost_active?
+    outpost_active_value == true
+  end
+
+  def transition(event, facts)
+    case event
+    when TurnPhase::Events::BuildChosen
+      next_terrain = chosen_terrain || facts.locked_terrain
+      TurnPhase::TransitionResult.new(
+        next_phase: self.class.new(
+          chosen_terrain: next_terrain,
+          builds: builds + [ event.coordinate ],
+          outpost_active: outpost_active?
+        ),
+        terrain_lock: next_terrain
+      )
+    when TurnPhase::Events::TileActionSelected
+      TurnPhase::TransitionResult.new(
+        next_phase: facts.selected_phase,
+        action_completed: false,
+        source_cleared: true
+      )
+    else
+      super
+    end
+  end
+
+  def serialize
+    hash = { "type" => "mandatory" }
+    hash["chosen_terrain"] = chosen_terrain if chosen_terrain
+    hash["builds"] = builds if builds.any?
+    hash["outpost_active"] = true if outpost_active?
+    hash
+  end
+end
+
+class TurnPhase::TileBuildPhase < TurnPhase
+  attr_reader :action_type, :klass_value, :chosen_terrain_value, :remaining, :walls_placed
+
+  def self.from_hash(hash)
+    new(
+      action_type: hash.fetch("type"),
+      klass_name: hash["klass"],
+      chosen_terrain: hash["chosen_terrain"],
+      remaining: hash["remaining"],
+      walls_placed: hash["walls_placed"]
+    )
+  end
+
+  def initialize(action_type:, klass_name:, chosen_terrain: nil, remaining: nil, walls_placed: nil)
+    @action_type = action_type
+    @klass_value = klass_name
+    @chosen_terrain_value = chosen_terrain
+    @remaining = remaining
+    @walls_placed = walls_placed
+  end
+
+  def type
+    action_type
+  end
+
+  def klass_name
+    klass_value
+  end
+
+  def chosen_terrain
+    chosen_terrain_value
+  end
+
+  def decrement_remaining
+    self.class.new(
+      action_type: action_type,
+      klass_name: klass_name,
+      chosen_terrain: chosen_terrain,
+      remaining: remaining && remaining - 1,
+      walls_placed: walls_placed
+    )
+  end
+
+  def increment_walls_placed
+    self.class.new(
+      action_type: action_type,
+      klass_name: klass_name,
+      chosen_terrain: chosen_terrain,
+      remaining: remaining,
+      walls_placed: walls_placed.to_i + 1
+    )
+  end
+
+  def serialize
+    hash = { "type" => action_type }
+    hash["klass"] = klass_name if klass_name
+    hash["chosen_terrain"] = chosen_terrain if chosen_terrain
+    hash["remaining"] = remaining if remaining
+    hash["walls_placed"] = walls_placed if walls_placed
+    hash
+  end
+end
+
+class TurnPhase::FortPhase < TurnPhase
+  attr_reader :fort_terrain_value
+
+  def self.from_hash(hash)
+    new(fort_terrain: hash.fetch("fort_terrain"))
+  end
+
+  def initialize(fort_terrain:)
+    @fort_terrain_value = fort_terrain
+  end
+
+  def type
+    "fort"
+  end
+
+  def klass_name
+    "FortTile"
+  end
+
+  def fort_terrain
+    fort_terrain_value
+  end
+
+  def serialize
+    {
+      "type" => "fort",
+      "klass" => "FortTile",
+      "fort_terrain" => fort_terrain
+    }
+  end
+end
+
+class TurnPhase::SettlementMovePhase < TurnPhase
+  attr_reader :action_type, :klass_value, :from_value
+
+  def self.from_hash(hash)
+    new(
+      action_type: hash.fetch("type"),
+      klass_name: hash["klass"],
+      from: hash["from"]
+    )
+  end
+
+  def initialize(action_type:, klass_name:, from: nil)
+    @action_type = action_type
+    @klass_value = klass_name
+    @from_value = from
+  end
+
+  def type
+    action_type
+  end
+
+  def klass_name
+    klass_value
+  end
+
+  def from
+    from_value
+  end
+
+  def transition(event, facts)
+    case event
+    when TurnPhase::Events::SourceSelected
+      TurnPhase::TransitionResult.new(
+        next_phase: self.class.new(
+          action_type: action_type,
+          klass_name: klass_name,
+          from: event.coordinate_key
+        ),
+        source_cleared: false
+      )
+    when TurnPhase::Events::DestinationChosen
+      TurnPhase::TransitionResult.new(
+        next_phase: facts.next_phase,
+        action_completed: true,
+        source_cleared: true
+      )
+    else
+      super
+    end
+  end
+
+  def serialize
+    hash = { "type" => action_type }
+    hash["klass"] = klass_name if klass_name
+    hash["from"] = from if from
+    hash
+  end
+end
+
+class TurnPhase::ResettlementPhase < TurnPhase
+  attr_reader :budget_value, :vacated_value, :moves_value, :from_value
+
+  def self.from_hash(hash)
+    new(
+      budget: hash.fetch("budget"),
+      vacated: Array(hash["vacated"]),
+      moves: hash.fetch("moves"),
+      from: hash["from"]
+    )
+  end
+
+  def initialize(budget:, vacated:, moves:, from: nil)
+    @budget_value = budget
+    @vacated_value = vacated
+    @moves_value = moves
+    @from_value = from
+  end
+
+  def type
+    "resettlement"
+  end
+
+  def klass_name
+    "ResettlementTile"
+  end
+
+  def budget
+    budget_value
+  end
+
+  def vacated
+    vacated_value
+  end
+
+  def moves
+    moves_value
+  end
+
+  def from
+    from_value
+  end
+
+  def transition(event, facts)
+    case event
+    when TurnPhase::Events::SourceSelected
+      TurnPhase::TransitionResult.new(
+        next_phase: self.class.new(
+          budget: budget,
+          vacated: vacated,
+          moves: moves,
+          from: event.coordinate_key
+        ),
+        source_cleared: false
+      )
+    when TurnPhase::Events::DestinationChosen
+      TurnPhase::TransitionResult.new(
+        next_phase: facts.next_phase,
+        action_completed: facts.next_phase.is_a?(TurnPhase::MandatoryBuildPhase),
+        source_cleared: true
+      )
+    else
+      super
+    end
+  end
+
+  def serialize
+    hash = {
+      "type" => "resettlement",
+      "klass" => "ResettlementTile",
+      "budget" => budget,
+      "vacated" => vacated,
+      "moves" => moves
+    }
+    hash["from"] = from if from
+    hash
+  end
+end
+
+class TurnPhase::MeepleMovementPhase < TurnPhase
+  attr_reader :action_type, :klass_value, :from_value
+
+  def self.from_hash(hash)
+    new(
+      action_type: hash.fetch("type"),
+      klass_name: hash["klass"],
+      from: hash["from"]
+    )
+  end
+
+  def initialize(action_type:, klass_name:, from: nil)
+    @action_type = action_type
+    @klass_value = klass_name
+    @from_value = from
+  end
+
+  def type
+    action_type
+  end
+
+  def klass_name
+    klass_value
+  end
+
+  def from
+    from_value
+  end
+
+  def transition(event, facts)
+    case event
+    when TurnPhase::Events::SourceSelected
+      TurnPhase::TransitionResult.new(
+        next_phase: self.class.new(
+          action_type: action_type,
+          klass_name: klass_name,
+          from: event.coordinate_key
+        ),
+        source_cleared: false
+      )
+    when TurnPhase::Events::DestinationChosen
+      TurnPhase::TransitionResult.new(
+        next_phase: facts.next_phase,
+        action_completed: true,
+        source_cleared: true
+      )
+    else
+      super
+    end
+  end
+
+  def serialize
+    hash = { "type" => action_type }
+    hash["klass"] = klass_name if klass_name
+    hash["from"] = from if from
+    hash
+  end
+end
+
+class TurnPhase::TargetedRemovalPhase < TurnPhase
+  attr_reader :action_type, :klass_value, :pending_orders_value
+
+  def self.from_hash(hash)
+    new(
+      action_type: hash.fetch("type"),
+      klass_name: hash["klass"],
+      pending_orders: Array(hash["pending_orders"])
+    )
+  end
+
+  def initialize(action_type:, klass_name:, pending_orders:)
+    @action_type = action_type
+    @klass_value = klass_name
+    @pending_orders_value = pending_orders
+  end
+
+  def type
+    action_type
+  end
+
+  def klass_name
+    klass_value
+  end
+
+  def pending_orders
+    pending_orders_value
+  end
+
+  def consume_target(owner_order)
+    remaining = pending_orders - [owner_order]
+    if remaining.empty?
+      TurnPhase::TransitionResult.new(
+        next_phase: TurnPhase::MandatoryBuildPhase.new,
+        action_completed: true,
+        source_cleared: true
+      )
+    else
+      TurnPhase::TransitionResult.new(
+        next_phase: self.class.new(
+          action_type: action_type,
+          klass_name: klass_name,
+          pending_orders: remaining
+        ),
+        action_completed: false,
+        source_cleared: true
+      )
+    end
+  end
+
+  def serialize
+    {
+      "type" => action_type,
+      "klass" => klass_name,
+      "pending_orders" => pending_orders
+    }
+  end
+end
+
+class TurnPhase::MeepleActionPhase < TurnPhase
+  attr_reader :action_type, :klass_value
+
+  def self.from_hash(hash)
+    new(
+      action_type: hash.fetch("type"),
+      klass_name: hash["klass"]
+    )
+  end
+
+  def initialize(action_type:, klass_name:)
+    @action_type = action_type
+    @klass_value = klass_name
+  end
+
+  def type
+    action_type
+  end
+
+  def klass_name
+    klass_value
+  end
+
+  def serialize
+    {
+      "type" => action_type,
+      "klass" => klass_name
+    }
+  end
+end
+
+class TurnPhase::CityHallPhase < TurnPhase
+  attr_reader :action_type, :klass_value
+
+  def self.from_hash(hash)
+    new(
+      action_type: hash.fetch("type"),
+      klass_name: hash["klass"]
+    )
+  end
+
+  def initialize(action_type:, klass_name:)
+    @action_type = action_type
+    @klass_value = klass_name
+  end
+
+  def type
+    action_type
+  end
+
+  def klass_name
+    klass_value
+  end
+
+  def serialize
+    {
+      "type" => action_type,
+      "klass" => klass_name
+    }
+  end
+end
+
+class TurnPhase::LegacyPhase < TurnPhase
+  attr_reader :data
+
+  def initialize(data)
+    @data = data.deep_stringify_keys
+  end
+
+  def builds
+    Array(data["builds"])
+  end
+
+  def pending_orders
+    Array(data["pending_orders"])
+  end
+
+  def outpost_active?
+    data["outpost_active"] == true
+  end
+
+  def remaining
+    data["remaining"]
+  end
+
+  def walls_placed
+    data["walls_placed"]
+  end
+
+  def fort_terrain
+    data["fort_terrain"]
+  end
+
+  def budget
+    data["budget"]
+  end
+
+  def vacated
+    Array(data["vacated"])
+  end
+
+  def moves
+    data["moves"]
+  end
+
+  def serialize
+    data.deep_dup
+  end
+end

--- a/app/services/move_applicator.rb
+++ b/app/services/move_applicator.rb
@@ -3,12 +3,12 @@ module MoveApplicator
     player_order = move.game_player.order
     case move.action
     when "select_action"
-      backend.apply_select_action(player_order: player_order, type: move.to, klass: move.payload&.dig("klass"))
+      backend.apply_select_action(player_order: player_order, type: move.to, klass: move.payload&.dig("klass"), pending_orders: move.payload&.dig("pending_orders"))
     when "select_settlement"
       backend.apply_select_settlement(player_order: player_order, from: move.from)
     when "move_settlement"
       ct_before = move.payload&.key?("chosen_terrain_before") ? move.payload["chosen_terrain_before"] : :not_provided
-      backend.apply_move_settlement(player_order: player_order, from: move.from, to: move.to, tile_klass: move.payload&.dig("tile_klass"), action_before: move.payload&.dig("action_before"), chosen_terrain_before: ct_before)
+      backend.apply_move_settlement(player_order: player_order, from: move.from, to: move.to, tile_klass: move.payload&.dig("tile_klass"), action_before: move.payload&.dig("action_before"), phase_after: move.payload&.dig("phase_after"), chosen_terrain_before: ct_before)
     when "activate_fort"
       backend.apply_activate_fort(player_order: player_order)
     when "draw_fort_card"
@@ -21,7 +21,7 @@ module MoveApplicator
     when "build"
       fort_terrain = move.payload&.dig("tile_klass") == "FortTile" ? move.payload&.dig("card") : nil
       ct_before = move.payload&.key?("chosen_terrain_before") ? move.payload["chosen_terrain_before"] : :not_provided
-      backend.apply_build(player_order: player_order, to: move.to, tile_klass: move.payload&.dig("tile_klass"), remaining_before: move.payload&.dig("remaining_before"), fort_terrain: fort_terrain, chosen_terrain_before: ct_before)
+      backend.apply_build(player_order: player_order, to: move.to, tile_klass: move.payload&.dig("tile_klass"), remaining_before: move.payload&.dig("remaining_before"), fort_terrain: fort_terrain, build_terrain: move.payload&.dig("card"), chosen_terrain_before: ct_before)
     when "pick_up_tile"
       backend.apply_pick_up_tile(player_order: player_order, from: move.from, klass: move.payload["klass"])
     when "grant_meeple"
@@ -66,7 +66,7 @@ module MoveApplicator
     when "remove_ship"
       backend.apply_remove_ship(player_order: player_order, from: move.from, action_before: move.payload&.dig("action_before"))
     when "move_ship"
-      backend.apply_move_ship(player_order: player_order, from: move.from, to: move.to, action_before: move.payload&.dig("action_before"))
+      backend.apply_move_ship(player_order: player_order, from: move.from, to: move.to, action_before: move.payload&.dig("action_before"), phase_after: move.payload&.dig("phase_after"))
     when "select_ship"
       backend.apply_select_ship(player_order: player_order, from: move.from)
     when "place_wagon"
@@ -74,7 +74,7 @@ module MoveApplicator
     when "remove_wagon"
       backend.apply_remove_wagon(player_order: player_order, from: move.from, action_before: move.payload&.dig("action_before"))
     when "move_wagon"
-      backend.apply_move_wagon(player_order: player_order, from: move.from, to: move.to, action_before: move.payload&.dig("action_before"))
+      backend.apply_move_wagon(player_order: player_order, from: move.from, to: move.to, action_before: move.payload&.dig("action_before"), phase_after: move.payload&.dig("phase_after"))
     when "select_wagon"
       backend.apply_select_wagon(player_order: player_order, from: move.from)
     when "place_city_hall"
@@ -100,16 +100,66 @@ class MoveApplicator::HashState
     @turn_number = snapshot["turn_number"]
   end
 
-  def apply_select_action(player_order:, type:, klass: nil)
-    @current_action = { "type" => type }
-    @current_action["klass"] = klass if klass
+  def apply_select_action(player_order:, type:, klass: nil, pending_orders: nil)
+    tile_class = Tiles::Tile.for_klass(klass)
+    tile = tile_class&.new(0)
+    selected_phase =
+      if tile&.builds_settlement? || tile&.places_wall?
+        TurnPhase::TileBuildPhase.new(
+          action_type: type,
+          klass_name: klass,
+          remaining: (3 if tile.is_a?(Tiles::Nomad::DonationTile)),
+          walls_placed: (0 if tile.is_a?(Tiles::QuarryTile))
+        )
+      elsif tile&.places_meeple? && %w[ship wagon].include?(tile.meeple_kind)
+        TurnPhase::MeepleMovementPhase.new(
+          action_type: type,
+          klass_name: klass
+        )
+      elsif tile&.places_meeple? && tile.meeple_kind == "warrior"
+        TurnPhase::MeepleActionPhase.new(
+          action_type: type,
+          klass_name: klass
+        )
+      elsif tile&.sword_tile?
+        TurnPhase::TargetedRemovalPhase.new(
+          action_type: type,
+          klass_name: klass,
+          pending_orders: Array(pending_orders)
+        )
+      elsif tile&.moves_settlement? && !tile.is_a?(Tiles::Nomad::ResettlementTile)
+        TurnPhase::SettlementMovePhase.new(
+          action_type: type,
+          klass_name: klass
+        )
+      elsif tile&.is_a?(Tiles::Nomad::ResettlementTile)
+        TurnPhase::ResettlementPhase.new(
+          budget: 4,
+          vacated: [],
+          moves: 0
+        )
+      else
+        TurnPhase::LegacyPhase.new({ "type" => type, "klass" => klass }.compact)
+      end
+    @current_action = TurnPhase.deserialize(@current_action).transition(
+      TurnPhase::Events::TileActionSelected.new,
+      TurnPhase::Facts::TileActionSelection.new(selected_phase: selected_phase)
+    ).next_phase.serialize
   end
 
   def apply_select_settlement(player_order:, from:)
-    @current_action = @current_action.merge("from" => from)
+    current_phase = TurnPhase.deserialize(@current_action)
+    if current_phase.is_a?(TurnPhase::SettlementMovePhase) || current_phase.is_a?(TurnPhase::ResettlementPhase)
+      @current_action = current_phase.transition(
+        TurnPhase::Events::SourceSelected.new(coordinate_key: from),
+        nil
+      ).next_phase.serialize
+    else
+      @current_action = TurnPhase::LegacyPhase.new(@current_action.merge("from" => from)).serialize
+    end
   end
 
-  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil, fort_terrain: nil, chosen_terrain_before: :not_provided)
+  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil, fort_terrain: nil, build_terrain: nil, chosen_terrain_before: :not_provided)
     coord = Coordinate.from_key(to)
     @board.place_settlement(coord.row, coord.col, player_order)
     @players[player_order]["supply"]["settlements"] -= 1
@@ -120,15 +170,24 @@ class MoveApplicator::HashState
       mark_tile_used(@players[player_order], tile_klass)
       remaining_after = remaining_before ? remaining_before - 1 : nil
       if remaining_after && remaining_after > 0
-        @current_action = { "type" => tile_klass.delete_suffix("Tile").downcase, "klass" => tile_klass, "remaining" => remaining_after }
+        current_phase = TurnPhase.deserialize(@current_action)
+        @current_action = TurnPhase::TileBuildPhase.new(
+          action_type: tile_klass.delete_suffix("Tile").downcase,
+          klass_name: tile_klass,
+          chosen_terrain: current_phase.respond_to?(:chosen_terrain) ? current_phase.chosen_terrain : nil,
+          remaining: remaining_after
+        ).serialize
       else
         @current_action = { "type" => "mandatory" }
       end
     else
       @mandatory_count -= 1
-      @current_action = @current_action.merge(
-        "builds" => (@current_action["builds"] || []) + [ [ coord.row, coord.col ] ]
-      )
+      @current_action = TurnPhase.deserialize(@current_action).transition(
+        TurnPhase::Events::BuildChosen.new(coordinate: [ coord.row, coord.col ]),
+        TurnPhase::Facts::BuildChoice.new(
+          locked_terrain: build_terrain
+        )
+      ).next_phase.serialize
     end
   end
 
@@ -192,7 +251,17 @@ class MoveApplicator::HashState
 
   def apply_activate_outpost(player_order:)
     mark_tile_used(@players[player_order], "OutpostTile")
-    @current_action = @current_action.merge("outpost_active" => true)
+    current_phase = TurnPhase.deserialize(@current_action)
+    @current_action =
+      if current_phase.is_a?(TurnPhase::MandatoryBuildPhase)
+        TurnPhase::MandatoryBuildPhase.new(
+          chosen_terrain: current_phase.chosen_terrain,
+          builds: current_phase.builds,
+          outpost_active: true
+        ).serialize
+      else
+        TurnPhase::LegacyPhase.new(@current_action.merge("outpost_active" => true)).serialize
+      end
   end
 
   def apply_activate_fort(player_order:)
@@ -202,15 +271,22 @@ class MoveApplicator::HashState
   def apply_draw_fort_card(player_order:, drawn_card:, deck_after:, discard_after:)
     @deck = deck_after.dup
     @discard = discard_after.dup
-    @current_action = { "type" => "fort", "klass" => "FortTile", "fort_terrain" => drawn_card }
+    @current_action = TurnPhase::FortPhase.new(fort_terrain: drawn_card).serialize
   end
 
-  def apply_move_settlement(player_order:, from:, to:, tile_klass:, action_before: nil, chosen_terrain_before: :not_provided)
+  def apply_move_settlement(player_order:, from:, to:, tile_klass:, action_before: nil, phase_after: nil, chosen_terrain_before: :not_provided)
     from_coord = Coordinate.from_key(from)
     to_coord = Coordinate.from_key(to)
     @board.move_settlement(from_coord.row, from_coord.col, to_coord.row, to_coord.col)
-    @current_action = { "type" => "mandatory" }
-    mark_tile_used(@players[player_order], tile_klass)
+    if phase_after
+      @current_action = phase_after.deep_dup
+    else
+      @current_action = TurnPhase.deserialize(@current_action).transition(
+        TurnPhase::Events::DestinationChosen.new,
+        TurnPhase::Facts::DestinationChoice.new(next_phase: TurnPhase::MandatoryBuildPhase.new)
+      ).next_phase.serialize
+    end
+    mark_tile_used(@players[player_order], tile_klass) if TurnPhase.deserialize(@current_action).is_a?(TurnPhase::MandatoryBuildPhase)
   end
 
   private
@@ -231,10 +307,13 @@ class MoveApplicator::HashState
     player["tiles"] = updated
   end
 
+  public
+
   def apply_place_warrior(player_order:, to:, action_before: nil)
     coord = Coordinate.from_key(to)
     @board.place_warrior(coord.row, coord.col, player_order)
     @players[player_order]["supply"]["warriors"] = (@players[player_order]["supply"]["warriors"] || 0) - 1
+    mark_tile_used(@players[player_order], "BarracksTile")
     @current_action = { "type" => "mandatory" }
   end
 
@@ -242,6 +321,7 @@ class MoveApplicator::HashState
     coord = Coordinate.from_key(from)
     @board.remove(coord.row, coord.col)
     @players[player_order]["supply"]["warriors"] = (@players[player_order]["supply"]["warriors"] || 0) + 1
+    mark_tile_used(@players[player_order], "BarracksTile")
     @current_action = { "type" => "mandatory" }
   end
 
@@ -249,6 +329,7 @@ class MoveApplicator::HashState
     coord = Coordinate.from_key(to)
     @board.place_ship(coord.row, coord.col, player_order)
     @players[player_order]["supply"]["ships"] = (@players[player_order]["supply"]["ships"] || 0) - 1
+    mark_tile_used(@players[player_order], "LighthouseTile")
     @current_action = { "type" => "mandatory" }
   end
 
@@ -256,25 +337,35 @@ class MoveApplicator::HashState
     coord = Coordinate.from_key(from)
     @board.remove(coord.row, coord.col)
     @players[player_order]["supply"]["ships"] = (@players[player_order]["supply"]["ships"] || 0) + 1
-    @current_action = { "type" => "mandatory" }
-  end
-
-  def apply_move_ship(player_order:, from:, to:, action_before: nil)
-    from_coord = Coordinate.from_key(from)
-    to_coord = Coordinate.from_key(to)
-    @board.move_settlement(from_coord.row, from_coord.col, to_coord.row, to_coord.col)
     mark_tile_used(@players[player_order], "LighthouseTile")
     @current_action = { "type" => "mandatory" }
   end
 
+  def apply_move_ship(player_order:, from:, to:, action_before: nil, phase_after: nil)
+    from_coord = Coordinate.from_key(from)
+    to_coord = Coordinate.from_key(to)
+    @board.move_settlement(from_coord.row, from_coord.col, to_coord.row, to_coord.col)
+    mark_tile_used(@players[player_order], "LighthouseTile")
+    @current_action = phase_after ? phase_after.deep_dup : { "type" => "mandatory" }
+  end
+
   def apply_select_ship(player_order:, from:)
-    @current_action = @current_action.merge("from" => from)
+    current_phase = TurnPhase.deserialize(@current_action)
+    if current_phase.is_a?(TurnPhase::MeepleMovementPhase)
+      @current_action = current_phase.transition(
+        TurnPhase::Events::SourceSelected.new(coordinate_key: from),
+        nil
+      ).next_phase.serialize
+    else
+      @current_action = TurnPhase::LegacyPhase.new(@current_action.merge("from" => from)).serialize
+    end
   end
 
   def apply_place_wagon(player_order:, to:, action_before: nil)
     coord = Coordinate.from_key(to)
     @board.place_wagon(coord.row, coord.col, player_order)
     @players[player_order]["supply"]["wagons"] = (@players[player_order]["supply"]["wagons"] || 0) - 1
+    mark_tile_used(@players[player_order], "WagonTile")
     @current_action = { "type" => "mandatory" }
   end
 
@@ -282,19 +373,28 @@ class MoveApplicator::HashState
     coord = Coordinate.from_key(from)
     @board.remove(coord.row, coord.col)
     @players[player_order]["supply"]["wagons"] = (@players[player_order]["supply"]["wagons"] || 0) + 1
-    @current_action = { "type" => "mandatory" }
-  end
-
-  def apply_move_wagon(player_order:, from:, to:, action_before: nil)
-    from_coord = Coordinate.from_key(from)
-    to_coord = Coordinate.from_key(to)
-    @board.move_settlement(from_coord.row, from_coord.col, to_coord.row, to_coord.col)
     mark_tile_used(@players[player_order], "WagonTile")
     @current_action = { "type" => "mandatory" }
   end
 
+  def apply_move_wagon(player_order:, from:, to:, action_before: nil, phase_after: nil)
+    from_coord = Coordinate.from_key(from)
+    to_coord = Coordinate.from_key(to)
+    @board.move_settlement(from_coord.row, from_coord.col, to_coord.row, to_coord.col)
+    mark_tile_used(@players[player_order], "WagonTile")
+    @current_action = phase_after ? phase_after.deep_dup : { "type" => "mandatory" }
+  end
+
   def apply_select_wagon(player_order:, from:)
-    @current_action = @current_action.merge("from" => from)
+    current_phase = TurnPhase.deserialize(@current_action)
+    if current_phase.is_a?(TurnPhase::MeepleMovementPhase)
+      @current_action = current_phase.transition(
+        TurnPhase::Events::SourceSelected.new(coordinate_key: from),
+        nil
+      ).next_phase.serialize
+    else
+      @current_action = TurnPhase::LegacyPhase.new(@current_action.merge("from" => from)).serialize
+    end
   end
 
   def apply_place_city_hall(player_order:, to:, action_before: nil)
@@ -330,7 +430,7 @@ class MoveApplicator::LiveState
     @game = game
   end
 
-  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil, fort_terrain: nil, chosen_terrain_before: :not_provided)
+  def apply_build(player_order:, to:, tile_klass:, remaining_before: nil, fort_terrain: nil, build_terrain: nil, chosen_terrain_before: :not_provided)
     coord = Coordinate.from_key(to)
     @game.board_contents_will_change!
     @game.board_contents.remove(coord.row, coord.col)
@@ -342,15 +442,22 @@ class MoveApplicator::LiveState
       @game.current_action = { "type" => "fort", "klass" => "FortTile", "fort_terrain" => fort_terrain }
     elsif tile_klass
       gp.mark_tile_unused!(tile_klass)
-      action = { "type" => tile_klass.delete_suffix("Tile").downcase }
-      action["klass"] = tile_klass if remaining_before
-      action["remaining"] = remaining_before if remaining_before
-      @game.current_action = action
+      current_phase = @game.turn_phase
+      tile_action_type = tile_klass.delete_suffix("Tile").downcase
+      @game.turn_phase = TurnPhase::TileBuildPhase.new(
+        action_type: tile_action_type,
+        klass_name: tile_klass,
+        chosen_terrain: current_phase.respond_to?(:chosen_terrain) ? current_phase.chosen_terrain : nil,
+        remaining: remaining_before,
+        walls_placed: current_phase.respond_to?(:walls_placed) ? current_phase.walls_placed : nil
+      )
     else
       @game.mandatory_count += 1
-      builds = (@game.current_action["builds"] || [])[0..-2]
-      @game.current_action_will_change!
-      @game.current_action["builds"] = builds
+      current_phase = @game.turn_phase
+      @game.turn_phase = TurnPhase::MandatoryBuildPhase.new(
+        chosen_terrain: (chosen_terrain_before == :not_provided ? nil : chosen_terrain_before),
+        builds: current_phase.is_a?(TurnPhase::MandatoryBuildPhase) ? current_phase.builds[0..-2] : []
+      )
     end
     restore_chosen_terrain(chosen_terrain_before)
     gp.save
@@ -383,7 +490,7 @@ class MoveApplicator::LiveState
     gp.save
   end
 
-  def apply_select_action(player_order:, type:, klass: nil)
+  def apply_select_action(player_order:, type:, klass: nil, pending_orders: nil)
     @game.current_action = { "type" => "mandatory" }
     if klass
       gp = player_for(player_order)
@@ -393,14 +500,37 @@ class MoveApplicator::LiveState
   end
 
   def apply_select_settlement(player_order:, from:)
-    @game.current_action_will_change!
-    @game.current_action.delete("from")
+    current_phase = @game.turn_phase
+    if current_phase.is_a?(TurnPhase::SettlementMovePhase)
+      @game.turn_phase = TurnPhase::SettlementMovePhase.new(
+        action_type: current_phase.type,
+        klass_name: current_phase.klass_name
+      )
+    elsif current_phase.is_a?(TurnPhase::ResettlementPhase)
+      @game.turn_phase = TurnPhase::ResettlementPhase.new(
+        budget: current_phase.budget,
+        vacated: current_phase.vacated,
+        moves: current_phase.moves
+      )
+    else
+      current_action = @game.current_action.dup
+      current_action.delete("from")
+      @game.turn_phase = TurnPhase::LegacyPhase.new(current_action)
+    end
   end
 
-  def apply_move_settlement(player_order:, from:, to:, tile_klass:, action_before: nil, chosen_terrain_before: :not_provided)
+  def apply_move_settlement(player_order:, from:, to:, tile_klass:, action_before: nil, phase_after: nil, chosen_terrain_before: :not_provided)
     @game.board_contents_will_change!
     @game.board_contents.move_settlement(*Coordinate.from_key(to), *Coordinate.from_key(from))
-    @game.current_action = action_before || { "type" => tile_klass.delete_suffix("Tile").downcase, "from" => from }
+    @game.turn_phase = if action_before
+      TurnPhase.deserialize(action_before)
+    else
+      TurnPhase::SettlementMovePhase.new(
+        action_type: tile_klass.delete_suffix("Tile").downcase,
+        klass_name: tile_klass,
+        from: from
+      )
+    end
     restore_chosen_terrain(chosen_terrain_before)
     gp = player_for(player_order)
     gp.mark_tile_unused!(tile_klass)
@@ -423,7 +553,7 @@ class MoveApplicator::LiveState
     owner.remove_piece_from_supply!(meeple)
     owner.save
     if action_before
-      @game.current_action = action_before
+      @game.turn_phase = TurnPhase.deserialize(action_before)
     end
     if tile_used
       gp = player_for(player_order)
@@ -444,8 +574,18 @@ class MoveApplicator::LiveState
   def apply_activate_outpost(player_order:)
     gp = player_for(player_order)
     gp.mark_tile_unused!("OutpostTile")
-    @game.current_action_will_change!
-    @game.current_action.delete("outpost_active")
+    current_phase = @game.turn_phase
+    if current_phase.is_a?(TurnPhase::MandatoryBuildPhase)
+      @game.turn_phase = TurnPhase::MandatoryBuildPhase.new(
+        chosen_terrain: current_phase.chosen_terrain,
+        builds: current_phase.builds,
+        outpost_active: false
+      )
+    else
+      current_action = @game.current_action.dup
+      current_action.delete("outpost_active")
+      @game.turn_phase = TurnPhase::LegacyPhase.new(current_action)
+    end
     gp.save
   end
 
@@ -465,7 +605,7 @@ class MoveApplicator::LiveState
     gp.mark_tile_unused!("BarracksTile")
     gp.increment_warrior_supply!
     gp.save
-    @game.current_action = action_before if action_before
+    @game.turn_phase = TurnPhase.deserialize(action_before) if action_before
   end
 
   def apply_remove_warrior(player_order:, from:, action_before: nil)
@@ -476,7 +616,7 @@ class MoveApplicator::LiveState
     gp.mark_tile_unused!("BarracksTile")
     gp.decrement_warrior_supply!
     gp.save
-    @game.current_action = action_before if action_before
+    @game.turn_phase = TurnPhase.deserialize(action_before) if action_before
   end
 
   def apply_place_ship(player_order:, to:, action_before: nil)
@@ -487,7 +627,7 @@ class MoveApplicator::LiveState
     gp.mark_tile_unused!("LighthouseTile")
     gp.increment_ship_supply!
     gp.save
-    @game.current_action = action_before if action_before
+    @game.turn_phase = TurnPhase.deserialize(action_before) if action_before
   end
 
   def apply_remove_ship(player_order:, from:, action_before: nil)
@@ -498,10 +638,10 @@ class MoveApplicator::LiveState
     gp.mark_tile_unused!("LighthouseTile")
     gp.decrement_ship_supply!
     gp.save
-    @game.current_action = action_before if action_before
+    @game.turn_phase = TurnPhase.deserialize(action_before) if action_before
   end
 
-  def apply_move_ship(player_order:, from:, to:, action_before: nil)
+  def apply_move_ship(player_order:, from:, to:, action_before: nil, phase_after: nil)
     to_coord = Coordinate.from_key(to)
     from_coord = Coordinate.from_key(from)
     @game.board_contents_will_change!
@@ -509,12 +649,21 @@ class MoveApplicator::LiveState
     gp = player_for(player_order)
     gp.mark_tile_unused!("LighthouseTile")
     gp.save
-    @game.current_action = action_before if action_before
+    @game.turn_phase = TurnPhase.deserialize(action_before) if action_before
   end
 
   def apply_select_ship(player_order:, from:)
-    @game.current_action_will_change!
-    @game.current_action.delete("from")
+    current_phase = @game.turn_phase
+    if current_phase.is_a?(TurnPhase::MeepleMovementPhase)
+      @game.turn_phase = TurnPhase::MeepleMovementPhase.new(
+        action_type: current_phase.type,
+        klass_name: current_phase.klass_name
+      )
+    else
+      current_action = @game.current_action.dup
+      current_action.delete("from")
+      @game.turn_phase = TurnPhase::LegacyPhase.new(current_action)
+    end
   end
 
   def apply_place_wagon(player_order:, to:, action_before: nil)
@@ -525,7 +674,7 @@ class MoveApplicator::LiveState
     gp.mark_tile_unused!("WagonTile")
     gp.increment_wagon_supply!
     gp.save
-    @game.current_action = action_before if action_before
+    @game.turn_phase = TurnPhase.deserialize(action_before) if action_before
   end
 
   def apply_remove_wagon(player_order:, from:, action_before: nil)
@@ -536,10 +685,10 @@ class MoveApplicator::LiveState
     gp.mark_tile_unused!("WagonTile")
     gp.decrement_wagon_supply!
     gp.save
-    @game.current_action = action_before if action_before
+    @game.turn_phase = TurnPhase.deserialize(action_before) if action_before
   end
 
-  def apply_move_wagon(player_order:, from:, to:, action_before: nil)
+  def apply_move_wagon(player_order:, from:, to:, action_before: nil, phase_after: nil)
     to_coord = Coordinate.from_key(to)
     from_coord = Coordinate.from_key(from)
     @game.board_contents_will_change!
@@ -547,12 +696,21 @@ class MoveApplicator::LiveState
     gp = player_for(player_order)
     gp.mark_tile_unused!("WagonTile")
     gp.save
-    @game.current_action = action_before if action_before
+    @game.turn_phase = TurnPhase.deserialize(action_before) if action_before
   end
 
   def apply_select_wagon(player_order:, from:)
-    @game.current_action_will_change!
-    @game.current_action.delete("from")
+    current_phase = @game.turn_phase
+    if current_phase.is_a?(TurnPhase::MeepleMovementPhase)
+      @game.turn_phase = TurnPhase::MeepleMovementPhase.new(
+        action_type: current_phase.type,
+        klass_name: current_phase.klass_name
+      )
+    else
+      current_action = @game.current_action.dup
+      current_action.delete("from")
+      @game.turn_phase = TurnPhase::LegacyPhase.new(current_action)
+    end
   end
 
   def apply_place_city_hall(player_order:, to:, action_before: nil)
@@ -563,7 +721,7 @@ class MoveApplicator::LiveState
     gp = player_for(player_order)
     gp.increment_city_hall_supply!
     gp.mark_tile_unpermanent!("CityHallTile")
-    @game.current_action = action_before if action_before
+    @game.turn_phase = TurnPhase.deserialize(action_before) if action_before
     gp.save
   end
 
@@ -575,11 +733,21 @@ class MoveApplicator::LiveState
 
   def restore_chosen_terrain(chosen_terrain_before)
     return if chosen_terrain_before == :not_provided
-    @game.current_action_will_change!
-    if chosen_terrain_before.nil?
-      @game.current_action.delete("chosen_terrain")
+    current_phase = @game.turn_phase
+    if current_phase.is_a?(TurnPhase::MandatoryBuildPhase)
+      @game.turn_phase = TurnPhase::MandatoryBuildPhase.new(
+        chosen_terrain: chosen_terrain_before,
+        builds: current_phase.builds,
+        outpost_active: current_phase.outpost_active?
+      )
     else
-      @game.current_action["chosen_terrain"] = chosen_terrain_before
+      current_action = @game.current_action.dup
+      if chosen_terrain_before.nil?
+        current_action.delete("chosen_terrain")
+      else
+        current_action["chosen_terrain"] = chosen_terrain_before
+      end
+      @game.turn_phase = TurnPhase::LegacyPhase.new(current_action)
     end
   end
 end

--- a/app/services/move_applicator.rb
+++ b/app/services/move_applicator.rb
@@ -241,6 +241,12 @@ class MoveApplicator::HashState
     @board.remove(coord.row, coord.col)
     key = meeple ? meeple.pluralize : "settlements"
     @players[owner_order]["supply"][key] += 1
+    current_phase = action_before ? TurnPhase.deserialize(action_before) : TurnPhase.deserialize(@current_action)
+    if tile_used
+      @current_action = TurnPhase::MandatoryBuildPhase.new.serialize
+    elsif current_phase.respond_to?(:consume_target)
+      @current_action = current_phase.consume_target(owner_order).next_phase.serialize
+    end
   end
 
   def apply_place_wall(player_order:, to:, chosen_terrain_before: :not_provided)
@@ -740,14 +746,55 @@ class MoveApplicator::LiveState
         builds: current_phase.builds,
         outpost_active: current_phase.outpost_active?
       )
-    else
-      current_action = @game.current_action.dup
-      if chosen_terrain_before.nil?
-        current_action.delete("chosen_terrain")
-      else
-        current_action["chosen_terrain"] = chosen_terrain_before
-      end
-      @game.turn_phase = TurnPhase::LegacyPhase.new(current_action)
+    elsif current_phase.respond_to?(:chosen_terrain)
+      phase_class =
+        if current_phase.is_a?(TurnPhase::TileBuildPhase)
+          TurnPhase::TileBuildPhase
+        elsif current_phase.is_a?(TurnPhase::SettlementMovePhase)
+          TurnPhase::SettlementMovePhase
+        elsif current_phase.is_a?(TurnPhase::ResettlementPhase)
+          TurnPhase::ResettlementPhase
+        elsif current_phase.is_a?(TurnPhase::LegacyPhase)
+          TurnPhase::LegacyPhase
+        else
+          current_phase.class
+        end
+
+      @game.turn_phase =
+        case phase_class.name
+        when "TurnPhase::TileBuildPhase"
+          TurnPhase::TileBuildPhase.new(
+            action_type: current_phase.type,
+            klass_name: current_phase.klass_name,
+            chosen_terrain: chosen_terrain_before,
+            remaining: current_phase.respond_to?(:remaining) ? current_phase.remaining : nil,
+            walls_placed: current_phase.respond_to?(:walls_placed) ? current_phase.walls_placed : nil
+          )
+        when "TurnPhase::SettlementMovePhase"
+          TurnPhase::SettlementMovePhase.new(
+            action_type: current_phase.type,
+            klass_name: current_phase.klass_name,
+            from: current_phase.from
+          )
+        when "TurnPhase::ResettlementPhase"
+          TurnPhase::ResettlementPhase.new(
+            budget: current_phase.budget,
+            vacated: current_phase.vacated,
+            moves: current_phase.moves,
+            from: current_phase.from
+          )
+        when "TurnPhase::LegacyPhase"
+          current_action = current_phase.serialize
+          current_action = current_action.deep_dup
+          if chosen_terrain_before.nil?
+            current_action.delete("chosen_terrain")
+          else
+            current_action["chosen_terrain"] = chosen_terrain_before
+          end
+          TurnPhase::LegacyPhase.new(current_action)
+        else
+          current_phase
+        end
     end
   end
 end

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -43,21 +43,23 @@ class TurnEngine
     game_player = @game.current_player
     Rails.logger.debug(" I have #{game_player.settlements_remaining} settlements remaining")
     return "No settlements left" unless game_player.settlements_remaining?
-    chosen_terrain_before = @game.current_action["chosen_terrain"]
+    current_phase = @game.turn_phase
+    chosen_terrain_before = current_phase.chosen_terrain
     card_terrain = effective_terrain(game_player)
 
-    if @game.current_action["outpost_active"]
+    if current_phase.is_a?(TurnPhase::MandatoryBuildPhase) && current_phase.outpost_active?
       card_terrain ||= game_player.hand.find { |t| @game.board.terrain_at(row, col) == t }
       # Skip adjacency: just check it's empty and correct terrain
       return "Not available" unless @game.board_contents.available_for_building?(row, col) && @game.board.terrain_at(row, col) == card_terrain
       lock_terrain!(card_terrain, chosen_terrain_before) unless chosen_terrain_before
       build_on_terrain(card_terrain, row, col, game_player, chosen_terrain_before: chosen_terrain_before)
       @game.mandatory_count -= 1
-      @game.current_action_will_change!
-      @game.current_action.delete("outpost_active")
-      @game.current_action_will_change!
-      builds = (@game.current_action["builds"] || []) + [ [ row, col ] ]
-      @game.current_action["builds"] = builds
+      phase_result = current_phase.transition(
+        TurnPhase::Events::BuildChosen.new(coordinate: [ row, col ]),
+        TurnPhase::Facts::BuildChoice.new(locked_terrain: card_terrain)
+      )
+      @game.turn_phase = phase_result.next_phase
+      builds = @game.turn_phase.builds || []
       check_families_goal(game_player) if builds.size == 3
     else
       if card_terrain.nil?
@@ -72,9 +74,12 @@ class TurnEngine
       end
       build_on_terrain(card_terrain, row, col, game_player, chosen_terrain_before: chosen_terrain_before)
       @game.mandatory_count -= 1
-      @game.current_action_will_change!
-      builds = (@game.current_action["builds"] || []) + [ [ row, col ] ]
-      @game.current_action["builds"] = builds
+      phase_result = current_phase.transition(
+        TurnPhase::Events::BuildChosen.new(coordinate: [ row, col ]),
+        TurnPhase::Facts::BuildChoice.new(locked_terrain: card_terrain)
+      )
+      @game.turn_phase = phase_result.next_phase
+      builds = @game.turn_phase.builds || []
       check_families_goal(game_player) if builds.size == 3
     end
 
@@ -98,8 +103,12 @@ class TurnEngine
       message: "#{game_player.player.handle} activated the Outpost tile"
     )
     game_player.mark_tile_used!("OutpostTile")
-    @game.current_action_will_change!
-    @game.current_action["outpost_active"] = true
+    current_phase = @game.turn_phase
+    @game.turn_phase = TurnPhase::MandatoryBuildPhase.new(
+      chosen_terrain: current_phase.chosen_terrain,
+      builds: current_phase.is_a?(TurnPhase::MandatoryBuildPhase) ? current_phase.builds : [],
+      outpost_active: true
+    )
     game_player.save
     @game.save
   end
@@ -107,7 +116,7 @@ class TurnEngine
   def activate_fort_tile
     @game.instantiate
     game_player = @game.current_player
-    return "Not available" unless @game.current_action["type"] == "mandatory"
+    return "Not available" unless @game.turn_phase.is_a?(TurnPhase::MandatoryBuildPhase)
     return "Not available" unless game_player.find_unused_tile("FortTile")
     return "No settlements left" unless game_player.settlements_remaining?
 
@@ -138,7 +147,7 @@ class TurnEngine
       message: "#{game_player.player.handle} drew a #{Boards::Board::TERRAIN_NAMES[drawn_card]} card"
     )
 
-    @game.current_action = { "type" => "fort", "klass" => "FortTile", "fort_terrain" => drawn_card }
+    @game.turn_phase = TurnPhase::FortPhase.new(fort_terrain: drawn_card)
     @game.save
   end
 
@@ -147,15 +156,17 @@ class TurnEngine
     game_player = @game.current_player
 
     return "Not a valid target" if @game.board_contents.city_hall_at?(row, col)
-    pending_orders = @game.current_action["pending_orders"] || []
+    current_phase = @game.turn_phase
+    pending_orders = current_phase.respond_to?(:pending_orders) ? current_phase.pending_orders : []
     owner_order = @game.board_contents.player_at(row, col)
     return "Not a valid target" unless owner_order && pending_orders.include?(owner_order)
 
     owner = @game.game_players.find { |gp| gp.order == owner_order }
 
-    action_before = @game.current_action.deep_dup
+    action_before = @game.turn_phase.serialize
+    phase_result = current_phase.is_a?(TurnPhase::TargetedRemovalPhase) ? current_phase.consume_target(owner_order) : nil
     remaining_orders = pending_orders - [ owner_order ]
-    tile_used = remaining_orders.empty?
+    tile_used = phase_result ? phase_result.action_completed : remaining_orders.empty?
     meeple = @game.board_contents.meeple_at(row, col)
 
     @game.move_count += 1
@@ -179,10 +190,17 @@ class TurnEngine
     if tile_used
       klass_name = current_action_tile_klass
       game_player.mark_tile_used!(klass_name.demodulize)
-      reset_to_mandatory
+      @game.turn_phase = TurnPhase::MandatoryBuildPhase.new
     else
-      @game.current_action_will_change!
-      @game.current_action["pending_orders"] = remaining_orders
+      if phase_result
+        @game.turn_phase = phase_result.next_phase
+      else
+        @game.turn_phase = TurnPhase::TargetedRemovalPhase.new(
+          action_type: current_phase.type,
+          klass_name: current_phase.klass_name,
+          pending_orders: remaining_orders
+        )
+      end
     end
 
     owner.save
@@ -199,9 +217,11 @@ class TurnEngine
 
     tile_obj = Tiles::Tile.from_hash(tile)
 
-    if @game.current_action["from"]
+    current_phase = @game.turn_phase
+
+    if current_phase.from
       # complete a ship or wagon move to destination
-      from_coord = Coordinate.from_key(@game.current_action["from"])
+      from_coord = Coordinate.from_key(current_phase.from)
       destinations = tile_obj.valid_destinations(
         from_row: from_coord.row, from_col: from_coord.col,
         board_contents: @game.board_contents, board: @game.board,
@@ -209,8 +229,8 @@ class TurnEngine
       )
       return "Not available" unless destinations.include?([ row, col ])
       case tile_obj.meeple_kind
-      when "ship"  then move_ship(row, col, game_player, tile_klass:)
-      when "wagon" then move_wagon(row, col, game_player, tile_klass:)
+      when "ship"  then move_ship(row, col, game_player, tile_klass:, phase_after: TurnPhase::MandatoryBuildPhase.new.serialize)
+      when "wagon" then move_wagon(row, col, game_player, tile_klass:, phase_after: TurnPhase::MandatoryBuildPhase.new.serialize)
       end
     elsif @game.board_contents.wagon_at?(row, col) &&
           @game.board_contents.player_at(row, col) == game_player.order
@@ -300,7 +320,18 @@ class TurnEngine
       reversible: true,
       message: "#{game_player.player.handle} selected their #{action_word} at [#{row}, #{col}]"
     )
-    @game.current_action = @game.current_action.merge("from" => "[#{row}, #{col}]")
+    current_phase = @game.turn_phase
+    if current_phase.is_a?(TurnPhase::MeepleMovementPhase)
+      phase_result = current_phase.transition(
+        TurnPhase::Events::SourceSelected.new(coordinate_key: "[#{row}, #{col}]"),
+        nil
+      )
+      @game.turn_phase = phase_result.next_phase
+    else
+      @game.turn_phase = TurnPhase::LegacyPhase.new(
+        @game.current_action.merge("from" => "[#{row}, #{col}]")
+      )
+    end
     @game.save
   end
 
@@ -348,14 +379,17 @@ class TurnEngine
     tile = game_player.find_unused_tile(tile_klass)
     return "Not available" unless tile
     tile_obj = Tiles::Tile.from_hash(tile)
-    chosen_terrain_before = @game.current_action["chosen_terrain"]
-    if @game.current_action["outpost_active"]
+    current_phase = @game.turn_phase
+    chosen_terrain_before = current_phase.chosen_terrain
+    if current_phase.is_a?(TurnPhase::MandatoryBuildPhase) && current_phase.outpost_active?
       return "Not available" unless @game.board_contents.empty?(row, col)
-      @game.current_action_will_change!
-      @game.current_action.delete("outpost_active")
+      @game.turn_phase = TurnPhase::MandatoryBuildPhase.new(
+        chosen_terrain: current_phase.chosen_terrain,
+        builds: current_phase.builds
+      )
     else
       if tile_obj.fort_tile?
-        hand = @game.current_action["fort_terrain"]
+        hand = current_phase.respond_to?(:fort_terrain) ? current_phase.fort_terrain : nil
         destinations = tile_obj.valid_destinations(
           board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: hand
         )
@@ -376,12 +410,17 @@ class TurnEngine
     if tile_obj.uses_played_terrain? && chosen_terrain_before.nil? && game_player.hand.size > 1
       lock_terrain!(@game.board.terrain_at(row, col), chosen_terrain_before)
     end
-    remaining_before = @game.current_action["remaining"]
+    remaining_before = current_phase.respond_to?(:remaining) ? current_phase.remaining : nil
     build_on_terrain(@game.board.terrain_at(row, col), row, col, game_player, tile_klass: tile_klass, remaining_before: remaining_before, chosen_terrain_before: chosen_terrain_before)
     if tile_obj.is_a?(Tiles::Nomad::DonationTile)
-      remaining = @game.current_action["remaining"].to_i - 1
+      remaining = current_phase.remaining.to_i - 1
       if remaining > 0
-        @game.current_action = @game.current_action.merge("remaining" => remaining)
+        @game.turn_phase = TurnPhase::TileBuildPhase.new(
+          action_type: current_phase.type,
+          klass_name: current_phase.klass_name,
+          chosen_terrain: current_phase.chosen_terrain,
+          remaining: remaining
+        )
       else
         game_player.mark_tile_used!(tile_klass)
         reset_to_mandatory
@@ -396,7 +435,57 @@ class TurnEngine
 
   def select_action(type)
     klass_name = tile_klass_name_for_type(type)
+    payload = { "klass" => klass_name }
     @game.move_count += 1
+    tile_klass = Tiles::Tile.for_klass(klass_name)
+    tile_obj = tile_klass&.new(0)
+    selected_phase =
+      if tile_obj&.builds_settlement? || tile_obj&.places_wall?
+        TurnPhase::TileBuildPhase.new(
+          action_type: type,
+          klass_name: klass_name,
+          remaining: (3 if tile_obj.is_a?(Tiles::Nomad::DonationTile)),
+          walls_placed: (0 if tile_obj.is_a?(Tiles::QuarryTile))
+        )
+      elsif tile_obj&.moves_settlement? && !tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
+        TurnPhase::SettlementMovePhase.new(
+          action_type: type,
+          klass_name: klass_name
+        )
+      elsif tile_obj&.is_a?(Tiles::Nomad::ResettlementTile)
+        TurnPhase::ResettlementPhase.new(
+          budget: 4,
+          vacated: [],
+          moves: 0
+        )
+      elsif tile_obj&.places_meeple? && %w[ship wagon].include?(tile_obj.meeple_kind)
+        TurnPhase::MeepleMovementPhase.new(
+          action_type: type,
+          klass_name: klass_name
+        )
+      elsif tile_obj&.places_meeple? && tile_obj.meeple_kind == "warrior"
+        TurnPhase::MeepleActionPhase.new(
+          action_type: type,
+          klass_name: klass_name
+        )
+      else
+        action = { "type" => type, "klass" => klass_name }
+        TurnPhase::LegacyPhase.new(action)
+      end
+    if tile_obj&.is_a?(Tiles::Nomad::SwordTile)
+      opponents = @game.game_players
+        .reject { |gp| gp == @game.current_player }
+        .select { |gp| @game.board_contents.settlements_for(gp.order).any? }
+        .map(&:order)
+        .sort
+      return "No opponents with settlements" if opponents.empty?
+      payload["pending_orders"] = opponents
+      selected_phase = TurnPhase::TargetedRemovalPhase.new(
+        action_type: type,
+        klass_name: klass_name,
+        pending_orders: opponents
+      )
+    end
     @game.moves.create(
       order: @game.move_count,
       game_player: @game.current_player,
@@ -404,30 +493,14 @@ class TurnEngine
       action: "select_action",
       to: type,
       reversible: true,
-      payload: { "klass" => klass_name },
+      payload: payload,
       message: "#{@game.current_player.player.handle} selected the #{type} action"
     )
-    action = { "type" => type, "klass" => klass_name }
-    tile_klass = Tiles::Tile.for_klass(klass_name)
-    action["remaining"] = 3 if tile_klass&.new(0)&.is_a?(Tiles::Nomad::DonationTile)
-    if tile_klass&.new(0)&.is_a?(Tiles::QuarryTile)
-      action["walls_placed"] = 0
-    end
-    if tile_klass&.new(0)&.is_a?(Tiles::Nomad::ResettlementTile)
-      action["budget"] = 4
-      action["vacated"] = []
-      action["moves"] = 0
-    end
-    if tile_klass&.new(0)&.is_a?(Tiles::Nomad::SwordTile)
-      opponents = @game.game_players
-        .reject { |gp| gp == @game.current_player }
-        .select { |gp| @game.board_contents.settlements_for(gp.order).any? }
-        .map(&:order)
-        .sort
-      return "No opponents with settlements" if opponents.empty?
-      action["pending_orders"] = opponents
-    end
-    @game.current_action = action
+    phase_result = @game.turn_phase.transition(
+      TurnPhase::Events::TileActionSelected.new,
+      TurnPhase::Facts::TileActionSelection.new(selected_phase: selected_phase)
+    )
+    @game.turn_phase = phase_result.next_phase
     @game.save
   end
 
@@ -442,65 +515,106 @@ class TurnEngine
       reversible: true,
       message: "#{@game.current_player.player.handle} selected a settlement at [#{row}, #{col}]"
     )
-    @game.current_action = @game.current_action.merge("from" => "[#{row}, #{col}]")
+    current_phase = @game.turn_phase
+    if current_phase.is_a?(TurnPhase::SettlementMovePhase) || current_phase.is_a?(TurnPhase::ResettlementPhase)
+      phase_result = current_phase.transition(
+        TurnPhase::Events::SourceSelected.new(coordinate_key: "[#{row}, #{col}]"),
+        nil
+      )
+      @game.turn_phase = phase_result.next_phase
+    else
+      @game.turn_phase = TurnPhase::LegacyPhase.new(
+        @game.current_action.merge("from" => "[#{row}, #{col}]")
+      )
+    end
     @game.save
   end
 
   def move_settlement(row, col)
     @game.instantiate
-    from = @game.current_action["from"]
+    current_phase = @game.turn_phase
+    from = current_phase.from
     from_coord = Coordinate.from_key(from)
     tile_klass_name = current_action_tile_klass
     tile_obj = Tiles::Tile.for_klass(tile_klass_name)&.new(0)
-    chosen_terrain_before = @game.current_action["chosen_terrain"]
+    chosen_terrain_before = current_phase.chosen_terrain
     if tile_obj&.uses_played_terrain? && chosen_terrain_before.nil? && @game.current_player.hand.size > 1
       lock_terrain!(@game.board.terrain_at(row, col), chosen_terrain_before)
     end
-    action_before = @game.current_action.slice("type", "klass", "budget", "vacated", "moves", "from")
-    payload = { "tile_klass" => tile_klass_name, "action_before" => action_before, "chosen_terrain_before" => chosen_terrain_before }
+    action_before = current_phase.serialize
     @game.move_count += 1
-    @game.moves.create(
-      order: @game.move_count,
-      game_player: @game.current_player,
-      deliberate: true,
-      action: "move_settlement",
-      from: from,
-      to: Coordinate.new(row, col).to_key,
-      reversible: true,
-      payload: payload,
-      message: "#{@game.current_player.player.handle} moved a settlement to [#{row}, #{col}]"
-    )
+    payload = { "tile_klass" => tile_klass_name, "action_before" => action_before, "chosen_terrain_before" => chosen_terrain_before }
     if tile_obj&.is_a?(Tiles::Nomad::ResettlementTile)
       step_cost = tile_obj.move_cost(
         from_row: from_coord.row, from_col: from_coord.col,
         to_row: row, to_col: col,
         board_contents: @game.board_contents, board: @game.board,
         player_order: @game.current_player.order,
-        budget: @game.current_action["budget"].to_i,
-        vacated: @game.current_action["vacated"] || []
+        budget: current_phase.budget.to_i,
+        vacated: current_phase.vacated || []
       ) || 1
     end
     @game.board_contents_will_change!
     @game.board_contents.move_settlement(*from_coord, row, col)
 
     if tile_obj&.is_a?(Tiles::Nomad::ResettlementTile)
-      budget = @game.current_action["budget"].to_i - step_cost
-      vacated = (@game.current_action["vacated"] || []) + [ from ]
-      moves = @game.current_action["moves"].to_i + 1
+      budget = current_phase.budget.to_i - step_cost
+      vacated = (current_phase.vacated || []) + [ from ]
+      moves = current_phase.moves.to_i + 1
       # Rule: Resettlement picks up tiles at each step; forfeits location tiles no longer adjacent
       # (Nomad tiles are exempt from location-based forfeit per the nomad_tile? guard in apply_tile_forfeit)
       apply_tile_forfeit(@game.current_player)
       apply_tile_pickup(@game.current_player, row, col)
+      next_phase =
+        if budget <= 0
+          TurnPhase::MandatoryBuildPhase.new
+        else
+          TurnPhase::ResettlementPhase.new(
+            budget: budget,
+            vacated: vacated,
+            moves: moves
+          )
+        end
+      payload["phase_after"] = next_phase.serialize
+      @game.moves.create(
+        order: @game.move_count,
+        game_player: @game.current_player,
+        deliberate: true,
+        action: "move_settlement",
+        from: from,
+        to: Coordinate.new(row, col).to_key,
+        reversible: true,
+        payload: payload,
+        message: "#{@game.current_player.player.handle} moved a settlement to [#{row}, #{col}]"
+      )
       if budget <= 0
         @game.current_player.mark_tile_used!(tile_klass_name.demodulize)
-        reset_to_mandatory
+        @game.turn_phase = next_phase
       else
-        @game.current_action = @game.current_action.except("from").merge(
-          "budget" => budget, "vacated" => vacated, "moves" => moves
+        phase_result = current_phase.transition(
+          TurnPhase::Events::DestinationChosen.new,
+          TurnPhase::Facts::DestinationChoice.new(next_phase: next_phase)
         )
+        @game.turn_phase = phase_result.next_phase
       end
     else
-      reset_to_mandatory
+      payload["phase_after"] = TurnPhase::MandatoryBuildPhase.new.serialize
+      @game.moves.create(
+        order: @game.move_count,
+        game_player: @game.current_player,
+        deliberate: true,
+        action: "move_settlement",
+        from: from,
+        to: Coordinate.new(row, col).to_key,
+        reversible: true,
+        payload: payload,
+        message: "#{@game.current_player.player.handle} moved a settlement to [#{row}, #{col}]"
+      )
+      phase_result = current_phase.transition(
+        TurnPhase::Events::DestinationChosen.new,
+        TurnPhase::Facts::DestinationChoice.new(next_phase: TurnPhase::MandatoryBuildPhase.new)
+      )
+      @game.turn_phase = phase_result.next_phase
       @game.current_player.mark_tile_used!(tile_klass_name)
       apply_tile_forfeit(@game.current_player)
       apply_tile_pickup(@game.current_player, row, col)
@@ -514,8 +628,9 @@ class TurnEngine
     @game.instantiate
     game_player = @game.current_player
     tile_klass_name = current_action_tile_klass
-    moves_made = @game.current_action["moves"].to_i
-    walls_placed = @game.current_action["walls_placed"].to_i
+    current_phase = @game.turn_phase
+    moves_made = current_phase.respond_to?(:moves) ? current_phase.moves.to_i : 0
+    walls_placed = current_phase.respond_to?(:walls_placed) ? current_phase.walls_placed.to_i : 0
     return "Not allowed" unless moves_made >= 1 || walls_placed >= 1
 
     game_player.mark_tile_used!(tile_klass_name.demodulize)
@@ -527,7 +642,8 @@ class TurnEngine
   def place_wall(row, col)
     @game.instantiate
     game_player = @game.current_player
-    chosen_terrain_before = @game.current_action["chosen_terrain"]
+    current_phase = @game.turn_phase
+    chosen_terrain_before = current_phase.chosen_terrain
 
     tile_obj = Tiles::QuarryTile.new(0)
     wall_terrain = effective_terrain(game_player)
@@ -544,10 +660,11 @@ class TurnEngine
     if chosen_terrain_before.nil? && game_player.hand.size > 1
       hex_terrain = @game.board.terrain_at(row, col)
       lock_terrain!(hex_terrain, chosen_terrain_before)
+      current_phase = @game.turn_phase
     end
     wall_terrain = effective_terrain(game_player)
 
-    walls_placed = @game.current_action["walls_placed"].to_i + 1
+    walls_placed = current_phase.respond_to?(:walls_placed) ? current_phase.walls_placed.to_i + 1 : 1
 
     @game.move_count += 1
     payload = { "chosen_terrain_before" => chosen_terrain_before }
@@ -574,8 +691,7 @@ class TurnEngine
       game_player.mark_tile_used!("QuarryTile")
       reset_to_mandatory
     else
-      @game.current_action_will_change!
-      @game.current_action["walls_placed"] = walls_placed
+      @game.turn_phase = current_phase.increment_walls_placed
     end
 
     game_player.save
@@ -585,7 +701,7 @@ class TurnEngine
   def tile_activatable?(tile)
     return false if tile["used"]
     return false unless Tiles::Tile.for_klass(tile["klass"])
-    return false unless @game.current_action["type"] == "mandatory" &&
+    return false unless @game.turn_phase.is_a?(TurnPhase::MandatoryBuildPhase) &&
       (@game.mandatory_count == Game::MANDATORY_COUNT || @game.mandatory_count <= 0 || !@game.current_player.settlements_remaining?)
     @game.instantiate
     tile_obj = Tiles::Tile.from_hash(tile)
@@ -597,21 +713,21 @@ class TurnEngine
 
   def turn_endable?
     @game.playing? &&
-      @game.current_action["type"] == "mandatory" &&
+      @game.turn_phase.is_a?(TurnPhase::MandatoryBuildPhase) &&
       (@game.mandatory_count <= 0 || !@game.current_player.settlements_remaining?)
   end
 
   def outpost_activatable?(tile)
     return false if tile["used"]
     return false unless build_action?
-    return false if @game.current_action["outpost_active"]
+    return false if @game.turn_phase.respond_to?(:outpost_active?) && @game.turn_phase.outpost_active?
     @game.current_player.settlements_remaining?
   end
 
   def tile_action_endable?
     @game.playing? && (
-      (@game.current_action["type"] == "resettlement" && @game.current_action["moves"].to_i >= 1) ||
-      (@game.current_action["type"] == "quarry" && @game.current_action["walls_placed"].to_i >= 1)
+      (@game.turn_phase.is_a?(TurnPhase::ResettlementPhase) && @game.turn_phase.moves.to_i >= 1) ||
+      (@game.turn_phase.is_a?(TurnPhase::TileBuildPhase) && @game.turn_phase.walls_placed.to_i >= 1)
     )
   end
 
@@ -626,17 +742,22 @@ class TurnEngine
   end
 
   def turn_state
-    action_type = @game.current_action["type"]
+    current_phase = @game.turn_phase
+    action_type = current_phase.type
     tile_klass = Tiles::Tile.for_klass(current_action_tile_klass) if action_type != "mandatory"
     if tile_klass
       tile_for_msg = tile_klass.new(0)
-      hand_for_msg = tile_for_msg.fort_tile? ? @game.current_action["fort_terrain"] : @game.current_player.hand.first
+      hand_for_msg = if tile_for_msg.fort_tile? && current_phase.respond_to?(:fort_terrain)
+        current_phase.fort_terrain
+      else
+        @game.current_player.hand.first
+      end
       msg = tile_for_msg.action_message(
         player_handle: @game.current_player.player.handle,
         terrain_names: Boards::Board::TERRAIN_NAMES,
         hand: hand_for_msg
       )
-      remaining = @game.current_action["remaining"]
+      remaining = current_phase.respond_to?(:remaining) ? current_phase.remaining : nil
       remaining ? "#{msg} (#{remaining} remaining)" : msg
     else
       has_activatable = (@game.current_player.tiles || []).any? { |t| tile_activatable?(t) }
@@ -719,11 +840,12 @@ class TurnEngine
     @buildable_cells ||= begin
       @game.instantiate
       player = @game.current_player
-      action = @game.current_action["type"]
+      current_phase = @game.turn_phase
+      action = current_phase.type
 
       if action == "mandatory"
         if player.settlements_remaining? && @game.mandatory_count > 0
-          if @game.current_action["outpost_active"]
+          if current_phase.respond_to?(:outpost_active?) && current_phase.outpost_active?
             terrain = effective_terrain(player)
             (0..19).flat_map do |r|
               (0..19).filter_map { |c| [ r, c ] if @game.board_contents.empty?(r, c) && @game.board.terrain_at(r, c) == terrain }
@@ -739,7 +861,7 @@ class TurnEngine
           []
         end
       elsif action == "sword"
-        pending_orders = @game.current_action["pending_orders"] || []
+        pending_orders = @game.turn_phase.respond_to?(:pending_orders) ? @game.turn_phase.pending_orders : []
         pending_orders.flat_map { |order| @game.board_contents.settlements_for(order) }
       else
         klass = current_action_tile_klass
@@ -747,8 +869,8 @@ class TurnEngine
         if tile
           tile_obj = Tiles::Tile.from_hash(tile)
           if tile_obj.places_meeple?
-            if @game.current_action["from"]
-              from = Coordinate.from_key(@game.current_action["from"])
+            if current_phase.from
+              from = Coordinate.from_key(current_phase.from)
               tile_obj.valid_destinations(
                 from_row: from.row, from_col: from.col,
                 board_contents: @game.board_contents, board: @game.board,
@@ -774,13 +896,13 @@ class TurnEngine
             end
           elsif tile_obj.moves_settlement?
             hand_arg = effective_terrain(player) || player.hand.first
-            if @game.current_action["from"]
-              from = Coordinate.from_key(@game.current_action["from"])
+            if current_phase.from
+              from = Coordinate.from_key(current_phase.from)
               extra_kwargs = {}
               if tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
                 extra_kwargs = {
-                  budget: @game.current_action["budget"].to_i,
-                  vacated: @game.current_action["vacated"] || []
+                  budget: current_phase.respond_to?(:budget) ? current_phase.budget.to_i : 0,
+                  vacated: current_phase.respond_to?(:vacated) ? current_phase.vacated || [] : []
                 }
               end
               if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
@@ -798,8 +920,8 @@ class TurnEngine
               extra_kwargs = {}
               if tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
                 extra_kwargs = {
-                  budget: @game.current_action["budget"].to_i,
-                  vacated: @game.current_action["vacated"] || []
+                  budget: current_phase.respond_to?(:budget) ? current_phase.budget.to_i : 0,
+                  vacated: current_phase.respond_to?(:vacated) ? current_phase.vacated || [] : []
                 }
               end
               if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
@@ -819,7 +941,7 @@ class TurnEngine
             )
           else
             if tile_obj.fort_tile?
-              hand = @game.current_action["fort_terrain"]
+              hand = current_phase.respond_to?(:fort_terrain) ? current_phase.fort_terrain : nil
               tile_obj.valid_destinations(
                 board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: hand
               )
@@ -844,7 +966,7 @@ class TurnEngine
   end
 
   def city_hall_clusters
-    return {} unless @game.current_action["type"] == "cityhall"
+    return {} unless @game.turn_phase.is_a?(TurnPhase::CityHallPhase)
     @game.instantiate
     player = @game.current_player
     tile_obj = Tiles::CityHallTile.new(0)
@@ -876,8 +998,7 @@ class TurnEngine
   private
 
   def build_action?
-    type = @game.current_action["type"]
-    return true if type == "mandatory"
+    return true if @game.turn_phase.is_a?(TurnPhase::MandatoryBuildPhase)
     klass = Tiles::Tile.for_klass(current_action_tile_klass)
     klass&.new(0)&.builds_settlement? || false
   end
@@ -886,7 +1007,8 @@ class TurnEngine
   # Uses "klass" from current_action if present (stored by select_action),
   # otherwise falls back to the capitalize convention for existing tiles.
   def current_action_tile_klass
-    @game.current_action["klass"] || "#{@game.current_action["type"].capitalize}Tile"
+    phase = @game.turn_phase
+    phase.klass_name || "#{phase.type.capitalize}Tile"
   end
 
   # Derives the tile klass name from the action type string.
@@ -1050,7 +1172,7 @@ class TurnEngine
 
   def check_families_goal(game_player)
     return unless Array(@game.goals).include?("families")
-    builds = @game.current_action["builds"] || []
+    builds = @game.turn_phase.builds
     return unless builds.size == 3
     return unless straight_line?(builds)
     score_goal(game_player, "families", 2,
@@ -1105,15 +1227,30 @@ class TurnEngine
   end
 
   def lock_terrain!(terrain, before)
-    return if @game.current_action["chosen_terrain"]
-    @game.current_action_will_change!
-    @game.current_action["chosen_terrain"] = terrain
+    phase = @game.turn_phase
+    return if phase.respond_to?(:chosen_terrain) && phase.chosen_terrain
+    @game.turn_phase =
+      if phase.is_a?(TurnPhase::TileBuildPhase)
+        TurnPhase::TileBuildPhase.new(
+          action_type: phase.type,
+          klass_name: phase.klass_name,
+          chosen_terrain: terrain,
+          remaining: phase.remaining,
+          walls_placed: phase.walls_placed
+        )
+      else
+        TurnPhase::MandatoryBuildPhase.new(
+          chosen_terrain: terrain,
+          builds: phase.is_a?(TurnPhase::MandatoryBuildPhase) ? phase.builds : [],
+          outpost_active: phase.respond_to?(:outpost_active?) && phase.outpost_active?
+        )
+      end
   end
 
   def reset_to_mandatory
-    ct = @game.current_action["chosen_terrain"]
-    @game.current_action = { "type" => "mandatory" }
-    @game.current_action["chosen_terrain"] = ct if ct
+    current_phase = @game.turn_phase
+    ct = current_phase.respond_to?(:chosen_terrain) ? current_phase.chosen_terrain : nil
+    @game.turn_phase = TurnPhase::MandatoryBuildPhase.new(chosen_terrain: ct)
   end
 
   def has_crossroads_tile?(game_player)
@@ -1121,11 +1258,12 @@ class TurnEngine
   end
 
   def effective_terrain(player)
-    @game.current_action["chosen_terrain"] || (player.hand.size == 1 ? player.hand.first : nil)
+    current_phase = @game.turn_phase
+    (current_phase.respond_to?(:chosen_terrain) ? current_phase.chosen_terrain : nil) || (player.hand.size == 1 ? player.hand.first : nil)
   end
 
   def place_warrior(row, col, game_player, tile_klass:)
-    action_before = @game.current_action.slice("type", "klass")
+    action_before = @game.turn_phase.serialize
     @game.move_count += 1
     @game.moves.create(
       order: @game.move_count,
@@ -1144,7 +1282,7 @@ class TurnEngine
   end
 
   def remove_warrior(row, col, game_player, tile_klass:)
-    action_before = @game.current_action.slice("type", "klass")
+    action_before = @game.turn_phase.serialize
     @game.move_count += 1
     @game.moves.create(
       order: @game.move_count,
@@ -1162,7 +1300,7 @@ class TurnEngine
   end
 
   def place_ship(row, col, game_player, tile_klass:)
-    action_before = @game.current_action.slice("type", "klass")
+    action_before = @game.turn_phase.serialize
     @game.move_count += 1
     @game.moves.create(
       order: @game.move_count,
@@ -1180,7 +1318,7 @@ class TurnEngine
   end
 
   def remove_ship(row, col, game_player, tile_klass:)
-    action_before = @game.current_action.slice("type", "klass")
+    action_before = @game.turn_phase.serialize
     @game.move_count += 1
     @game.moves.create(
       order: @game.move_count,
@@ -1197,9 +1335,9 @@ class TurnEngine
     game_player.increment_ship_supply!
   end
 
-  def move_ship(row, col, game_player, tile_klass:)
-    from = @game.current_action["from"]
-    action_before = @game.current_action.slice("type", "klass", "from")
+  def move_ship(row, col, game_player, tile_klass:, phase_after: nil)
+    from = @game.turn_phase.from
+    action_before = @game.turn_phase.serialize
     from_coord = Coordinate.from_key(from)
     @game.move_count += 1
     @game.moves.create(
@@ -1210,7 +1348,7 @@ class TurnEngine
       from: from,
       to: "[#{row}, #{col}]",
       reversible: true,
-      payload: { "klass" => tile_klass, "action_before" => action_before },
+      payload: { "klass" => tile_klass, "action_before" => action_before, "phase_after" => phase_after },
       message: "#{game_player.player.handle} moved their ship to [#{row}, #{col}]"
     )
     @game.board_contents_will_change!
@@ -1218,7 +1356,7 @@ class TurnEngine
   end
 
   def place_wagon(row, col, game_player, tile_klass:)
-    action_before = @game.current_action.slice("type", "klass")
+    action_before = @game.turn_phase.serialize
     @game.move_count += 1
     @game.moves.create(
       order: @game.move_count,
@@ -1236,7 +1374,7 @@ class TurnEngine
   end
 
   def remove_wagon(row, col, game_player, tile_klass:)
-    action_before = @game.current_action.slice("type", "klass")
+    action_before = @game.turn_phase.serialize
     @game.move_count += 1
     @game.moves.create(
       order: @game.move_count,
@@ -1253,9 +1391,9 @@ class TurnEngine
     game_player.increment_wagon_supply!
   end
 
-  def move_wagon(row, col, game_player, tile_klass:)
-    from = @game.current_action["from"]
-    action_before = @game.current_action.slice("type", "klass", "from")
+  def move_wagon(row, col, game_player, tile_klass:, phase_after: nil)
+    from = @game.turn_phase.from
+    action_before = @game.turn_phase.serialize
     from_coord = Coordinate.from_key(from)
     @game.move_count += 1
     @game.moves.create(
@@ -1266,7 +1404,7 @@ class TurnEngine
       from: from,
       to: "[#{row}, #{col}]",
       reversible: true,
-      payload: { "klass" => tile_klass, "action_before" => action_before },
+      payload: { "klass" => tile_klass, "action_before" => action_before, "phase_after" => phase_after },
       message: "#{game_player.player.handle} moved their wagon to [#{row}, #{col}]"
     )
     @game.board_contents_will_change!

--- a/test/models/game_replayer_test.rb
+++ b/test/models/game_replayer_test.rb
@@ -342,6 +342,26 @@ class GameReplayerTest < ActiveSupport::TestCase
     assert_states_equal game.capture_snapshot, game.replayed_state
   end
 
+  test "replayed_state matches current state after remove_settlement with sword" do
+    game = game_with_known_state
+    chris = game_players(:chris)
+    opponent = game_players(:paula)
+    game.board_contents = BoardState.new.tap do |s|
+      s.place_settlement(2, 7, opponent.order)
+    end
+    game.current_action = { "type" => "sword", "klass" => "SwordTile", "pending_orders" => [ opponent.order ] }
+    chris.tiles = [ { "klass" => "SwordTile", "from" => "[0, 0]", "used" => false } ]
+    chris.save!
+    game.reload
+    game.save!
+    game.update!(base_snapshot: game.capture_snapshot)
+
+    engine(game).remove_settlement(2, 7)
+    game.reload
+
+    assert_states_equal game.capture_snapshot, game.replayed_state
+  end
+
   test "replayed_state matches current state after forfeit_tile" do
     game = game_with_known_state
     chris = game_players(:chris)

--- a/test/models/game_replayer_test.rb
+++ b/test/models/game_replayer_test.rb
@@ -169,6 +169,32 @@ class GameReplayerTest < ActiveSupport::TestCase
     assert_states_equal game.capture_snapshot, game.replayed_state
   end
 
+  test "replayed_state matches current state after resettlement move" do
+    game = game_with_known_state
+    chris = game_players(:chris)
+    game.boards = [ [ 6, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    from_hex, dest_hex = reachable_resettlement_hexes(game, "G")
+    game.board_contents = BoardState.new.tap { |s| s.place_settlement(*from_hex, chris.order) }
+    game.current_action = {
+      "type" => "resettlement",
+      "klass" => "ResettlementTile",
+      "budget" => 4,
+      "vacated" => [],
+      "moves" => 0,
+      "from" => "[#{from_hex[0]}, #{from_hex[1]}]"
+    }
+    game.save
+    chris.tiles = [ { "klass" => "ResettlementTile", "from" => "[0, 0]", "used" => false } ]
+    chris.save
+    game.reload
+    game.update(base_snapshot: game.capture_snapshot)
+
+    engine(game).move_settlement(*dest_hex)
+    game.reload
+
+    assert_states_equal game.capture_snapshot, game.replayed_state
+  end
+
   test "replayed_state matches current state after build_on_terrain (oasis action)" do
     game = game_with_known_state
     chris = game_players(:chris)
@@ -181,6 +207,136 @@ class GameReplayerTest < ActiveSupport::TestCase
     game.update(base_snapshot: game.capture_snapshot)
 
     engine(game).activate_tile_build(0, 1)
+    game.reload
+
+    assert_states_equal game.capture_snapshot, game.replayed_state
+  end
+
+  test "replayed_state matches current state after place_warrior" do
+    game = game_with_known_state
+    chris = game_players(:chris)
+    chris.tiles = [ { "klass" => "BarracksTile", "from" => "[2, 7]", "used" => false } ]
+    chris.add_warriors!(2)
+    chris.save!
+    game.reload
+    game.update!(current_action: { "type" => "barracks", "klass" => "BarracksTile" })
+    game.update!(base_snapshot: game.capture_snapshot)
+
+    hex = empty_hexes_of(game, "G", 1).first
+    raise "No grass hex available" unless hex
+
+    engine(game).execute_meeple_action(*hex)
+    game.reload
+
+    assert_states_equal game.capture_snapshot, game.replayed_state
+  end
+
+  test "replayed_state matches current state after remove_warrior" do
+    game = game_with_known_state
+    chris = game_players(:chris)
+    chris.tiles = [ { "klass" => "BarracksTile", "from" => "[2, 7]", "used" => false } ]
+    chris.add_warriors!(2)
+    chris.save!
+    game.reload
+    hex = empty_hexes_of(game, "G", 1).first
+    raise "No grass hex available" unless hex
+    game.board_contents = BoardState.new.tap { |s| s.place_warrior(*hex, chris.order) }
+    game.current_action = { "type" => "barracks", "klass" => "BarracksTile" }
+    game.save!
+    game.update!(base_snapshot: game.capture_snapshot)
+
+    engine(game).remove_meeple_action(*hex)
+    game.reload
+
+    assert_states_equal game.capture_snapshot, game.replayed_state
+  end
+
+  test "replayed_state matches current state after place_ship" do
+    game = game_with_known_state
+    chris = game_players(:chris)
+    chris.tiles = [ { "klass" => "LighthouseTile", "from" => "[2, 7]", "used" => false } ]
+    chris.add_ships!(1)
+    chris.save!
+    game.reload
+    game.update!(current_action: { "type" => "lighthouse", "klass" => "LighthouseTile" })
+    game.update!(base_snapshot: game.capture_snapshot)
+
+    hex = valid_meeple_destination(game, "LighthouseTile", chris).first
+    raise "No ship hex available" unless hex
+
+    engine(game).execute_meeple_action(*hex)
+    game.reload
+
+    assert_states_equal game.capture_snapshot, game.replayed_state
+  end
+
+  test "replayed_state matches current state after remove_ship" do
+    game = game_with_known_state
+    chris = game_players(:chris)
+    chris.tiles = [ { "klass" => "LighthouseTile", "from" => "[2, 7]", "used" => false } ]
+    chris.add_ships!(1)
+    chris.save!
+    game.reload
+    hex = valid_meeple_destination(game, "LighthouseTile", chris).first
+    raise "No ship hex available" unless hex
+    game.board_contents = BoardState.new.tap { |s| s.place_ship(*hex, chris.order) }
+    game.current_action = { "type" => "lighthouse", "klass" => "LighthouseTile" }
+    game.save!
+    game.update!(base_snapshot: game.capture_snapshot)
+
+    engine(game).remove_meeple_action(*hex)
+    game.reload
+
+    assert_states_equal game.capture_snapshot, game.replayed_state
+  end
+
+  test "replayed_state matches current state after place_wagon" do
+    game = game_with_known_state
+    chris = game_players(:chris)
+    chris.tiles = [ { "klass" => "WagonTile", "from" => "[2, 7]", "used" => false } ]
+    chris.add_wagons!(1)
+    chris.save!
+    game.reload
+    game.update!(current_action: { "type" => "wagon", "klass" => "WagonTile" })
+    game.update!(base_snapshot: game.capture_snapshot)
+
+    hex = valid_meeple_destination(game, "WagonTile", chris).first
+    raise "No wagon hex available" unless hex
+
+    engine(game).execute_meeple_action(*hex)
+    game.reload
+
+    assert_states_equal game.capture_snapshot, game.replayed_state
+  end
+
+  test "replayed_state matches current state after remove_wagon" do
+    game = game_with_known_state
+    chris = game_players(:chris)
+    chris.tiles = [ { "klass" => "WagonTile", "from" => "[2, 7]", "used" => false } ]
+    chris.add_wagons!(1)
+    chris.save!
+    game.reload
+    hex = valid_meeple_destination(game, "WagonTile", chris).first
+    raise "No wagon hex available" unless hex
+    game.board_contents = BoardState.new.tap { |s| s.place_wagon(*hex, chris.order) }
+    game.current_action = { "type" => "wagon", "klass" => "WagonTile" }
+    game.save!
+    game.update!(base_snapshot: game.capture_snapshot)
+
+    engine(game).remove_meeple_action(*hex)
+    game.reload
+
+    assert_states_equal game.capture_snapshot, game.replayed_state
+  end
+
+  test "replayed_state matches current state after place_city_hall" do
+    game = game_with_known_state
+    chris = game_players(:chris)
+    center = setup_city_hall_scenario(game, chris)
+    return skip "No valid city hall position found" unless center
+    game.update!(base_snapshot: game.capture_snapshot)
+
+    engine(game).place_city_hall(*center)
     game.reload
 
     assert_states_equal game.capture_snapshot, game.replayed_state
@@ -224,6 +380,108 @@ class GameReplayerTest < ActiveSupport::TestCase
 
   def engine(game)
     TurnEngine.new(game)
+  end
+
+  def empty_hexes_of(game, terrain, n)
+    game.instantiate
+    cells = []
+    20.times do |row|
+      20.times do |col|
+        cells << [row, col] if game.board.terrain_at(row, col) == terrain && game.board_contents.empty?(row, col)
+      end
+    end
+    cells.first(n)
+  end
+
+  def reachable_resettlement_hexes(game, terrain)
+    from_hex = empty_hexes_of(game, terrain, 10).first
+    raise "No source hex found for #{terrain}" unless from_hex
+
+    game.instantiate
+    tile = Tiles::Nomad::ResettlementTile.new(0)
+    dest_hex = empty_hexes_of(game, terrain, 20).find do |candidate|
+      next if candidate == from_hex
+      tile.move_cost(
+        from_row: from_hex[0], from_col: from_hex[1],
+        to_row: candidate[0], to_col: candidate[1],
+        board_contents: game.board_contents, board: game.board,
+        player_order: game_players(:chris).order
+      )
+    end
+    raise "No reachable destination found for #{terrain}" unless dest_hex
+
+    [from_hex, dest_hex]
+  end
+
+  def valid_meeple_destination(game, tile_klass, player)
+    game.instantiate
+    tile = Tiles::Tile.for_klass(tile_klass).new(0)
+    tile.valid_destinations(
+      board_contents: game.board_contents,
+      board: game.board,
+      player_order: player.order,
+      supply: player.supply_hash
+    )
+  end
+
+  def valid_city_hall_center(game, player)
+    game.instantiate
+    tile = Tiles::CityHallTile.new(0)
+    tile.valid_destinations(
+      board_contents: game.board_contents,
+      board: game.board,
+      player_order: player.order,
+      supply: player.supply_hash
+    ).first
+  end
+
+  def setup_city_hall_scenario(game, player)
+    player.add_city_halls!(1)
+    player.tiles = [ { "klass" => "CityHallTile", "from" => "[2, 5]", "used" => false } ]
+    player.save!
+    game.reload
+    game.update!(current_action: { "type" => "cityhall", "klass" => "CityHallTile" })
+
+    board = game.instantiate
+    center = find_valid_city_hall_center(game, board)
+    return nil unless center
+
+    neighbors_of_center = game.board_contents.neighbors(*center)
+    outer_settlement = nil
+    neighbors_of_center.each do |nr, nc|
+      game.board_contents.neighbors(nr, nc).each do |or_, oc|
+        cluster = [ center ] + neighbors_of_center
+        unless cluster.include?([ or_, oc ]) || !game.board_contents.empty?(or_, oc)
+          outer_settlement = [ or_, oc ]
+          break
+        end
+      end
+      break if outer_settlement
+    end
+    return nil unless outer_settlement
+
+    game.board_contents_will_change!
+    game.board_contents.place_settlement(*outer_settlement, player.order)
+    game.save!
+    game.reload
+
+    center
+  end
+
+  def find_valid_city_hall_center(game, board)
+    (1..18).each do |r|
+      (1..18).each do |c|
+        next unless Tiles::Tile::BUILDABLE_TERRAIN.include?(board.terrain_at(r, c))
+        next unless game.board_contents.empty?(r, c)
+        neighbors = game.board_contents.neighbors(r, c)
+        next unless neighbors.size == 6
+        next unless neighbors.all? { |nr, nc|
+          game.board_contents.empty?(nr, nc) && Tiles::Tile::BUILDABLE_TERRAIN.include?(board.terrain_at(nr, nc))
+        }
+        return [ r, c ]
+      end
+    end
+    nil
   end
 
   # Returns a saved game with a known, deterministic initial state and a

--- a/test/models/turn_phase_test.rb
+++ b/test/models/turn_phase_test.rb
@@ -1,0 +1,157 @@
+require "test_helper"
+
+class TurnPhaseTest < ActiveSupport::TestCase
+  test "mandatory build transition records chosen terrain and build coordinates" do
+    phase = TurnPhase.deserialize({ "type" => "mandatory" })
+
+    result = phase.transition(
+      TurnPhase::Events::BuildChosen.new(coordinate: [ 3, 4 ]),
+      TurnPhase::Facts::BuildChoice.new(locked_terrain: "G")
+    )
+
+    assert_instance_of TurnPhase::MandatoryBuildPhase, result.next_phase
+    assert_equal(
+      { "type" => "mandatory", "chosen_terrain" => "G", "builds" => [ [ 3, 4 ] ] },
+      result.next_phase.serialize
+    )
+  end
+
+  test "mandatory tile selection can enter tile build phase" do
+    phase = TurnPhase.deserialize({ "type" => "mandatory" })
+    selected_phase = TurnPhase::TileBuildPhase.new(action_type: "oasis", klass_name: "OasisTile")
+
+    result = phase.transition(
+      TurnPhase::Events::TileActionSelected.new,
+      TurnPhase::Facts::TileActionSelection.new(selected_phase: selected_phase)
+    )
+
+    assert_instance_of TurnPhase::TileBuildPhase, result.next_phase
+    assert_equal(
+      { "type" => "oasis", "klass" => "OasisTile" },
+      result.next_phase.serialize
+    )
+  end
+
+  test "deserializing a build-family current_action returns tile build phase" do
+    phase = TurnPhase.deserialize({ "type" => "donationdesert", "klass" => "DonationDesertTile", "remaining" => 3 })
+
+    assert_instance_of TurnPhase::TileBuildPhase, phase
+    assert_equal "donationdesert", phase.type
+    assert_equal "DonationDesertTile", phase.klass_name
+    assert_equal 3, phase.remaining
+  end
+
+  test "settlement move source selection records from coordinate" do
+    phase = TurnPhase.deserialize({ "type" => "paddock", "klass" => "PaddockTile" })
+
+    result = phase.transition(
+      TurnPhase::Events::SourceSelected.new(coordinate_key: "[5, 5]"),
+      nil
+    )
+
+    assert_instance_of TurnPhase::SettlementMovePhase, result.next_phase
+    assert_equal(
+      { "type" => "paddock", "klass" => "PaddockTile", "from" => "[5, 5]" },
+      result.next_phase.serialize
+    )
+  end
+
+  test "deserializing a settlement move current_action returns settlement move phase" do
+    phase = TurnPhase.deserialize({ "type" => "harbor", "klass" => "HarborTile", "from" => "[5, 5]" })
+
+    assert_instance_of TurnPhase::SettlementMovePhase, phase
+    assert_equal "harbor", phase.type
+    assert_equal "HarborTile", phase.klass_name
+    assert_equal "[5, 5]", phase.from
+  end
+
+  test "deserializing fort current_action returns fort phase" do
+    phase = TurnPhase.deserialize({ "type" => "fort", "klass" => "FortTile", "fort_terrain" => "D" })
+
+    assert_instance_of TurnPhase::FortPhase, phase
+    assert_equal "fort", phase.type
+    assert_equal "FortTile", phase.klass_name
+    assert_equal "D", phase.fort_terrain
+    assert_equal(
+      { "type" => "fort", "klass" => "FortTile", "fort_terrain" => "D" },
+      phase.serialize
+    )
+  end
+
+  test "resettlement source selection records from coordinate" do
+    phase = TurnPhase.deserialize({
+      "type" => "resettlement",
+      "klass" => "ResettlementTile",
+      "budget" => 4,
+      "vacated" => [],
+      "moves" => 0
+    })
+
+    result = phase.transition(
+      TurnPhase::Events::SourceSelected.new(coordinate_key: "[1, 2]"),
+      nil
+    )
+
+    assert_instance_of TurnPhase::ResettlementPhase, result.next_phase
+    assert_equal "[1, 2]", result.next_phase.from
+    assert_equal 4, result.next_phase.budget
+    assert_equal [], result.next_phase.vacated
+    assert_equal 0, result.next_phase.moves
+  end
+
+  test "deserializing resettlement current_action returns resettlement phase" do
+    phase = TurnPhase.deserialize({
+      "type" => "resettlement",
+      "klass" => "ResettlementTile",
+      "budget" => 3,
+      "vacated" => ["[2, 3]"],
+      "moves" => 1,
+      "from" => "[5, 5]"
+    })
+
+    assert_instance_of TurnPhase::ResettlementPhase, phase
+    assert_equal 3, phase.budget
+    assert_equal ["[2, 3]"], phase.vacated
+    assert_equal 1, phase.moves
+    assert_equal "[5, 5]", phase.from
+  end
+
+  test "meeple movement source selection records from coordinate" do
+    phase = TurnPhase.deserialize({ "type" => "lighthouse", "klass" => "LighthouseTile" })
+
+    result = phase.transition(
+      TurnPhase::Events::SourceSelected.new(coordinate_key: "[0, 3]"),
+      nil
+    )
+
+    assert_instance_of TurnPhase::MeepleMovementPhase, result.next_phase
+    assert_equal(
+      { "type" => "lighthouse", "klass" => "LighthouseTile", "from" => "[0, 3]" },
+      result.next_phase.serialize
+    )
+  end
+
+  test "targeted removal phase removes one pending order at a time" do
+    phase = TurnPhase.deserialize({ "type" => "sword", "klass" => "SwordTile", "pending_orders" => [1, 2] })
+
+    result = phase.consume_target(1)
+
+    assert_instance_of TurnPhase::TargetedRemovalPhase, result.next_phase
+    assert_equal({ "type" => "sword", "klass" => "SwordTile", "pending_orders" => [2] }, result.next_phase.serialize)
+    assert_equal false, result.action_completed
+  end
+
+  test "deserializing barracks current_action returns meeple action phase" do
+    phase = TurnPhase.deserialize({ "type" => "barracks", "klass" => "BarracksTile" })
+
+    assert_instance_of TurnPhase::MeepleActionPhase, phase
+    assert_equal({ "type" => "barracks", "klass" => "BarracksTile" }, phase.serialize)
+  end
+
+  test "deserializing city hall current_action returns city hall phase" do
+    phase = TurnPhase.deserialize({ "type" => "cityhall", "klass" => "CityHallTile" })
+
+    assert_instance_of TurnPhase::CityHallPhase, phase
+    assert_equal({ "type" => "cityhall", "klass" => "CityHallTile" }, phase.serialize)
+  end
+end

--- a/test/services/move_applicator_test.rb
+++ b/test/services/move_applicator_test.rb
@@ -236,6 +236,172 @@ class MoveApplicatorTest < ActiveSupport::TestCase
     assert_equal({ "type" => "paddock", "from" => "[5, 5]" }, state.current_action)
   end
 
+  test "dispatch select_ship stores from for lighthouse action" do
+    state = minimal_state("current_action" => { "type" => "lighthouse", "klass" => "LighthouseTile" })
+    move = fake_move(action: "select_ship", from: "[0, 3]")
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "lighthouse", "klass" => "LighthouseTile", "from" => "[0, 3]" }, state.current_action)
+  end
+
+  test "dispatch move_ship can use explicit phase_after payload" do
+    board = BoardState.new
+    board.place_ship(0, 3, 0)
+    state = minimal_state(
+      "board_contents" => BoardState.dump(board),
+      "current_action" => { "type" => "lighthouse", "klass" => "LighthouseTile", "from" => "[0, 3]" },
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40 },
+                       "tiles" => [ { "klass" => "LighthouseTile", "from" => "[2, 0]", "used" => false } ] } ]
+    )
+    move = fake_move(
+      action: "move_ship",
+      from: "[0, 3]",
+      to: "[0, 4]",
+      payload: {
+        "action_before" => { "type" => "lighthouse", "klass" => "LighthouseTile", "from" => "[0, 3]" },
+        "phase_after" => { "type" => "mandatory" }
+      }
+    )
+
+    MoveApplicator.dispatch(state, move)
+
+    assert state.board.empty?(0, 3)
+    assert state.board.ship_at?(0, 4)
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+  end
+
+  test "dispatch place_ship marks LighthouseTile used and resets current_action" do
+    state = minimal_state(
+      "current_action" => { "type" => "lighthouse", "klass" => "LighthouseTile" },
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40, "ships" => 1 },
+                       "tiles" => [ { "klass" => "LighthouseTile", "from" => "[2, 7]", "used" => false } ] } ]
+    )
+    move = fake_move(action: "place_ship", to: "[0, 1]", payload: {
+      "action_before" => { "type" => "lighthouse", "klass" => "LighthouseTile" }
+    })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+    assert_equal 0, state.players[0]["supply"]["ships"]
+    assert state.board.ship_at?(0, 1)
+    assert state.players[0]["tiles"].first["used"]
+  end
+
+  test "dispatch remove_ship marks LighthouseTile used and resets current_action" do
+    board = BoardState.new
+    board.place_ship(0, 1, 0)
+    state = minimal_state(
+      "board_contents" => BoardState.dump(board),
+      "current_action" => { "type" => "lighthouse", "klass" => "LighthouseTile" },
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40, "ships" => 0 },
+                       "tiles" => [ { "klass" => "LighthouseTile", "from" => "[2, 7]", "used" => false } ] } ]
+    )
+    move = fake_move(action: "remove_ship", from: "[0, 1]", payload: {
+      "action_before" => { "type" => "lighthouse", "klass" => "LighthouseTile" }
+    })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+    assert_equal 1, state.players[0]["supply"]["ships"]
+    assert state.board.empty?(0, 1)
+    assert state.players[0]["tiles"].first["used"]
+  end
+
+  test "dispatch place_wagon marks WagonTile used and resets current_action" do
+    state = minimal_state(
+      "current_action" => { "type" => "wagon", "klass" => "WagonTile" },
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40, "wagons" => 1 },
+                       "tiles" => [ { "klass" => "WagonTile", "from" => "[2, 7]", "used" => false } ] } ]
+    )
+    move = fake_move(action: "place_wagon", to: "[0, 1]", payload: {
+      "action_before" => { "type" => "wagon", "klass" => "WagonTile" }
+    })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+    assert_equal 0, state.players[0]["supply"]["wagons"]
+    assert state.board.wagon_at?(0, 1)
+    assert state.players[0]["tiles"].first["used"]
+  end
+
+  test "dispatch remove_wagon marks WagonTile used and resets current_action" do
+    board = BoardState.new
+    board.place_wagon(0, 1, 0)
+    state = minimal_state(
+      "board_contents" => BoardState.dump(board),
+      "current_action" => { "type" => "wagon", "klass" => "WagonTile" },
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40, "wagons" => 0 },
+                       "tiles" => [ { "klass" => "WagonTile", "from" => "[2, 7]", "used" => false } ] } ]
+    )
+    move = fake_move(action: "remove_wagon", from: "[0, 1]", payload: {
+      "action_before" => { "type" => "wagon", "klass" => "WagonTile" }
+    })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+    assert_equal 1, state.players[0]["supply"]["wagons"]
+    assert state.board.empty?(0, 1)
+    assert state.players[0]["tiles"].first["used"]
+  end
+
+  test "dispatch select_action for sword preserves pending orders from payload" do
+    state = minimal_state(
+      "players" => [
+        { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40 }, "tiles" => [] },
+        { "order" => 1, "hand" => "T", "supply" => { "settlements" => 40 }, "tiles" => [] }
+      ]
+    )
+    move = fake_move(action: "select_action", to: "sword", payload: { "klass" => "SwordTile", "pending_orders" => [1] })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "sword", "klass" => "SwordTile", "pending_orders" => [1] }, state.current_action)
+  end
+
+  test "dispatch place_warrior marks BarracksTile used and resets current_action" do
+    state = minimal_state(
+      "current_action" => { "type" => "barracks", "klass" => "BarracksTile" },
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40, "warriors" => 2 },
+                       "tiles" => [ { "klass" => "BarracksTile", "from" => "[2, 7]", "used" => false } ] } ]
+    )
+    move = fake_move(action: "place_warrior", to: "[0, 1]", payload: {
+      "action_before" => { "type" => "barracks", "klass" => "BarracksTile" }
+    })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+    assert_equal 1, state.players[0]["supply"]["warriors"]
+    assert state.board.warrior_at?(0, 1)
+    assert state.players[0]["tiles"].first["used"]
+  end
+
+  test "dispatch remove_warrior marks BarracksTile used and resets current_action" do
+    board = BoardState.new
+    board.place_warrior(0, 1, 0)
+    state = minimal_state(
+      "board_contents" => BoardState.dump(board),
+      "current_action" => { "type" => "barracks", "klass" => "BarracksTile" },
+      "players" => [ { "order" => 0, "hand" => "G", "supply" => { "settlements" => 40, "warriors" => 1 },
+                       "tiles" => [ { "klass" => "BarracksTile", "from" => "[2, 7]", "used" => false } ] } ]
+    )
+    move = fake_move(action: "remove_warrior", from: "[0, 1]", payload: {
+      "action_before" => { "type" => "barracks", "klass" => "BarracksTile" }
+    })
+
+    MoveApplicator.dispatch(state, move)
+
+    assert_equal({ "type" => "mandatory" }, state.current_action)
+    assert_equal 2, state.players[0]["supply"]["warriors"]
+    assert state.board.empty?(0, 1)
+    assert state.players[0]["tiles"].first["used"]
+  end
+
   private
 
   def minimal_state(overrides = {})

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -335,6 +335,55 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_equal 0, @game.moves.count
   end
 
+  test "select_action for paddock preserves klass" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "PaddockTile", "from" => "[5, 5]", "used" => false } ])
+
+    @engine.select_action("paddock")
+    @game.reload
+
+    assert_equal "paddock", @game.current_action["type"]
+    assert_equal "PaddockTile", @game.current_action["klass"]
+  end
+
+  test "select_action for donation tile preserves klass and remaining count" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "DonationDesertTile", "from" => "[5, 5]", "used" => false } ])
+
+    @engine.select_action("donationdesert")
+    @game.reload
+
+    assert_equal "donationdesert", @game.current_action["type"]
+    assert_equal "DonationDesertTile", @game.current_action["klass"]
+    assert_equal 3, @game.current_action["remaining"]
+  end
+
+  test "select_action for quarry preserves klass and walls placed counter" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "QuarryTile", "from" => "[5, 5]", "used" => false } ])
+
+    @engine.select_action("quarry")
+    @game.reload
+
+    assert_equal "quarry", @game.current_action["type"]
+    assert_equal "QuarryTile", @game.current_action["klass"]
+    assert_equal 0, @game.current_action["walls_placed"]
+  end
+
+  test "select_action for resettlement preserves klass and movement state" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "ResettlementTile", "from" => "[5, 5]", "used" => false } ])
+
+    @engine.select_action("resettlement")
+    @game.reload
+
+    assert_equal "resettlement", @game.current_action["type"]
+    assert_equal "ResettlementTile", @game.current_action["klass"]
+    assert_equal 4, @game.current_action["budget"]
+    assert_equal [], @game.current_action["vacated"]
+    assert_equal 0, @game.current_action["moves"]
+  end
+
   test "undo of select_action marks quarry tile as unused" do
     player = @game.current_player
     player.update!(tiles: [ { "klass" => "QuarryTile", "from" => "[5, 5]", "used" => false } ])
@@ -1167,6 +1216,20 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_nil tile["permanent"]
   end
 
+  test "undo of place_city_hall restores current_action to city hall tile state" do
+    center, = setup_city_hall_scenario
+    return skip "No valid city hall position found" unless center
+
+    @engine.place_city_hall(*center)
+    @game.reload
+
+    TurnEngine.new(@game).undo_last_move
+    @game.reload
+
+    assert_equal "cityhall", @game.current_action["type"]
+    assert_equal "CityHallTile", @game.current_action["klass"]
+  end
+
   test "sword tile cannot remove a city hall hex" do
     center, = setup_city_hall_scenario
     return skip "No valid city hall position found" unless center
@@ -1495,6 +1558,168 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert @game.board_contents.warrior_at?(*hex)
   end
 
+  test "select_action for lighthouse preserves klass" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "LighthouseTile", "from" => "[0, 0]", "used" => false } ])
+
+    @engine.select_action("lighthouse")
+    @game.reload
+
+    assert_equal "lighthouse", @game.current_action["type"]
+    assert_equal "LighthouseTile", @game.current_action["klass"]
+  end
+
+  test "select_action for sword preserves pending orders" do
+    opponent = @game.game_players.find { |gp| gp != @game.current_player }
+    @game.current_player.update!(tiles: [ { "klass" => "SwordTile", "from" => "[0, 0]", "used" => false } ])
+    @game.instantiate
+    @game.board_contents.place_settlement(2, 7, opponent.order)
+    @game.save!
+
+    @engine.select_action("sword")
+    @game.reload
+
+    assert_equal "sword", @game.current_action["type"]
+    assert_equal "SwordTile", @game.current_action["klass"]
+    assert_equal [opponent.order], @game.current_action["pending_orders"]
+  end
+
+  test "select_action for barracks preserves klass" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "BarracksTile", "from" => "[0, 0]", "used" => false } ])
+
+    @engine.select_action("barracks")
+    @game.reload
+
+    assert_equal "barracks", @game.current_action["type"]
+    assert_equal "BarracksTile", @game.current_action["klass"]
+  end
+
+  test "select_meeple_for_move stores from for lighthouse action" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "LighthouseTile", "from" => "[0, 0]", "used" => false } ])
+    @game.update!(current_action: { "type" => "lighthouse", "klass" => "LighthouseTile" })
+    @game.boards = [ [ 1, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    @game.save!
+    @game.board_contents_will_change!
+    @game.board_contents.place_ship(0, 3, player.order)
+    @game.save!
+
+    TurnEngine.new(@game.reload).select_meeple_for_move(0, 3)
+    @game.reload
+
+    assert_equal "[0, 3]", @game.current_action["from"]
+  end
+
+  test "undo of select_meeple_for_move clears from for lighthouse action" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "LighthouseTile", "from" => "[0, 0]", "used" => false } ])
+    @game.update!(current_action: { "type" => "lighthouse", "klass" => "LighthouseTile" })
+    @game.boards = [ [ 1, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    @game.save!
+    @game.board_contents_will_change!
+    @game.board_contents.place_ship(0, 3, player.order)
+    @game.save!
+
+    engine = TurnEngine.new(@game.reload)
+    engine.select_meeple_for_move(0, 3)
+    @game.reload
+    engine.undo_last_move
+    @game.reload
+
+    assert_equal "lighthouse", @game.current_action["type"]
+    assert_equal "LighthouseTile", @game.current_action["klass"]
+    assert_nil @game.current_action["from"]
+  end
+
+  test "undo of place_ship restores current_action to lighthouse tile state" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "LighthouseTile", "from" => "[0, 0]", "used" => false } ])
+    player.reload.add_ships!(1)
+    player.save!
+    @game.update!(current_action: { "type" => "lighthouse", "klass" => "LighthouseTile" })
+
+    hex = valid_meeple_destination("LighthouseTile").first
+    raise "No ship hex available" unless hex
+    @engine.execute_meeple_action(*hex)
+    assert_equal "mandatory", @game.reload.current_action["type"]
+
+    TurnEngine.new(@game.reload).undo_last_move
+    @game.reload
+
+    assert_equal "lighthouse", @game.current_action["type"]
+    assert_equal "LighthouseTile", @game.current_action["klass"]
+    assert_equal false, @game.current_player.tiles.find { |t| t["klass"] == "LighthouseTile" }["used"]
+    assert_equal 1, @game.current_player.ships_remaining
+  end
+
+  test "undo of remove_ship restores current_action to lighthouse tile state" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "LighthouseTile", "from" => "[0, 0]", "used" => false } ])
+    player.reload.add_ships!(1)
+    player.save!
+    @game.board_contents_will_change!
+    hex = valid_meeple_destination("LighthouseTile").first
+    raise "No ship hex available" unless hex
+    @game.board_contents.place_ship(*hex, player.order)
+    @game.save!
+    @game.update!(current_action: { "type" => "lighthouse", "klass" => "LighthouseTile" })
+
+    TurnEngine.new(@game.reload).remove_meeple_action(*hex)
+    assert_equal "mandatory", @game.reload.current_action["type"]
+
+    TurnEngine.new(@game.reload).undo_last_move
+    @game.reload
+
+    assert_equal "lighthouse", @game.current_action["type"]
+    assert_equal "LighthouseTile", @game.current_action["klass"]
+    assert @game.board_contents.ship_at?(*hex)
+  end
+
+  test "undo of place_wagon restores current_action to wagon tile state" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "WagonTile", "from" => "[0, 0]", "used" => false } ])
+    player.reload.add_wagons!(1)
+    player.save!
+    @game.update!(current_action: { "type" => "wagon", "klass" => "WagonTile" })
+
+    hex = valid_meeple_destination("WagonTile").first
+    raise "No wagon hex available" unless hex
+    @engine.execute_meeple_action(*hex)
+    assert_equal "mandatory", @game.reload.current_action["type"]
+
+    TurnEngine.new(@game.reload).undo_last_move
+    @game.reload
+
+    assert_equal "wagon", @game.current_action["type"]
+    assert_equal "WagonTile", @game.current_action["klass"]
+    assert_equal false, @game.current_player.tiles.find { |t| t["klass"] == "WagonTile" }["used"]
+    assert_equal 1, @game.current_player.wagons_remaining
+  end
+
+  test "undo of remove_wagon restores current_action to wagon tile state" do
+    player = @game.current_player
+    player.update!(tiles: [ { "klass" => "WagonTile", "from" => "[0, 0]", "used" => false } ])
+    player.reload.add_wagons!(1)
+    player.save!
+    @game.board_contents_will_change!
+    hex = valid_meeple_destination("WagonTile").first
+    raise "No wagon hex available" unless hex
+    @game.board_contents.place_wagon(*hex, player.order)
+    @game.save!
+    @game.update!(current_action: { "type" => "wagon", "klass" => "WagonTile" })
+
+    TurnEngine.new(@game.reload).remove_meeple_action(*hex)
+    assert_equal "mandatory", @game.reload.current_action["type"]
+
+    TurnEngine.new(@game.reload).undo_last_move
+    @game.reload
+
+    assert_equal "wagon", @game.current_action["type"]
+    assert_equal "WagonTile", @game.current_action["klass"]
+    assert @game.board_contents.wagon_at?(*hex)
+  end
+
   # ---------------------------------------------------------------------------
   # activate_fort_tile
   # ---------------------------------------------------------------------------
@@ -1688,6 +1913,17 @@ class TurnEngineTest < ActiveSupport::TestCase
       end
     end
     spots
+  end
+
+  def valid_meeple_destination(tile_klass)
+    @game.instantiate
+    tile = Tiles::Tile.for_klass(tile_klass).new(0)
+    tile.valid_destinations(
+      board_contents: @game.board_contents,
+      board: @game.board,
+      player_order: @game.current_player.order,
+      supply: @game.current_player.supply_hash
+    )
   end
 end
 

--- a/test/system/fort_tile_test.rb
+++ b/test/system/fort_tile_test.rb
@@ -1,0 +1,37 @@
+require "application_system_test_case"
+
+class FortTileTest < ApplicationSystemTestCase
+  setup do
+    @game = games(:game2player)
+    @chris = game_players(:chris)
+
+    @game.update!(
+      current_action: { "type" => "mandatory" },
+      mandatory_count: 0,
+      deck: %w[D F G],
+      discard: []
+    )
+    @chris.update!(
+      tiles: [
+        { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
+      ]
+    )
+  end
+
+  test "current player can open the Fort warning and activate the tile" do
+    visit root_path
+    fill_in "Enter your email address", with: "chris@example.com"
+    fill_in "Enter your password", with: "password"
+    click_on "Sign in"
+    assert_selector "h1", text: "KBC Dashboard"
+
+    visit game_path(@game)
+
+    assert_selector "form[action='#{activate_fort_game_path(@game)}']", visible: false
+    page.execute_script("document.querySelector(\"form[action='#{activate_fort_game_path(@game)}']\").requestSubmit()")
+
+    assert_equal "fort", @game.reload.current_action["type"]
+    assert_equal "FortTile", @game.current_action["klass"]
+    assert_includes %w[D F G], @game.current_action["fort_terrain"]
+  end
+end


### PR DESCRIPTION
Turn flow now uses an explicit TurnPhase seam for mandatory build, tile build, settlement movement, resettlement, fort, meeple movement, targeted removal, and City Hall paths.

Summary:
- Introduce canonical phase objects in app/models/turn_phase.rb and wire Game#turn_phase serialization.
- Move live turn handling and replay/undo through phase transitions instead of raw current_action hash surgery.
- Preserve terrain-lock, continuation, and undo semantics for quarry, outpost, City Hall, and meeple flows.
- Add focused phase and replay tests around the new seam.

Tests:
- bin/rails test test/models/turn_phase_test.rb test/services/move_applicator_test.rb test/services/turn_engine_test.rb test/models/game_replayer_test.rb
- bin/rails test test/models/game_test.rb
- bin/rails test