### PR TITLE
Turn engine deepening: slice 2 — per-consequence undo

### DIFF
--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -1,0 +1,107 @@
+# Turn — container for a single player's turn.
+#
+# Owns turn-level state and the transitions between sub-phases. Reconstructed
+# per request from Game.current_action["turn"]. Sub-phases are pushed onto the
+# turn when activated and popped on completion; the turn decides what's
+# available next, the sub-phase only knows how to do its own job.
+#
+# Convention: params from the controller arrive as (row, col) integers; the
+# first thing each entry point does is build a Coordinate. Only Coordinate
+# (and the legacy storage layer it serializes to) ever sees the "[r, c]"
+# string form.
+class Turn
+  attr_reader :player_order, :sub_phase
+
+  def initialize(player_order:, sub_phase: nil)
+    @player_order = player_order
+    @sub_phase = sub_phase
+  end
+
+  def self.from_game(game)
+    raw = (game.current_action.is_a?(Hash) ? game.current_action["turn"] : nil) || {}
+    new(
+      player_order: game.current_player&.order,
+      sub_phase: parse_sub_phase(raw["sub_phase"])
+    )
+  end
+
+  def to_h
+    {
+      "sub_phase" => sub_phase ? sub_phase_payload(sub_phase) : nil
+    }
+  end
+
+  def handle(action_name, game:, **params)
+    case action_name
+    when :select_action
+      handle_select_action(game:, **params)
+    when :build
+      handle_build(game:, **params)
+    else
+      [ error("unsupported turn action: #{action_name}") ]
+    end
+  end
+
+  private
+
+  def handle_select_action(game:, tile:)
+    return [ error("a sub-phase is already active") ] if sub_phase
+
+    case tile
+    when :farm
+      handle_farm_activation(game:)
+    else
+      [ error("unsupported tile: #{tile}") ]
+    end
+  end
+
+  def handle_farm_activation(game:)
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+
+    held = gp.find_unused_tile("FarmTile")
+    return [ error("no unused Farm tile available") ] unless held
+
+    pushed = Turn::SubPhases::TileBuildPhase.new(
+      restricted_terrain: "G",
+      tile_klass: "FarmTile",
+      tile_source: Coordinate.from_key(held["from"])
+    )
+    [
+      Turn::Consequences::SubPhasePushed.new(
+        phase_type: Turn::SubPhases::TileBuildPhase::TYPE,
+        state: pushed.to_h
+      )
+    ]
+  end
+
+  def handle_build(game:, **params)
+    return [ error("no active sub-phase") ] unless sub_phase
+
+    consequences = sub_phase.handle(:build, game:, player_order:, **params)
+    consequences << Turn::Consequences::SubPhasePopped.new if sub_phase.complete?
+    consequences
+  end
+
+  def error(msg)
+    Turn::Consequences::Error.new(message: msg)
+  end
+
+  def sub_phase_payload(sp)
+    type = sp.class.const_defined?(:TYPE) ? sp.class::TYPE : sp.class.name
+    { "type" => type, "state" => sp.to_h }
+  end
+
+  class << self
+    private
+
+    def parse_sub_phase(hash)
+      return nil unless hash.is_a?(Hash)
+
+      case hash["type"]
+      when Turn::SubPhases::TileBuildPhase::TYPE
+        Turn::SubPhases::TileBuildPhase.from_h(hash["state"] || {})
+      end
+    end
+  end
+end

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -78,8 +78,9 @@ class Turn
   def handle_build(game:, **params)
     return [ error("no active sub-phase") ] unless sub_phase
 
+    prior_state = sub_phase_payload(sub_phase)
     consequences = sub_phase.handle(:build, game:, player_order:, **params)
-    consequences << Turn::Consequences::SubPhasePopped.new if sub_phase.complete?
+    consequences << Turn::Consequences::SubPhasePopped.new(prior_state: prior_state) if sub_phase.complete?
     consequences
   end
 

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -1,0 +1,4 @@
+class Turn
+  module Consequences
+  end
+end

--- a/app/models/turn/consequences/error.rb
+++ b/app/models/turn/consequences/error.rb
@@ -4,6 +4,9 @@ class Turn
       def apply!(_game)
       end
 
+      def unapply!(_game)
+      end
+
       def error? = true
     end
   end

--- a/app/models/turn/consequences/error.rb
+++ b/app/models/turn/consequences/error.rb
@@ -1,0 +1,10 @@
+class Turn
+  module Consequences
+    Error = Data.define(:message) do
+      def apply!(_game)
+      end
+
+      def error? = true
+    end
+  end
+end

--- a/app/models/turn/consequences/settlement_placed.rb
+++ b/app/models/turn/consequences/settlement_placed.rb
@@ -1,0 +1,11 @@
+class Turn
+  module Consequences
+    SettlementPlaced = Data.define(:at, :player, :terrain) do
+      def apply!(game)
+        game.board_contents_will_change!
+        game.board_contents.place_settlement(at.row, at.col, player)
+        game.game_players.find { |gp| gp.order == player }.decrement_supply!
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/settlement_placed.rb
+++ b/app/models/turn/consequences/settlement_placed.rb
@@ -6,6 +6,12 @@ class Turn
         game.board_contents.place_settlement(at.row, at.col, player)
         game.game_players.find { |gp| gp.order == player }.decrement_supply!
       end
+
+      def unapply!(game)
+        game.board_contents_will_change!
+        game.board_contents.remove(at.row, at.col)
+        game.game_players.find { |gp| gp.order == player }.increment_supply!
+      end
     end
   end
 end

--- a/app/models/turn/consequences/sub_phase_popped.rb
+++ b/app/models/turn/consequences/sub_phase_popped.rb
@@ -1,0 +1,14 @@
+class Turn
+  module Consequences
+    class SubPhasePopped
+      def apply!(game)
+        return unless game.current_action.is_a?(Hash) && game.current_action["turn"].is_a?(Hash)
+        game.current_action["turn"]["sub_phase"] = nil
+      end
+
+      def ==(other) = other.is_a?(SubPhasePopped)
+      def eql?(other) = self == other
+      def hash = self.class.hash
+    end
+  end
+end

--- a/app/models/turn/consequences/sub_phase_popped.rb
+++ b/app/models/turn/consequences/sub_phase_popped.rb
@@ -1,14 +1,16 @@
 class Turn
   module Consequences
-    class SubPhasePopped
+    SubPhasePopped = Data.define(:prior_state) do
       def apply!(game)
         return unless game.current_action.is_a?(Hash) && game.current_action["turn"].is_a?(Hash)
         game.current_action["turn"]["sub_phase"] = nil
       end
 
-      def ==(other) = other.is_a?(SubPhasePopped)
-      def eql?(other) = self == other
-      def hash = self.class.hash
+      def unapply!(game)
+        game.current_action ||= {}
+        game.current_action["turn"] ||= {}
+        game.current_action["turn"]["sub_phase"] = prior_state
+      end
     end
   end
 end

--- a/app/models/turn/consequences/sub_phase_pushed.rb
+++ b/app/models/turn/consequences/sub_phase_pushed.rb
@@ -6,6 +6,11 @@ class Turn
         game.current_action["turn"] ||= {}
         game.current_action["turn"]["sub_phase"] = { "type" => phase_type.to_s, "state" => state }
       end
+
+      def unapply!(game)
+        return unless game.current_action.is_a?(Hash) && game.current_action["turn"].is_a?(Hash)
+        game.current_action["turn"]["sub_phase"] = nil
+      end
     end
   end
 end

