### PR TITLE
Turn engine deepening: slice 3a — TurnClick persistence + consequence serialization

### DIFF
--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -1,4 +1,16 @@
 class Turn
   module Consequences
+    def self.from_h(hash)
+      klass = case hash["type"]
+              when "error" then Error
+              when "settlement_placed" then SettlementPlaced
+              when "tile_consumed" then TileConsumed
+              when "tile_picked_up" then TilePickedUp
+              when "sub_phase_pushed" then SubPhasePushed
+              when "sub_phase_popped" then SubPhasePopped
+              else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
+              end
+      klass.from_h(hash)
+    end
   end
 end

--- a/app/models/turn/consequences/error.rb
+++ b/app/models/turn/consequences/error.rb
@@ -8,6 +8,14 @@ class Turn
       end
 
       def error? = true
+
+      def to_h
+        { "type" => "error", "message" => message }
+      end
+
+      def self.from_h(h)
+        new(message: h["message"])
+      end
     end
   end
 end

--- a/app/models/turn/consequences/settlement_placed.rb
+++ b/app/models/turn/consequences/settlement_placed.rb
@@ -12,6 +12,14 @@ class Turn
         game.board_contents.remove(at.row, at.col)
         game.game_players.find { |gp| gp.order == player }.increment_supply!
       end
+
+      def to_h
+        { "type" => "settlement_placed", "at" => at.to_key, "player" => player, "terrain" => terrain }
+      end
+
+      def self.from_h(h)
+        new(at: Coordinate.from_key(h["at"]), player: h["player"], terrain: h["terrain"])
+      end
     end
   end
 end

--- a/app/models/turn/consequences/sub_phase_popped.rb
+++ b/app/models/turn/consequences/sub_phase_popped.rb
@@ -11,6 +11,14 @@ class Turn
         game.current_action["turn"] ||= {}
         game.current_action["turn"]["sub_phase"] = prior_state
       end
+
+      def to_h
+        { "type" => "sub_phase_popped", "prior_state" => prior_state }
+      end
+
+      def self.from_h(h)
+        new(prior_state: h["prior_state"])
+      end
     end
   end
 end

--- a/app/models/turn/consequences/sub_phase_pushed.rb
+++ b/app/models/turn/consequences/sub_phase_pushed.rb
@@ -11,6 +11,14 @@ class Turn
         return unless game.current_action.is_a?(Hash)
         game.current_action.delete("turn")
       end
+
+      def to_h
+        { "type" => "sub_phase_pushed", "phase_type" => phase_type.to_s, "state" => state }
+      end
+
+      def self.from_h(h)
+        new(phase_type: h["phase_type"], state: h["state"])
+      end
     end
   end
 end

--- a/app/models/turn/consequences/tile_consumed.rb
+++ b/app/models/turn/consequences/tile_consumed.rb
@@ -8,6 +8,14 @@ class Turn
       def unapply!(game)
         game.game_players.find { |gp| gp.order == player }.mark_tile_unused!(klass)
       end
+
+      def to_h
+        { "type" => "tile_consumed", "klass" => klass, "player" => player }
+      end
+
+      def self.from_h(h)
+        new(klass: h["klass"], player: h["player"])
+      end
     end
   end
 end

--- a/app/models/turn/consequences/tile_picked_up.rb
+++ b/app/models/turn/consequences/tile_picked_up.rb
@@ -24,6 +24,14 @@ class Turn
 
         game.board_contents.increment_tile(from.row, from.col)
       end
+
+      def to_h
+        { "type" => "tile_picked_up", "from" => from.to_key, "klass" => klass, "player" => player }
+      end
+
+      def self.from_h(h)
+        new(from: Coordinate.from_key(h["from"]), klass: h["klass"], player: h["player"])
+      end
     end
   end
 end

--- a/app/models/turn_click.rb
+++ b/app/models/turn_click.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: turn_clicks
+#
+#  id           :bigint           not null, primary key
+#  consequences :json             not null
+#  order        :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  game_id      :bigint           not null
+#
+# Indexes
+#
+#  index_turn_clicks_on_game_id            (game_id)
+#  index_turn_clicks_on_game_id_and_order  (game_id,order) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (game_id => games.id)
+#
+class TurnClick < ApplicationRecord
+  belongs_to :game
+
+  scope :for_game, ->(game) { where(game: game).order(order: :desc) }
+
+  def self.most_recent_for(game)
+    for_game(game).first
+  end
+end