--- a/app/models/turn/consequences/sub_phase_pushed.rb
+++ b/app/models/turn/consequences/sub_phase_pushed.rb
@@ -1,0 +1,11 @@
+class Turn
+  module Consequences
+    SubPhasePushed = Data.define(:phase_type, :state) do
+      def apply!(game)
+        game.current_action ||= {}
+        game.current_action["turn"] ||= {}
+        game.current_action["turn"]["sub_phase"] = { "type" => phase_type.to_s, "state" => state }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/sub_phase_pushed.rb
+++ b/app/models/turn/consequences/sub_phase_pushed.rb
@@ -8,8 +8,8 @@ class Turn
       end
 
       def unapply!(game)
-        return unless game.current_action.is_a?(Hash) && game.current_action["turn"].is_a?(Hash)
-        game.current_action["turn"]["sub_phase"] = nil
+        return unless game.current_action.is_a?(Hash)
+        game.current_action.delete("turn")
       end
     end
   end

--- a/app/models/turn/consequences/tile_consumed.rb
+++ b/app/models/turn/consequences/tile_consumed.rb
@@ -1,0 +1,9 @@
+class Turn
+  module Consequences
+    TileConsumed = Data.define(:klass, :player) do
+      def apply!(game)
+        game.game_players.find { |gp| gp.order == player }.mark_tile_used!(klass)
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/tile_consumed.rb
+++ b/app/models/turn/consequences/tile_consumed.rb
@@ -4,6 +4,10 @@ class Turn
       def apply!(game)
         game.game_players.find { |gp| gp.order == player }.mark_tile_used!(klass)
       end
+
+      def unapply!(game)
+        game.game_players.find { |gp| gp.order == player }.mark_tile_unused!(klass)
+      end
     end
   end
 end

--- a/app/models/turn/consequences/tile_picked_up.rb
+++ b/app/models/turn/consequences/tile_picked_up.rb
@@ -12,10 +12,16 @@ class Turn
       def unapply!(game)
         game.board_contents_will_change!
         gp = game.game_players.find { |g| g.order == player }
+
         taken = (gp.taken_from || []).dup
         taken.pop if taken.last == from.to_key
-        gp.taken_from = taken
-        gp.remove_tile_from!(from.to_key)
+        gp.taken_from = taken.empty? ? nil : taken
+
+        tiles = (gp.tiles || []).dup
+        idx = tiles.rindex { |t| t["klass"] == klass && t["from"] == from.to_key }
+        tiles.delete_at(idx) if idx
+        gp.tiles = tiles
+
         game.board_contents.increment_tile(from.row, from.col)
       end
     end

--- a/app/models/turn/consequences/tile_picked_up.rb
+++ b/app/models/turn/consequences/tile_picked_up.rb
@@ -8,6 +8,16 @@ class Turn
         gp.receive_tile!(klass, from: from.to_key)
         gp.taken_from = (gp.taken_from || []) + [ from.to_key ]
       end
+
+      def unapply!(game)
+        game.board_contents_will_change!
+        gp = game.game_players.find { |g| g.order == player }
+        taken = (gp.taken_from || []).dup
+        taken.pop if taken.last == from.to_key
+        gp.taken_from = taken
+        gp.remove_tile_from!(from.to_key)
+        game.board_contents.increment_tile(from.row, from.col)
+      end
     end
   end
 end

--- a/app/models/turn/consequences/tile_picked_up.rb
+++ b/app/models/turn/consequences/tile_picked_up.rb
@@ -1,0 +1,13 @@
+class Turn
+  module Consequences
+    TilePickedUp = Data.define(:from, :klass, :player) do
+      def apply!(game)
+        game.board_contents_will_change!
+        game.board_contents.decrement_tile(from.row, from.col)
+        gp = game.game_players.find { |g| g.order == player }
+        gp.receive_tile!(klass, from: from.to_key)
+        gp.taken_from = (gp.taken_from || []) + [ from.to_key ]
+      end
+    end
+  end
+end

--- a/app/models/turn/sub_phase.rb
+++ b/app/models/turn/sub_phase.rb
@@ -1,0 +1,17 @@
+class Turn
+  class SubPhase
+    def complete? = @complete == true
+
+    def handle(_action_name, **_kwargs)
+      raise NotImplementedError, "#{self.class} must implement #handle"
+    end
+
+    def to_h
+      raise NotImplementedError, "#{self.class} must implement #to_h"
+    end
+
+    def self.from_h(_hash)
+      raise NotImplementedError, "#{self} must implement .from_h"
+    end
+  end
+end

--- a/app/models/turn/sub_phases.rb
+++ b/app/models/turn/sub_phases.rb
@@ -1,0 +1,4 @@
+class Turn
+  module SubPhases
+  end
+end

--- a/app/models/turn/sub_phases/tile_build_phase.rb
+++ b/app/models/turn/sub_phases/tile_build_phase.rb
@@ -1,0 +1,74 @@
+class Turn
+  module SubPhases
+    class TileBuildPhase < Turn::SubPhase
+      TYPE = "tile_build".freeze
+
+      attr_reader :restricted_terrain, :tile_klass, :tile_source
+
+      def initialize(restricted_terrain:, tile_klass:, tile_source:)
+        super()
+        @restricted_terrain = restricted_terrain
+        @tile_klass = tile_klass
+        @tile_source = tile_source
+        @complete = false
+      end
+
+      def to_h
+        {
+          "restricted_terrain" => restricted_terrain,
+          "tile_klass" => tile_klass,
+          "tile_source" => tile_source.to_key
+        }
+      end
+
+      def self.from_h(hash)
+        new(
+          restricted_terrain: hash["restricted_terrain"],
+          tile_klass: hash["tile_klass"],
+          tile_source: Coordinate.from_key(hash["tile_source"])
+        )
+      end
+
+      def handle(action_name, game:, player_order:, **params)
+        case action_name
+        when :build
+          handle_build(game:, player_order:, row: params[:row], col: params[:col])
+        else
+          [ Turn::Consequences::Error.new(message: "unsupported action: #{action_name}") ]
+        end
+      end
+
+      private
+
+      def handle_build(game:, player_order:, row:, col:)
+        game.instantiate_board unless game.board
+
+        return error("hex outside restricted terrain #{restricted_terrain}") unless game.board.terrain_at(row, col) == restricted_terrain
+        return error("hex (#{row}, #{col}) is not empty") unless game.board_contents.empty?(row, col)
+
+        consequences = [
+          Turn::Consequences::SettlementPlaced.new(
+            at: Coordinate.new(row, col), player: player_order, terrain: restricted_terrain
+          )
+        ]
+
+        game.board_contents.neighbors(row, col).each do |nr, nc|
+          next unless game.board_contents.tile_qty(nr, nc) > 0
+          consequences << Turn::Consequences::TilePickedUp.new(
+            from: Coordinate.new(nr, nc),
+            klass: game.board_contents.tile_klass(nr, nc),
+            player: player_order
+          )
+        end
+
+        consequences << Turn::Consequences::TileConsumed.new(klass: tile_klass, player: player_order)
+        @complete = true
+        consequences
+      end
+
+      def error(msg)
+        [ Turn::Consequences::Error.new(message: msg) ]
+      end
+    end
+  end
+end

--- a/app/services/broadcaster.rb
+++ b/app/services/broadcaster.rb
@@ -1,0 +1,71 @@
+# Broadcaster — translates a consequence list into Turbo Stream broadcast plans.
+#
+# Slice 1: emits stub html for each plan. Slice 1.5 will swap in the real
+# partials (board, turn_state, game_player) once the new stack is wired
+# through the controller and the partials' locals are sourced from Turn /
+# sub-phase state instead of TurnEngine.
+class Broadcaster
+  Plan = Data.define(:channel, :target, :html)
+
+  def self.publish(game, consequences)
+    new(game, consequences).publish
+  end
+
+  def initialize(game, consequences)
+    @game = game
+    @consequences = Array(consequences)
+  end
+
+  def plans
+    @plans ||= compute_plans
+  end
+
+  def publish
+    plans.each do |p|
+      Turbo::StreamsChannel.broadcast_update_to(p.channel, target: p.target, html: p.html)
+    end
+    plans
+  end
+
+  private
+
+  def compute_plans
+    out = []
+    out << Plan.new("game_#{@game.id}", "board", stub("board")) if board_changed?
+    out << Plan.new("game_#{@game.id}", "turn-state", stub("turn-state")) if turn_state_changed?
+    affected_players.each do |gp|
+      out << Plan.new("game_player_#{gp.id}_private", "game_player_#{gp.id}", stub("game_player_#{gp.id}"))
+    end
+    out
+  end
+
+  def board_changed?
+    @consequences.any? { |c| board_changing?(c) }
+  end
+
+  def turn_state_changed?
+    @consequences.any? { |c| turn_state_changing?(c) }
+  end
+
+  def board_changing?(c)
+    c.is_a?(Turn::Consequences::SettlementPlaced) || c.is_a?(Turn::Consequences::TilePickedUp)
+  end
+
+  def turn_state_changing?(c)
+    c.is_a?(Turn::Consequences::SubPhasePushed) ||
+      c.is_a?(Turn::Consequences::SubPhasePopped) ||
+      board_changing?(c)
+  end
+
+  def affected_players
+    orders = Set.new
+    @consequences.each do |c|
+      orders << c.player if c.respond_to?(:player)
+    end
+    @game.game_players.select { |gp| orders.include?(gp.order) }
+  end
+
+  def stub(target)
+    %(<div data-broadcaster-target="#{target}"></div>)
+  end
+end

--- a/app/services/consequence_applier.rb
+++ b/app/services/consequence_applier.rb
@@ -1,0 +1,31 @@
+class ConsequenceApplier
+  class ApplyError < StandardError
+    attr_reader :messages
+
+    def initialize(messages)
+      @messages = messages
+      super(messages.join("; "))
+    end
+  end
+
+  def self.apply!(game, consequences)
+    new(game, consequences).apply!
+  end
+
+  def initialize(game, consequences)
+    @game = game
+    @consequences = Array(consequences)
+  end
+
+  def apply!
+    errors = @consequences.select { |c| c.respond_to?(:error?) && c.error? }
+    raise ApplyError.new(errors.map(&:message)) if errors.any?
+
+    Game.transaction do
+      @consequences.each { |c| c.apply!(@game) }
+      @game.save!
+      @game.game_players.each(&:save!)
+    end
+    @game
+  end
+end

--- a/app/services/consequence_applier.rb
+++ b/app/services/consequence_applier.rb
@@ -12,6 +12,10 @@ class ConsequenceApplier
     new(game, consequences).apply!
   end
 
+  def self.unapply!(game, consequences)
+    new(game, consequences).unapply!
+  end
+
   def initialize(game, consequences)
     @game = game
     @consequences = Array(consequences)
@@ -23,6 +27,15 @@ class ConsequenceApplier
 
     Game.transaction do
       @consequences.each { |c| c.apply!(@game) }
+      @game.save!
+      @game.game_players.each(&:save!)
+    end
+    @game
+  end
+
+  def unapply!
+    Game.transaction do
+      @consequences.reverse_each { |c| c.unapply!(@game) }
       @game.save!
       @game.game_players.each(&:save!)
     end

--- a/test/integration/farm_slice_through_new_stack_test.rb
+++ b/test/integration/farm_slice_through_new_stack_test.rb
@@ -1,0 +1,129 @@
+require "test_helper"
+require "turbo/broadcastable/test_helper"
+
+# Slice 1 integration test: Farm tile activation + Grass build, end-to-end
+# through the new stack (Turn → sub-phase → consequences → ConsequenceApplier
+# → Broadcaster). No controller, no comparison with the old engine; that's
+# slice 1.5.
+class FarmSliceThroughNewStackTest < ActiveSupport::TestCase
+  include Turbo::Broadcastable::TestHelper
+
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+
+    @player = @game.current_player
+    @farm_source = "[3, 4]"
+    @player.update!(tiles: [ { "klass" => "FarmTile", "from" => @farm_source, "used" => false } ])
+    @game.reload
+  end
+
+  test "Farm activation followed by Grass build: applies and persists end-to-end" do
+    settlements_before = @player.settlements_remaining
+
+    # 1. Activate Farm.
+    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: :farm)
+    ConsequenceApplier.apply!(@game, activation)
+    Broadcaster.publish(@game, activation)
+
+    @game.reload
+    sub_phase_state = @game.current_action.dig("turn", "sub_phase")
+    assert_equal "tile_build", sub_phase_state["type"]
+    assert_equal "G", sub_phase_state.dig("state", "restricted_terrain")
+    assert_equal "FarmTile", sub_phase_state.dig("state", "tile_klass")
+    assert_equal @farm_source, sub_phase_state.dig("state", "tile_source")
+
+    # 2. Build on a Grass hex.
+    @game.instantiate
+    row, col = first_empty_grass
+
+    build = Turn.from_game(@game).handle(:build, game: @game, row:, col:)
+    ConsequenceApplier.apply!(@game, build)
+    Broadcaster.publish(@game, build)
+
+    @game.reload
+    assert_equal @player.order, @game.board_contents.player_at(row, col)
+    assert_equal settlements_before - 1, @player.reload.settlements_remaining
+
+    farm_tile = @player.tiles.find { |t| t["klass"] == "FarmTile" }
+    assert_equal true, farm_tile["used"], "Farm tile should be marked used after build"
+
+    assert_nil @game.current_action.dig("turn", "sub_phase"), "sub_phase should be popped after build"
+  end
+
+  test "build emits a board broadcast" do
+    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: :farm)
+    ConsequenceApplier.apply!(@game, activation)
+    @game.reload
+    @game.instantiate
+    row, col = first_empty_grass
+
+    build = Turn.from_game(@game).handle(:build, game: @game, row:, col:)
+    ConsequenceApplier.apply!(@game, build)
+
+    assert_turbo_stream_broadcasts("game_#{@game.id}") do
+      Broadcaster.publish(@game, build)
+    end
+  end
+
+  test "activation when player has no Farm tile is rejected (no state changes)" do
+    @player.update!(tiles: [])
+    @game.reload
+    settlements_before = @player.settlements_remaining
+
+    consequences = Turn.from_game(@game).handle(:select_action, game: @game, tile: :farm)
+    assert_kind_of Turn::Consequences::Error, consequences.first
+    assert_raises(ConsequenceApplier::ApplyError) do
+      ConsequenceApplier.apply!(@game, consequences)
+    end
+
+    @game.reload
+    assert_equal settlements_before, @player.reload.settlements_remaining
+    assert_nil @game.current_action.dig("turn", "sub_phase") if @game.current_action
+  end
+
+  test "build on a non-Grass hex during Farm sub-phase is rejected and sub-phase remains active" do
+    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: :farm)
+    ConsequenceApplier.apply!(@game, activation)
+    @game.reload
+    @game.instantiate
+
+    non_grass = first_empty_non_grass
+    consequences = Turn.from_game(@game).handle(:build, game: @game, row: non_grass[0], col: non_grass[1])
+    assert_kind_of Turn::Consequences::Error, consequences.first
+
+    assert_raises(ConsequenceApplier::ApplyError) do
+      ConsequenceApplier.apply!(@game, consequences)
+    end
+
+    @game.reload
+    assert_not_nil @game.current_action.dig("turn", "sub_phase")
+  end
+
+  private
+
+  def first_empty_grass
+    20.times do |row|
+      20.times do |col|
+        next unless @game.board.terrain_at(row, col) == "G"
+        return [ row, col ] if @game.board_contents.empty?(row, col)
+      end
+    end
+    raise "no empty grass hex"
+  end
+
+  def first_empty_non_grass
+    20.times do |row|
+      20.times do |col|
+        terrain = @game.board.terrain_at(row, col)
+        next if terrain.nil? || terrain == "G" || terrain == "L" || terrain == "S"
+        return [ row, col ] if @game.board_contents.empty?(row, col)
+      end
+    end
+    raise "no empty non-grass hex"
+  end
+end