--- a/app/services/consequence_applier.rb
+++ b/app/services/consequence_applier.rb
@@ -12,8 +12,8 @@ class ConsequenceApplier
     new(game, consequences).apply!
   end
 
-  def self.unapply!(game, consequences)
-    new(game, consequences).unapply!
+  def self.unapply!(game)
+    new(game, []).unapply!
   end
 
   def initialize(game, consequences)
@@ -29,16 +29,30 @@ class ConsequenceApplier
       @consequences.each { |c| c.apply!(@game) }
       @game.save!
       @game.game_players.each(&:save!)
+      record_click!
     end
     @game
   end
 
   def unapply!
+    click = TurnClick.most_recent_for(@game)
+    return @game unless click
+
+    consequences = click.consequences.map { |h| Turn::Consequences.from_h(h) }
+
     Game.transaction do
-      @consequences.reverse_each { |c| c.unapply!(@game) }
+      consequences.reverse_each { |c| c.unapply!(@game) }
       @game.save!
       @game.game_players.each(&:save!)
+      click.destroy!
     end
     @game
+  end
+
+  private
+
+  def record_click!
+    next_order = (TurnClick.where(game_id: @game.id).maximum(:order) || 0) + 1
+    TurnClick.create!(game: @game, order: next_order, consequences: @consequences.map(&:to_h))
   end
 end

--- a/db/migrate/20260507214153_create_turn_clicks.rb
+++ b/db/migrate/20260507214153_create_turn_clicks.rb
@@ -1,0 +1,11 @@
+class CreateTurnClicks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :turn_clicks do |t|
+      t.references :game, null: false, foreign_key: true
+      t.integer :order, null: false
+      t.json :consequences, null: false, default: []
+      t.timestamps
+    end
+    add_index :turn_clicks, [ :game_id, :order ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_183402) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_07_214153) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -219,6 +219,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_183402) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  create_table "turn_clicks", force: :cascade do |t|
+    t.json "consequences", default: [], null: false
+    t.datetime "created_at", null: false
+    t.bigint "game_id", null: false
+    t.integer "order", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id", "order"], name: "index_turn_clicks_on_game_id_and_order", unique: true
+    t.index ["game_id"], name: "index_turn_clicks_on_game_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.boolean "approved", default: false
     t.datetime "created_at", null: false
@@ -241,4 +251,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_183402) do
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "turn_clicks", "games"
 end

--- a/test/models/turn/consequences/error_test.rb
+++ b/test/models/turn/consequences/error_test.rb
@@ -14,4 +14,10 @@ class Turn::Consequences::ErrorTest < ActiveSupport::TestCase
   test "error? is true" do
     assert Turn::Consequences::Error.new(message: "nope").error?
   end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::Error.new(message: "nope")
+    assert_equal({ "type" => "error", "message" => "nope" }, c.to_h)
+    assert_equal c, Turn::Consequences::Error.from_h(c.to_h)
+  end
 end

--- a/test/models/turn/consequences/settlement_placed_test.rb
+++ b/test/models/turn/consequences/settlement_placed_test.rb
@@ -51,6 +51,16 @@ class Turn::Consequences::SettlementPlacedTest < ActiveSupport::TestCase
     assert_equal before, player(1).settlements_remaining
   end
 