--- a/test/integration/replay_consequence_stream_test.rb
+++ b/test/integration/replay_consequence_stream_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+# Slice 1 forward-compat probe: capture the consequence stream from running a
+# Farm slice, reset the game to its pre-slice state, replay the stream, and
+# assert the end state matches. Validates that the slice 1 consequence
+# vocabulary is sufficient to reconstruct game state from events alone — the
+# precondition for any future event-sourcing work.
+class ReplayConsequenceStreamTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+
+    @player = @game.current_player
+    @player.update!(tiles: [ { "klass" => "FarmTile", "from" => "[3, 4]", "used" => false } ])
+    @game.reload
+    @game.instantiate
+  end
+
+  test "consequence stream replays cleanly: end state matches first run" do
+    snapshot = @game.capture_snapshot
+
+    stream = []
+    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: :farm)
+    ConsequenceApplier.apply!(@game, activation)
+    stream.concat(activation)
+
+    @game.reload
+    @game.instantiate
+    row, col = first_empty_grass
+
+    build = Turn.from_game(@game).handle(:build, game: @game, row:, col:)
+    ConsequenceApplier.apply!(@game, build)
+    stream.concat(build)
+
+    @game.reload
+    expected = end_state_fingerprint(@game)
+
+    restore_from_snapshot(@game, snapshot)
+    @game.reload
+
+    ConsequenceApplier.apply!(@game, stream)
+    @game.reload
+    actual = end_state_fingerprint(@game)
+
+    assert_equal expected, actual,
+      "replay did not reproduce the same end state — consequence vocabulary is incomplete"
+  end
+
+  private
+
+  def first_empty_grass
+    20.times do |row|
+      20.times do |col|
+        next unless @game.board.terrain_at(row, col) == "G"
+        return [ row, col ] if @game.board_contents.empty?(row, col)
+      end
+    end
+    raise "no empty grass hex"
+  end
+
+  def end_state_fingerprint(game)
+    {
+      "board_contents" => BoardState.dump(game.board_contents),
+      "current_action" => game.current_action,
+      "players" => game.game_players.in_player_order.map do |gp|
+        gp.reload
+        { "order" => gp.order, "supply" => gp.supply, "tiles" => gp.tiles, "taken_from" => gp.taken_from || [] }
+      end
+    }
+  end
+
+  def restore_from_snapshot(game, snap)
+    game.board_contents = BoardState.load(snap["board_contents"])
+    game.current_action = snap["current_action"]
+    game.save!
+    game.game_players.each do |gp|
+      ps = snap["players"].find { |p| p["order"] == gp.order }
+      gp.update!(hand: ps["hand"], supply: ps["supply"], tiles: ps["tiles"], taken_from: ps["taken_from"])
+    end
+  end
+end

--- a/test/models/turn/consequences/error_test.rb
+++ b/test/models/turn/consequences/error_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class Turn::Consequences::ErrorTest < ActiveSupport::TestCase
+  test "apply! is a no-op" do
+    game = games(:game2player)
+    Turn::Consequences::Error.new(message: "nope").apply!(game)
+  end
+
+  test "unapply! is a no-op" do
+    game = games(:game2player)
+    Turn::Consequences::Error.new(message: "nope").unapply!(game)
+  end
+
+  test "error? is true" do
+    assert Turn::Consequences::Error.new(message: "nope").error?
+  end
+end

--- a/test/models/turn/consequences/settlement_placed_test.rb
+++ b/test/models/turn/consequences/settlement_placed_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class Turn::Consequences::SettlementPlacedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+  end
+
+  def player(order) = @game.game_players.find { |gp| gp.order == order }
+
+  def consequence(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    Turn::Consequences::SettlementPlaced.new(at:, player:, terrain:)
+  end
+
+  test "places a settlement at the coordinate for the given player" do
+    consequence(at: Coordinate.new(5, 7), player: 0).apply!(@game)
+    assert_equal 0, @game.board_contents.player_at(5, 7)
+  end
+
+  test "decrements the player's settlement supply" do
+    before = player(0).settlements_remaining
+    consequence(player: 0).apply!(@game)
+    assert_equal before - 1, player(0).settlements_remaining
+  end
+
+  test "leaves other players' supply unchanged" do
+    before = player(1).settlements_remaining
+    consequence(player: 0).apply!(@game)
+    assert_equal before, player(1).settlements_remaining
+  end
+
+  test "equality is by value" do
+    a = consequence(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    b = consequence(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    assert_equal a, b
+  end
+end

--- a/test/models/turn/consequences/settlement_placed_test.rb
+++ b/test/models/turn/consequences/settlement_placed_test.rb
@@ -28,6 +28,29 @@ class Turn::Consequences::SettlementPlacedTest < ActiveSupport::TestCase
     assert_equal before, player(1).settlements_remaining
   end
 
+  test "unapply! removes the settlement from the board" do
+    c = consequence(at: Coordinate.new(5, 7), player: 0)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_nil @game.board_contents.player_at(5, 7)
+  end
+
+  test "unapply! restores the player's supply" do
+    before = player(0).settlements_remaining
+    c = consequence(player: 0)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal before, player(0).settlements_remaining
+  end
+
+  test "unapply! leaves other players' supply unchanged" do
+    before = player(1).settlements_remaining
+    c = consequence(player: 0)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal before, player(1).settlements_remaining
+  end
+
   test "equality is by value" do
     a = consequence(at: Coordinate.new(5, 7), player: 0, terrain: "G")
     b = consequence(at: Coordinate.new(5, 7), player: 0, terrain: "G")

--- a/test/models/turn/consequences/sub_phase_popped_test.rb
+++ b/test/models/turn/consequences/sub_phase_popped_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class Turn::Consequences::SubPhasePoppedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+  end
+
+  test "clears current_action.turn.sub_phase" do
+    @game.current_action = { "turn" => { "sub_phase" => { "type" => "tile_build", "state" => {} } } }
+    Turn::Consequences::SubPhasePopped.new.apply!(@game)
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+  end
+
+  test "no-op if no current_action" do
+    @game.current_action = nil
+    assert_nothing_raised { Turn::Consequences::SubPhasePopped.new.apply!(@game) }
+  end
+
+  test "no-op if no turn key" do
+    @game.current_action = { "type" => "mandatory" }
+    assert_nothing_raised { Turn::Consequences::SubPhasePopped.new.apply!(@game) }
+    assert_equal "mandatory", @game.current_action["type"]
+  end
+
+  test "two instances are equal" do
+    assert_equal Turn::Consequences::SubPhasePopped.new, Turn::Consequences::SubPhasePopped.new
+  end
+end

--- a/test/models/turn/consequences/sub_phase_popped_test.rb
+++ b/test/models/turn/consequences/sub_phase_popped_test.rb
@@ -3,26 +3,38 @@ require "test_helper"
 class Turn::Consequences::SubPhasePoppedTest < ActiveSupport::TestCase
   def setup
     @game = games(:game2player)
+    @prior = { "type" => "tile_build",
+               "state" => { "restricted_terrain" => "G", "tile_klass" => "FarmTile", "tile_source" => "[2, 3]" } }
   end
 
   test "clears current_action.turn.sub_phase" do
-    @game.current_action = { "turn" => { "sub_phase" => { "type" => "tile_build", "state" => {} } } }
-    Turn::Consequences::SubPhasePopped.new.apply!(@game)
+    @game.current_action = { "turn" => { "sub_phase" => @prior } }
+    Turn::Consequences::SubPhasePopped.new(prior_state: @prior).apply!(@game)
     assert_nil @game.current_action.dig("turn", "sub_phase")
   end
 
   test "no-op if no current_action" do
     @game.current_action = nil
-    assert_nothing_raised { Turn::Consequences::SubPhasePopped.new.apply!(@game) }
+    assert_nothing_raised { Turn::Consequences::SubPhasePopped.new(prior_state: @prior).apply!(@game) }
   end
 
   test "no-op if no turn key" do
     @game.current_action = { "type" => "mandatory" }
-    assert_nothing_raised { Turn::Consequences::SubPhasePopped.new.apply!(@game) }
+    assert_nothing_raised { Turn::Consequences::SubPhasePopped.new(prior_state: @prior).apply!(@game) }
     assert_equal "mandatory", @game.current_action["type"]
   end
 
-  test "two instances are equal" do
-    assert_equal Turn::Consequences::SubPhasePopped.new, Turn::Consequences::SubPhasePopped.new
+  test "unapply! restores the prior sub_phase" do
+    @game.current_action = { "turn" => { "sub_phase" => @prior } }
+    c = Turn::Consequences::SubPhasePopped.new(prior_state: @prior)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal @prior, @game.current_action.dig("turn", "sub_phase")
+  end
+
+  test "equality is by value" do
+    a = Turn::Consequences::SubPhasePopped.new(prior_state: @prior)
+    b = Turn::Consequences::SubPhasePopped.new(prior_state: @prior)
+    assert_equal a, b
   end
 end

--- a/test/models/turn/consequences/sub_phase_pushed_test.rb
+++ b/test/models/turn/consequences/sub_phase_pushed_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Turn::Consequences::SubPhasePushedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @game.current_action = nil
+  end
+
+  test "writes sub_phase under current_action.turn" do
+    consequence = Turn::Consequences::SubPhasePushed.new(
+      phase_type: "tile_build",
+      state: { "restricted_terrain" => "G", "tile_klass" => "FarmTile" }
+    )
+    consequence.apply!(@game)
+    sub_phase = @game.current_action.dig("turn", "sub_phase")
+    assert_equal "tile_build", sub_phase["type"]
+    assert_equal "G", sub_phase.dig("state", "restricted_terrain")
+    assert_equal "FarmTile", sub_phase.dig("state", "tile_klass")
+  end
+
+  test "preserves other current_action keys" do
+    @game.current_action = { "type" => "mandatory" }
+    Turn::Consequences::SubPhasePushed.new(phase_type: "tile_build", state: {}).apply!(@game)
+    assert_equal "mandatory", @game.current_action["type"]
+    assert_not_nil @game.current_action.dig("turn", "sub_phase")
+  end
+end

--- a/test/models/turn/consequences/sub_phase_pushed_test.rb
+++ b/test/models/turn/consequences/sub_phase_pushed_test.rb
@@ -24,4 +24,15 @@ class Turn::Consequences::SubPhasePushedTest < ActiveSupport::TestCase
     assert_equal "mandatory", @game.current_action["type"]
     assert_not_nil @game.current_action.dig("turn", "sub_phase")
   end
+
+  test "unapply! clears the active sub_phase" do
+    c = Turn::Consequences::SubPhasePushed.new(
+      phase_type: "tile_build",
+      state: { "restricted_terrain" => "G", "tile_klass" => "FarmTile" }
+    )
+    c.apply!(@game)
+    assert_equal "tile_build", @game.current_action.dig("turn", "sub_phase", "type")
+    c.unapply!(@game)
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+  end
 end

--- a/test/models/turn/consequences/tile_consumed_test.rb
+++ b/test/models/turn/consequences/tile_consumed_test.rb
@@ -22,8 +22,7 @@ class Turn::Consequences::TileConsumedTest < ActiveSupport::TestCase
 
   test "unapply! marks the tile unused again" do
     gp = player(0)
-    gp.tiles = []
-    gp.receive_tile!("FarmTile", from: "[2, 3]")
+    gp.tiles = [ { "klass" => "FarmTile", "from" => "[2, 3]", "used" => false } ]
     c = Turn::Consequences::TileConsumed.new(klass: "FarmTile", player: 0)
     c.apply!(@game)
     refute_nil gp.tiles.find { |t| t["klass"] == "FarmTile" && t["used"] }

--- a/test/models/turn/consequences/tile_consumed_test.rb
+++ b/test/models/turn/consequences/tile_consumed_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class Turn::Consequences::TileConsumedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @player = @game.game_players.find { |gp| gp.order == 0 }
+    @player.tiles = [ { "klass" => "FarmTile", "from" => "[3, 4]", "used" => false } ]
+  end
+
+  test "marks the player's tile as used" do
+    Turn::Consequences::TileConsumed.new(klass: "FarmTile", player: 0).apply!(@game)
+    held = @game.game_players.find { |gp| gp.order == 0 }.tiles.first
+    assert_equal true, held["used"]
+  end
+
+  test "no-op if no unused tile of that klass" do
+    @player.tiles = [ { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true } ]
+    assert_nothing_raised do
+      Turn::Consequences::TileConsumed.new(klass: "FarmTile", player: 0).apply!(@game)
+    end
+  end
+end

--- a/test/models/turn/consequences/tile_consumed_test.rb
+++ b/test/models/turn/consequences/tile_consumed_test.rb
@@ -19,4 +19,18 @@ class Turn::Consequences::TileConsumedTest < ActiveSupport::TestCase
       Turn::Consequences::TileConsumed.new(klass: "FarmTile", player: 0).apply!(@game)
     end
   end
+
+  test "unapply! marks the tile unused again" do
+    gp = player(0)
+    gp.tiles = []
+    gp.receive_tile!("FarmTile", from: "[2, 3]")
+    c = Turn::Consequences::TileConsumed.new(klass: "FarmTile", player: 0)
+    c.apply!(@game)
+    refute_nil gp.tiles.find { |t| t["klass"] == "FarmTile" && t["used"] }
+    c.unapply!(@game)
+    assert_nil gp.tiles.find { |t| t["klass"] == "FarmTile" && t["used"] }
+    refute_nil gp.tiles.find { |t| t["klass"] == "FarmTile" }
+  end
+
+  def player(order) = @game.game_players.find { |gp| gp.order == order }
 end

--- a/test/models/turn/consequences/tile_picked_up_test.rb
+++ b/test/models/turn/consequences/tile_picked_up_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Turn::Consequences::TilePickedUpTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @game.board_contents.place_tile(3, 4, "FarmTile", 2)
+    @from = Coordinate.new(3, 4)
+  end
+
+  def player(order) = @game.game_players.find { |gp| gp.order == order }
+
+  def consequence(from: @from, klass: "FarmTile", player: 0)
+    Turn::Consequences::TilePickedUp.new(from:, klass:, player:)
+  end
+
+  test "decrements the tile qty on the board" do
+    consequence.apply!(@game)
+    assert_equal 1, @game.board_contents.tile_qty(3, 4)
+  end
+
+  test "adds the tile to the player's tiles with from = coord key" do
+    consequence(player: 0).apply!(@game)
+    held = player(0).tiles
+    assert_equal 1, held.size
+    assert_equal "FarmTile", held.first["klass"]
+    assert_equal "[3, 4]", held.first["from"]
+  end
+
+  test "appends the location to the player's taken_from" do
+    consequence(player: 0).apply!(@game)
+    assert_equal [ "[3, 4]" ], player(0).taken_from
+  end
+end

--- a/test/models/turn/consequences/tile_picked_up_test.rb
+++ b/test/models/turn/consequences/tile_picked_up_test.rb
@@ -30,4 +30,34 @@ class Turn::Consequences::TilePickedUpTest < ActiveSupport::TestCase
     consequence(player: 0).apply!(@game)
     assert_equal [ "[3, 4]" ], player(0).taken_from
   end
+
+  test "unapply! restores the tile qty on the source hex" do
+    c = consequence(player: 0)
+    c.apply!(@game)
+    assert_equal 1, @game.board_contents.tile_qty(3, 4)
+    c.unapply!(@game)
+    assert_equal 2, @game.board_contents.tile_qty(3, 4)
+  end
+
+  test "unapply! removes the tile from the player" do
+    gp = player(0)
+    gp.tiles = []
+    gp.taken_from = []
+    c = consequence(player: 0)
+    c.apply!(@game)
+    assert(gp.tiles.any? { |t| t["klass"] == "FarmTile" && t["from"] == "[3, 4]" })
+    c.unapply!(@game)
+    refute(gp.tiles.any? { |t| t["klass"] == "FarmTile" && t["from"] == "[3, 4]" })
+  end
+
+  test "unapply! pops the source coord from taken_from" do
+    gp = player(0)
+    gp.tiles = []
+    gp.taken_from = []
+    c = consequence(player: 0)
+    c.apply!(@game)
+    assert_includes gp.taken_from, "[3, 4]"
+    c.unapply!(@game)
+    refute_includes (gp.taken_from || []), "[3, 4]"
+  end
 end

--- a/test/models/turn/sub_phases/tile_build_phase_test.rb
+++ b/test/models/turn/sub_phases/tile_build_phase_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class Turn::SubPhases::TileBuildPhaseTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+  end
+
+  def phase(restricted_terrain: "G", tile_klass: "FarmTile", tile_source: Coordinate.new(0, 0))
+    Turn::SubPhases::TileBuildPhase.new(
+      restricted_terrain:, tile_klass:, tile_source:
+    )
+  end
+
+  def first_empty_grass
+    20.times do |row|
+      20.times do |col|
+        next unless @game.board.terrain_at(row, col) == "G"
+        return [ row, col ] if @game.board_contents.empty?(row, col)
+      end
+    end
+    raise "no empty grass hex on this board"
+  end
+
+  test "complete? is false on construction" do
+    refute phase.complete?
+  end
+
+  test "to_h / from_h round-trip" do
+    p = phase(tile_source: Coordinate.new(3, 4))
+    rebuilt = Turn::SubPhases::TileBuildPhase.from_h(p.to_h)
+    assert_equal "G", rebuilt.restricted_terrain
+    assert_equal "FarmTile", rebuilt.tile_klass
+    assert_equal Coordinate.new(3, 4), rebuilt.tile_source
+  end
+
+  test "handle(:build) on a Grass hex emits SettlementPlaced + TileConsumed and sets complete?" do
+    row, col = first_empty_grass
+    p = phase
+    consequences = p.handle(:build, game: @game, player_order: 0, row:, col:)
+
+    assert_kind_of Turn::Consequences::SettlementPlaced, consequences.first
+    assert_equal Coordinate.new(row, col), consequences.first.at
+    assert(consequences.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) && c.klass == "FarmTile" })
+    assert p.complete?
+  end
+
+  test "handle(:build) on a non-Grass hex emits Error and stays incomplete" do
+    @game.instantiate
+    spot = nil
+    20.times do |row|
+      20.times do |col|
+        if @game.board.terrain_at(row, col) != "G" && @game.board_contents.empty?(row, col) && @game.board.terrain_at(row, col) != "L" && @game.board.terrain_at(row, col) != "S"
+          spot = [ row, col ]
+          break
+        end
+      end
+      break if spot
+    end
+    raise "no non-grass empty hex" unless spot
+
+    p = phase
+    consequences = p.handle(:build, game: @game, player_order: 0, row: spot[0], col: spot[1])
+
+    assert_equal 1, consequences.size
+    assert_kind_of Turn::Consequences::Error, consequences.first
+    refute p.complete?
+  end
+
+  test "handle(:build) on an occupied hex emits Error" do
+    row, col = first_empty_grass
+    @game.board_contents.place_settlement(row, col, 1)
+
+    consequences = phase.handle(:build, game: @game, player_order: 0, row:, col:)
+    assert_kind_of Turn::Consequences::Error, consequences.first
+  end
+
+  test "handle(:build) emits TilePickedUp for adjacent location with qty > 0" do
+    row, col = first_empty_grass
+    nr, nc = @game.board_contents.neighbors(row, col).first
+    @game.board_contents.place_tile(nr, nc, "OracleTile", 2)
+
+    consequences = phase.handle(:build, game: @game, player_order: 0, row:, col:)
+    pickup = consequences.find { |c| c.is_a?(Turn::Consequences::TilePickedUp) }
+    assert pickup, "expected TilePickedUp in consequences"
+    assert_equal "OracleTile", pickup.klass
+    assert_equal Coordinate.new(nr, nc), pickup.from
+  end
+
+  test "handle with unsupported action returns Error" do
+    consequences = phase.handle(:nonsense, game: @game, player_order: 0)
+    assert_kind_of Turn::Consequences::Error, consequences.first
+  end
+end

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -75,6 +75,8 @@ class TurnTest < ActiveSupport::TestCase
     assert(consequences.any? { |c| c.is_a?(Turn::Consequences::SettlementPlaced) })
     assert(consequences.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) })
     assert_kind_of Turn::Consequences::SubPhasePopped, consequences.last