+  test "to_h round-trips through from_h" do
+    c = consequence(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    h = c.to_h
+    assert_equal "settlement_placed", h["type"]
+    assert_equal "[5, 7]", h["at"]
+    assert_equal 0, h["player"]
+    assert_equal "G", h["terrain"]
+    assert_equal c, Turn::Consequences::SettlementPlaced.from_h(h)
+  end
+
   test "equality is by value" do
     a = consequence(at: Coordinate.new(5, 7), player: 0, terrain: "G")
     b = consequence(at: Coordinate.new(5, 7), player: 0, terrain: "G")

--- a/test/models/turn/consequences/sub_phase_popped_test.rb
+++ b/test/models/turn/consequences/sub_phase_popped_test.rb
@@ -32,6 +32,14 @@ class Turn::Consequences::SubPhasePoppedTest < ActiveSupport::TestCase
     assert_equal @prior, @game.current_action.dig("turn", "sub_phase")
   end
 
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::SubPhasePopped.new(prior_state: @prior)
+    h = c.to_h
+    assert_equal "sub_phase_popped", h["type"]
+    assert_equal @prior, h["prior_state"]
+    assert_equal c, Turn::Consequences::SubPhasePopped.from_h(h)
+  end
+
   test "equality is by value" do
     a = Turn::Consequences::SubPhasePopped.new(prior_state: @prior)
     b = Turn::Consequences::SubPhasePopped.new(prior_state: @prior)

--- a/test/models/turn/consequences/sub_phase_pushed_test.rb
+++ b/test/models/turn/consequences/sub_phase_pushed_test.rb
@@ -25,6 +25,18 @@ class Turn::Consequences::SubPhasePushedTest < ActiveSupport::TestCase
     assert_not_nil @game.current_action.dig("turn", "sub_phase")
   end
 
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::SubPhasePushed.new(
+      phase_type: "tile_build",
+      state: { "restricted_terrain" => "G", "tile_klass" => "FarmTile" }
+    )
+    h = c.to_h
+    assert_equal "sub_phase_pushed", h["type"]
+    assert_equal "tile_build", h["phase_type"]
+    assert_equal({ "restricted_terrain" => "G", "tile_klass" => "FarmTile" }, h["state"])
+    assert_equal c, Turn::Consequences::SubPhasePushed.from_h(h)
+  end
+
   test "unapply! clears the active sub_phase" do
     c = Turn::Consequences::SubPhasePushed.new(
       phase_type: "tile_build",

--- a/test/models/turn/consequences/tile_consumed_test.rb
+++ b/test/models/turn/consequences/tile_consumed_test.rb
@@ -31,5 +31,11 @@ class Turn::Consequences::TileConsumedTest < ActiveSupport::TestCase
     refute_nil gp.tiles.find { |t| t["klass"] == "FarmTile" }
   end
 
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::TileConsumed.new(klass: "FarmTile", player: 0)
+    assert_equal({ "type" => "tile_consumed", "klass" => "FarmTile", "player" => 0 }, c.to_h)
+    assert_equal c, Turn::Consequences::TileConsumed.from_h(c.to_h)
+  end
+
   def player(order) = @game.game_players.find { |gp| gp.order == order }
 end

--- a/test/models/turn/consequences/tile_picked_up_test.rb
+++ b/test/models/turn/consequences/tile_picked_up_test.rb
@@ -50,6 +50,14 @@ class Turn::Consequences::TilePickedUpTest < ActiveSupport::TestCase
     refute(gp.tiles.any? { |t| t["klass"] == "FarmTile" && t["from"] == "[3, 4]" })
   end
 
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::TilePickedUp.new(from: Coordinate.new(3, 4), klass: "FarmTile", player: 0)
+    h = c.to_h
+    assert_equal "tile_picked_up", h["type"]
+    assert_equal "[3, 4]", h["from"]
+    assert_equal c, Turn::Consequences::TilePickedUp.from_h(h)
+  end
+
   test "unapply! pops the source coord from taken_from" do
     gp = player(0)
     gp.tiles = []

--- a/test/models/turn/consequences_test.rb
+++ b/test/models/turn/consequences_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class Turn::ConsequencesTest < ActiveSupport::TestCase
+  test "from_h dispatches on type discriminator" do
+    placed = Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    consumed = Turn::Consequences::TileConsumed.new(klass: "FarmTile", player: 0)
+    picked = Turn::Consequences::TilePickedUp.new(from: Coordinate.new(3, 4), klass: "FarmTile", player: 0)
+    pushed = Turn::Consequences::SubPhasePushed.new(phase_type: "tile_build", state: { "x" => "y" })
+    popped = Turn::Consequences::SubPhasePopped.new(prior_state: { "type" => "tile_build", "state" => {} })
+    err = Turn::Consequences::Error.new(message: "nope")
+
+    [ placed, consumed, picked, pushed, popped, err ].each do |c|
+      assert_equal c, Turn::Consequences.from_h(c.to_h)
+    end
+  end
+
+  test "from_h raises on unknown type" do
+    assert_raises(ArgumentError) do
+      Turn::Consequences.from_h({ "type" => "nonsense" })
+    end
+  end
+end

--- a/test/models/turn_click_test.rb
+++ b/test/models/turn_click_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class TurnClickTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+  end
+
+  test "stores a consequences array as JSON" do
+    click = TurnClick.create!(game: @game, order: 1, consequences: [ { "type" => "error", "message" => "x" } ])
+    assert_equal "x", click.reload.consequences.first["message"]
+  end
+
+  test "most_recent_for returns the highest-order click for the game" do
+    TurnClick.create!(game: @game, order: 1, consequences: [])
+    latest = TurnClick.create!(game: @game, order: 2, consequences: [])
+    other_game = games(:paula_turn_game)
+    TurnClick.create!(game: other_game, order: 99, consequences: [])
+
+    assert_equal latest, TurnClick.most_recent_for(@game)
+  end
+
+  test "order must be unique per game" do
+    TurnClick.create!(game: @game, order: 1, consequences: [])
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      TurnClick.create!(game: @game, order: 1, consequences: [])
+    end
+  end
+end

--- a/test/services/consequence_applier_test.rb
+++ b/test/services/consequence_applier_test.rb
@@ -85,9 +85,10 @@ class ConsequenceApplierTest < ActiveSupport::TestCase
 
   test "unapply! reverses a single SettlementPlaced and persists" do
     before = player(0).settlements_remaining
-    cs = [ Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G") ]
-    ConsequenceApplier.apply!(@game, cs)
-    ConsequenceApplier.unapply!(@game.reload, cs)
+    ConsequenceApplier.apply!(@game, [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    ])
+    ConsequenceApplier.unapply!(@game.reload)
 
     @game.reload
     @game.instantiate
@@ -99,12 +100,11 @@ class ConsequenceApplierTest < ActiveSupport::TestCase
     @game.board_contents.place_tile(3, 4, "OracleTile", 2)
     @game.save!
 
-    cs = [
+    ConsequenceApplier.apply!(@game, [
       Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G"),
       Turn::Consequences::TilePickedUp.new(from: Coordinate.new(3, 4), klass: "OracleTile", player: 0)
-    ]
-    ConsequenceApplier.apply!(@game, cs)
-    ConsequenceApplier.unapply!(@game.reload, cs)
+    ])
+    ConsequenceApplier.unapply!(@game.reload)
 
     @game.reload
     @game.instantiate
@@ -113,8 +113,54 @@ class ConsequenceApplierTest < ActiveSupport::TestCase
     refute(player(0).reload.tiles.any? { |t| t["klass"] == "OracleTile" })
   end
 
-  test "unapply! is safe with Error consequences" do
-    cs = [ Turn::Consequences::Error.new(message: "nope") ]
-    assert_nothing_raised { ConsequenceApplier.unapply!(@game, cs) }
+  test "unapply! is a no-op when there is no recorded click" do
+    assert_nothing_raised { ConsequenceApplier.unapply!(@game) }
+  end
+
+  test "apply! creates a TurnClick with the serialized consequences" do
+    assert_difference -> { TurnClick.count }, 1 do
+      ConsequenceApplier.apply!(@game, [
+        Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+      ])
+    end
+    click = TurnClick.most_recent_for(@game)
+    assert_equal 1, click.consequences.size
+    assert_equal "settlement_placed", click.consequences.first["type"]
+  end
+
+  test "apply! gives each click a monotonic order per game" do
+    ConsequenceApplier.apply!(@game, [ Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G") ])
+    ConsequenceApplier.apply!(@game, [ Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 8), player: 0, terrain: "G") ])
+    orders = TurnClick.where(game: @game).pluck(:order).sort
+    assert_equal [ 1, 2 ], orders
+  end
+
+  test "apply! does not create a TurnClick when an Error is in the list" do
+    assert_no_difference -> { TurnClick.count } do
+      assert_raises(ConsequenceApplier::ApplyError) do
+        ConsequenceApplier.apply!(@game, [ Turn::Consequences::Error.new(message: "x") ])
+      end
+    end
+  end
+
+  test "unapply! deletes the click record it consumed" do
+    ConsequenceApplier.apply!(@game, [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    ])
+    assert_difference -> { TurnClick.count }, -1 do
+      ConsequenceApplier.unapply!(@game.reload)
+    end
+  end
+
+  test "unapply! only consumes one click at a time" do
+    ConsequenceApplier.apply!(@game, [ Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G") ])
+    ConsequenceApplier.apply!(@game, [ Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 8), player: 0, terrain: "G") ])
+    ConsequenceApplier.unapply!(@game.reload)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(5, 8)
+    assert_equal 0, @game.board_contents.player_at(5, 7)
+    assert_equal 1, TurnClick.where(game: @game).count
   end
 end

--- a/test/services/turn_click_persistence_test.rb
+++ b/test/services/turn_click_persistence_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class TurnClickPersistenceTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+
+    @player = @game.current_player
+    @player.update!(tiles: [ { "klass" => "FarmTile", "from" => "[3, 4]", "used" => false } ])
+    @game.board_contents.place_tile(3, 4, "FarmTile", 1)
+    @game.save!
+  end
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.settlements_remaining, tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  test "Farm flow records two TurnClicks and unwinds across request boundaries" do
+    before = snapshot
+
+    turn = Turn.from_game(@game)
+    cs = turn.handle(:select_action, game: @game, tile: :farm)
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    turn = Turn.from_game(@game)
+    row, col = first_empty_grass
+    cs = turn.handle(:build, game: @game, row: row, col: col)
+    ConsequenceApplier.apply!(@game, cs)
+
+    assert_equal 2, TurnClick.where(game: @game).count
+
+    ConsequenceApplier.unapply!(@game.reload)
+    ConsequenceApplier.unapply!(@game.reload)
+
+    assert_equal 0, TurnClick.where(game: @game).count
+    assert_equal before, snapshot
+  end
+
+  private
+
+  def first_empty_grass
+    20.times do |row|
+      20.times do |col|
+        next unless @game.board.terrain_at(row, col) == "G"
+        return [ row, col ] if @game.board_contents.empty?(row, col)
+      end
+    end
+    raise "no empty grass hex"
+  end
+end

--- a/test/services/turn_round_trip_test.rb
+++ b/test/services/turn_round_trip_test.rb
@@ -46,8 +46,8 @@ class TurnRoundTripTest < ActiveSupport::TestCase
     cs2 = turn.handle(:build, game: @game, row: row, col: col)
     ConsequenceApplier.apply!(@game, cs2)
 
-    all_consequences = cs1 + cs2
-    ConsequenceApplier.unapply!(@game.reload, all_consequences)
+    ConsequenceApplier.unapply!(@game.reload)
+    ConsequenceApplier.unapply!(@game.reload)
 
     assert_equal before, snapshot
   end


### PR DESCRIPTION
## Summary

Slice 3a of the TurnEngine deepening project. Adds the persistence layer that future strangler slices will use: every successful `Turn#handle` call now writes a `TurnClick` row carrying its consequences as JSON; `ConsequenceApplier.unapply!(game)` reverses the most recent click by loading and destroying that row.

No new game logic. Library-only — no controller wiring.

## Decisions made

- **Persistence:** new `TurnClick < ApplicationRecord` model + migration. Rejected extending `Move` (would mix old-engine and new-engine rows in the same table) and stuffing into `current_action` (doesn't scale past one click).
- **Serialization:** each consequence gains symmetric `to_h` / `from_h(hash)`. Module-level `Turn::Consequences.from_h(hash)` dispatches by `"type"` discriminator. Coordinates round-trip via existing `to_key` / `Coordinate.from_key`.
- **Breaking change:** slice 2's `ConsequenceApplier.unapply!(game, consequences)` signature is replaced by `unapply!(game)` (loads from `TurnClick`). Slice 2 callers updated; no backward-compat shim per project convention.

## Out of scope (intentional)

- Any new game logic (no Mandatory build, no `end_turn`, no goals, no tile pickup beyond what slice 1 already had).
- Controller wiring or user-visible undo button.
- Touching the legacy `Move`-based undo. Old `TurnEngine#undo_last_move` keeps working untouched.
- Cross-stack undo.

## Files

- `db/migrate/20260507214153_create_turn_clicks.rb` + `app/models/turn_click.rb`
- `app/models/turn/consequences.rb` (factory)
- `app/models/turn/consequences/*.rb` × 6 (each gains `to_h`/`from_h`)
- `app/services/consequence_applier.rb` (writes click on apply!, loads on unapply!)
- New tests: `test/models/turn_click_test.rb`, `test/models/turn/consequences_test.rb`, `test/services/turn_click_persistence_test.rb`
- Existing tests updated for the new `unapply!(game)` signature

## Test plan

- [ ] `bin/rails test` — full suite green (848 runs locally, +17 new)
- [ ] Skim the E2E test (`test/services/turn_click_persistence_test.rb`) — drives the Farm flow forward then back across simulated request boundaries; this is the regression net for the persistence layer
- [ ] Note the breaking signature change to `ConsequenceApplier.unapply!` if any work-in-progress branches reference the old arity

🤖 Generated with [Claude Code](https://claude.com/claude-code)