+    assert_equal Turn::SubPhases::TileBuildPhase::TYPE, consequences.last.prior_state["type"]
+    assert_equal "G", consequences.last.prior_state.dig("state", "restricted_terrain")
   end
 
   test "build with no active sub_phase returns Error" do

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+
+class TurnTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+
+    @player = @game.current_player
+    @player.update!(tiles: [ { "klass" => "FarmTile", "from" => "[3, 4]", "used" => false } ])
+    @game.reload
+  end
+
+  def turn = Turn.from_game(@game)
+
+  test "from_game with no sub_phase yields a turn with no sub_phase" do
+    assert_nil turn.sub_phase
+    assert_equal @player.order, turn.player_order
+  end
+
+  test "select_action(:farm) emits SubPhasePushed with TileBuildPhase state" do
+    consequences = turn.handle(:select_action, game: @game, tile: :farm)
+
+    assert_equal 1, consequences.size
+    pushed = consequences.first
+    assert_kind_of Turn::Consequences::SubPhasePushed, pushed
+    assert_equal Turn::SubPhases::TileBuildPhase::TYPE, pushed.phase_type
+    assert_equal "G", pushed.state["restricted_terrain"]
+    assert_equal "FarmTile", pushed.state["tile_klass"]
+    assert_equal "[3, 4]", pushed.state["tile_source"]
+  end
+
+  test "select_action(:farm) with no Farm tile returns Error" do
+    @player.update!(tiles: [])
+    @game.reload
+    consequences = turn.handle(:select_action, game: @game, tile: :farm)
+    assert_kind_of Turn::Consequences::Error, consequences.first
+  end
+
+  test "select_action(:farm) when Farm already used returns Error" do
+    @player.update!(tiles: [ { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true } ])
+    @game.reload
+    consequences = turn.handle(:select_action, game: @game, tile: :farm)
+    assert_kind_of Turn::Consequences::Error, consequences.first
+  end
+
+  test "select_action when sub_phase already active returns Error" do
+    @game.current_action = {
+      "turn" => {
+        "sub_phase" => {
+          "type" => Turn::SubPhases::TileBuildPhase::TYPE,
+          "state" => { "restricted_terrain" => "G", "tile_klass" => "FarmTile", "tile_source" => "[3, 4]" }
+        }
+      }
+    }
+    consequences = turn.handle(:select_action, game: @game, tile: :farm)
+    assert_kind_of Turn::Consequences::Error, consequences.first
+  end
+
+  test "build delegates to active sub_phase and appends SubPhasePopped on completion" do
+    @game.current_action = {
+      "turn" => {
+        "sub_phase" => {
+          "type" => Turn::SubPhases::TileBuildPhase::TYPE,
+          "state" => { "restricted_terrain" => "G", "tile_klass" => "FarmTile", "tile_source" => "[3, 4]" }
+        }
+      }
+    }
+    row, col = first_empty_grass
+    consequences = turn.handle(:build, game: @game, row:, col:)
+
+    assert(consequences.any? { |c| c.is_a?(Turn::Consequences::SettlementPlaced) })
+    assert(consequences.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) })
+    assert_kind_of Turn::Consequences::SubPhasePopped, consequences.last
+  end
+
+  test "build with no active sub_phase returns Error" do
+    consequences = turn.handle(:build, game: @game, row: 0, col: 0)
+    assert_kind_of Turn::Consequences::Error, consequences.first
+  end
+
+  test "build that errors does not append SubPhasePopped" do
+    @game.current_action = {
+      "turn" => {
+        "sub_phase" => {
+          "type" => Turn::SubPhases::TileBuildPhase::TYPE,
+          "state" => { "restricted_terrain" => "G", "tile_klass" => "FarmTile", "tile_source" => "[3, 4]" }
+        }
+      }
+    }
+    consequences = turn.handle(:build, game: @game, row: 0, col: 0) # likely not Grass
+    assert_kind_of Turn::Consequences::Error, consequences.first
+    refute(consequences.any? { |c| c.is_a?(Turn::Consequences::SubPhasePopped) })
+  end
+
+  test "unsupported action returns Error" do
+    consequences = turn.handle(:nonsense, game: @game)
+    assert_kind_of Turn::Consequences::Error, consequences.first
+  end
+
+  private
+
+  def first_empty_grass
+    20.times do |row|
+      20.times do |col|
+        next unless @game.board.terrain_at(row, col) == "G"
+        return [ row, col ] if @game.board_contents.empty?(row, col)
+      end
+    end
+    raise "no empty grass hex"
+  end
+end

--- a/test/services/broadcaster_test.rb
+++ b/test/services/broadcaster_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+require "turbo/broadcastable/test_helper"
+
+class BroadcasterTest < ActiveSupport::TestCase
+  include Turbo::Broadcastable::TestHelper
+
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+  end
+
+  def player(order) = @game.game_players.find { |gp| gp.order == order }
+
+  test "no consequences ⇒ no plans" do
+    assert_empty Broadcaster.new(@game, []).plans
+  end
+
+  test "SettlementPlaced ⇒ board + turn-state plans" do
+    plans = Broadcaster.new(@game, [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    ]).plans
+    targets = plans.map(&:target)
+    assert_includes targets, "board"
+    assert_includes targets, "turn-state"
+  end
+
+  test "SubPhasePushed alone ⇒ turn-state plan only" do
+    plans = Broadcaster.new(@game, [
+      Turn::Consequences::SubPhasePushed.new(phase_type: "tile_build", state: {})
+    ]).plans
+    targets = plans.map(&:target)
+    assert_includes targets, "turn-state"
+    refute_includes targets, "board"
+  end
+
+  test "TileConsumed for player 0 ⇒ that player's panel only" do
+    plans = Broadcaster.new(@game, [
+      Turn::Consequences::TileConsumed.new(klass: "FarmTile", player: 0)
+    ]).plans
+    panel_targets = plans.map(&:target).grep(/\Agame_player_/)
+    assert_equal [ "game_player_#{player(0).id}" ], panel_targets
+  end
+
+  test "deduplicates within one publish — board appears at most once" do
+    plans = Broadcaster.new(@game, [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G"),
+      Turn::Consequences::TilePickedUp.new(from: Coordinate.new(3, 4), klass: "OracleTile", player: 0)
+    ]).plans
+    assert_equal 1, plans.count { |p| p.target == "board" }
+    assert_equal 1, plans.count { |p| p.target == "turn-state" }
+  end
+
+  test "publish actually emits Turbo Streams to the planned channels" do
+    consequences = [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    ]
+    assert_turbo_stream_broadcasts("game_#{@game.id}") do
+      Broadcaster.publish(@game, consequences)
+    end
+  end
+end

--- a/test/services/consequence_applier_test.rb
+++ b/test/services/consequence_applier_test.rb
@@ -82,4 +82,39 @@ class ConsequenceApplierTest < ActiveSupport::TestCase
     @game.reload
     assert_nil @game.current_action.dig("turn", "sub_phase")
   end
+
+  test "unapply! reverses a single SettlementPlaced and persists" do
+    before = player(0).settlements_remaining
+    cs = [ Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G") ]
+    ConsequenceApplier.apply!(@game, cs)
+    ConsequenceApplier.unapply!(@game.reload, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(5, 7)
+    assert_equal before, player(0).reload.settlements_remaining
+  end
+
+  test "unapply! reverses consequences in reverse order" do
+    @game.board_contents.place_tile(3, 4, "OracleTile", 2)
+    @game.save!
+
+    cs = [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G"),
+      Turn::Consequences::TilePickedUp.new(from: Coordinate.new(3, 4), klass: "OracleTile", player: 0)
+    ]
+    ConsequenceApplier.apply!(@game, cs)
+    ConsequenceApplier.unapply!(@game.reload, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(5, 7)
+    assert_equal 2, @game.board_contents.tile_qty(3, 4)
+    refute(player(0).reload.tiles.any? { |t| t["klass"] == "OracleTile" })
+  end
+
+  test "unapply! is safe with Error consequences" do
+    cs = [ Turn::Consequences::Error.new(message: "nope") ]
+    assert_nothing_raised { ConsequenceApplier.unapply!(@game, cs) }
+  end
 end

--- a/test/services/consequence_applier_test.rb
+++ b/test/services/consequence_applier_test.rb
@@ -78,7 +78,7 @@ class ConsequenceApplierTest < ActiveSupport::TestCase
     @game.reload
     assert_equal "tile_build", @game.current_action.dig("turn", "sub_phase", "type")
 
-    ConsequenceApplier.apply!(@game, [ Turn::Consequences::SubPhasePopped.new ])
+    ConsequenceApplier.apply!(@game, [ Turn::Consequences::SubPhasePopped.new(prior_state: { "type" => "tile_build", "state" => {} }) ])
     @game.reload
     assert_nil @game.current_action.dig("turn", "sub_phase")
   end

--- a/test/services/consequence_applier_test.rb
+++ b/test/services/consequence_applier_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class ConsequenceApplierTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+  end
+
+  def player(order) = @game.game_players.find { |gp| gp.order == order }
+
+  test "applies a single SettlementPlaced and persists board + supply" do
+    before = player(0).settlements_remaining
+    ConsequenceApplier.apply!(@game, [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    ])
+
+    @game.reload
+    assert_equal 0, @game.board_contents.player_at(5, 7)
+    assert_equal before - 1, player(0).reload.settlements_remaining
+  end
+
+  test "applies consequences in order" do
+    @game.board_contents.place_tile(3, 4, "OracleTile", 2)
+
+    ConsequenceApplier.apply!(@game, [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G"),
+      Turn::Consequences::TilePickedUp.new(from: Coordinate.new(3, 4), klass: "OracleTile", player: 0)
+    ])
+
+    @game.reload
+    assert_equal 0, @game.board_contents.player_at(5, 7)
+    assert_equal 1, @game.board_contents.tile_qty(3, 4)
+    assert(player(0).reload.tiles.any? { |t| t["klass"] == "OracleTile" })
+  end
+
+  test "raises ApplyError if any consequence is an Error and rolls back" do
+    before = player(0).settlements_remaining
+
+    assert_raises(ConsequenceApplier::ApplyError) do
+      ConsequenceApplier.apply!(@game, [
+        Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G"),
+        Turn::Consequences::Error.new(message: "nope")
+      ])
+    end
+
+    @game.reload
+    assert @game.board_contents.empty?(5, 7)
+    assert_equal before, player(0).reload.settlements_remaining
+  end
+
+  test "rolls back when an apply! raises mid-stream" do
+    @game.board_contents.place_tile(3, 4, "OracleTile", 0)
+    before = player(0).settlements_remaining
+
+    assert_raises(StandardError) do
+      ConsequenceApplier.apply!(@game, [
+        Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G"),
+        Turn::Consequences::TilePickedUp.new(from: Coordinate.new(3, 4), klass: "OracleTile", player: 0)
+      ])
+    end
+
+    @game.reload
+    assert @game.board_contents.empty?(5, 7)
+    assert_equal before, player(0).reload.settlements_remaining
+  end
+
+  test "persists SubPhasePushed and SubPhasePopped" do
+    ConsequenceApplier.apply!(@game, [
+      Turn::Consequences::SubPhasePushed.new(
+        phase_type: Turn::SubPhases::TileBuildPhase::TYPE,
+        state: { "restricted_terrain" => "G", "tile_klass" => "FarmTile", "tile_source" => "[3, 4]" }
+      )
+    ])
+    @game.reload
+    assert_equal "tile_build", @game.current_action.dig("turn", "sub_phase", "type")
+
+    ConsequenceApplier.apply!(@game, [ Turn::Consequences::SubPhasePopped.new ])
+    @game.reload
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+  end
+end

--- a/test/services/turn_round_trip_test.rb
+++ b/test/services/turn_round_trip_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class TurnRoundTripTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+
+    @player = @game.current_player
+    @player.update!(tiles: [ { "klass" => "FarmTile", "from" => "[3, 4]", "used" => false } ])
+    @game.board_contents.place_tile(3, 4, "FarmTile", 1)
+    @game.save!
+  end
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        {
+          order: g.order,
+          supply: g.settlements_remaining,
+          tiles: g.tiles&.deep_dup,
+          taken_from: g.taken_from&.dup
+        }
+      }
+    }
+  end
+
+  test "select_action then build round-trips back to the starting snapshot" do
+    before = snapshot
+
+    turn = Turn.from_game(@game)
+    cs1 = turn.handle(:select_action, game: @game, tile: :farm)
+    ConsequenceApplier.apply!(@game, cs1)
+
+    @game.reload
+    @game.instantiate
+    turn = Turn.from_game(@game)
+    row, col = first_empty_grass
+    cs2 = turn.handle(:build, game: @game, row: row, col: col)
+    ConsequenceApplier.apply!(@game, cs2)
+
+    all_consequences = cs1 + cs2
+    ConsequenceApplier.unapply!(@game.reload, all_consequences)
+
+    assert_equal before, snapshot
+  end
+
+  private
+
+  def first_empty_grass
+    20.times do |row|
+      20.times do |col|
+        next unless @game.board.terrain_at(row, col) == "G"
+        return [ row, col ] if @game.board_contents.empty?(row, col)
+      end
+    end
+    raise "no empty grass hex"
+  end
+end


### PR DESCRIPTION
## Summary

Slice 2 of the TurnEngine deepening project. Adds `unapply!` to every `Turn::Consequence` value object so a click block (the consequences produced by one `Turn#handle` call) can be reversed in a transaction. The schema-pressure of writing inverses surfaced 3 real consequence-schema gaps.

**Note:** This PR also includes slice 1 (commit `a162256`) since it has not been merged to `main` yet.

## Slice 2 changes

- `Error.unapply!` is a no-op (errors raise; never apply).
- `SettlementPlaced.unapply!` removes the settlement and increments supply.
- `TileConsumed.unapply!` marks the tile unused.
- `TilePickedUp.unapply!` increments the source-hex qty, surgically pops the *last* matching `(klass, from)` tile from the player's hand, and restores `taken_from` to `nil` when it drains empty.
- `SubPhasePushed.unapply!` deletes the `"turn"` key it created.
- `SubPhasePopped` gained a `prior_state` field so it can be inverted; `Turn#handle_build` now populates it.
- `ConsequenceApplier.unapply!` runs `unapply!` on each consequence in reverse order inside a single DB transaction.
- `test/services/turn_round_trip_test.rb` drives the Farm flow forward then back and asserts byte-equivalence to the pre-apply snapshot.

## Schema-pressure findings (the whole point)

1. `SubPhasePopped` was stateless — couldn't be inverted at all without a `prior_state` field.
2. `SubPhasePushed.unapply!` initially nil-ed `sub_phase` but left the `"turn"` key — corrected to `delete("turn")`.
3. `TilePickedUp.unapply!` initially used `remove_tile_from!` which deleted *all* tiles with that source key — destroyed the player's pre-existing tile when it shared a source with the picked-up one. Replaced with a surgical `rindex` pop.

## Out of scope (intentional)

- Click-block persistence (where the consequence log lives across requests). Slice 2 stays library-only — undo is exercised by passing the consequence list directly to the applier in tests. Persistence is the gating decision for slice 3 before further phase extraction.
- Controller wiring for an undo endpoint.
- Parity with the legacy `TurnEngine#undo_last_move`.

## Test plan

- [ ] `bin/rails test` — full suite green (831 runs, 0 failures locally)
- [ ] Skim the round-trip test (`test/services/turn_round_trip_test.rb`) — this is the regression net for any future consequence type added to the Farm flow without a complete inverse

🤖 Generated with [Claude Code](https://claude.com/claude-code)