### PR TITLE
Turn engine deepening: slice 3b — mandatory build (basic)

### DIFF
--- a/app/models/board_state.rb
+++ b/app/models/board_state.rb
@@ -82,6 +82,29 @@ class BoardState
     empty?(row, col) && !warrior_blocked?(row, col)
   end
 
+  def can_mandatory_build?(board, player_order, terrain, row, col)
+    return false unless available_for_building?(row, col)
+    return false unless board.terrain_at(row, col) == terrain
+
+    if any_player_adjacency_to_terrain?(board, player_order, terrain)
+      adjacent_to_player?(player_order, row, col)
+    else
+      true
+    end
+  end
+
+  def any_player_adjacency_to_terrain?(board, player_order, terrain)
+    settlements_for(player_order).any? do |sr, sc|
+      neighbors(sr, sc).any? do |nr, nc|
+        empty?(nr, nc) && board.terrain_at(nr, nc) == terrain && !warrior_blocked?(nr, nc)
+      end
+    end
+  end
+
+  def adjacent_to_player?(player_order, row, col)
+    neighbors(row, col).any? { |nr, nc| player_at(nr, nc) == player_order }
+  end
+
   def move_settlement(from_row, from_col, to_row, to_col)
     cell = @cells.delete([ from_row, from_col ])
     @cells[[ to_row, to_col ]] = cell

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -10,24 +10,29 @@
 # (and the legacy storage layer it serializes to) ever sees the "[r, c]"
 # string form.
 class Turn
-  attr_reader :player_order, :sub_phase
+  attr_reader :player_order, :sub_phase, :mandatory_remaining
 
-  def initialize(player_order:, sub_phase: nil)
+  DEFAULT_MANDATORY = 3
+
+  def initialize(player_order:, sub_phase: nil, mandatory_remaining: DEFAULT_MANDATORY)
     @player_order = player_order
     @sub_phase = sub_phase
+    @mandatory_remaining = mandatory_remaining
   end
 
   def self.from_game(game)
     raw = (game.current_action.is_a?(Hash) ? game.current_action["turn"] : nil) || {}
     new(
       player_order: game.current_player&.order,
-      sub_phase: parse_sub_phase(raw["sub_phase"])
+      sub_phase: parse_sub_phase(raw["sub_phase"]),
+      mandatory_remaining: raw.fetch("mandatory_remaining", DEFAULT_MANDATORY)
     )
   end
 
   def to_h
     {
-      "sub_phase" => sub_phase ? sub_phase_payload(sub_phase) : nil
+      "sub_phase" => sub_phase ? sub_phase_payload(sub_phase) : nil,
+      "mandatory_remaining" => mandatory_remaining
     }
   end
 
@@ -76,12 +81,37 @@ class Turn
   end
 
   def handle_build(game:, **params)
-    return [ error("no active sub-phase") ] unless sub_phase
+    if sub_phase
+      handle_sub_phase_build(game:, **params)
+    else
+      handle_mandatory_build(game:, **params)
+    end
+  end
 
+  def handle_sub_phase_build(game:, **params)
     prior_state = sub_phase_payload(sub_phase)
     consequences = sub_phase.handle(:build, game:, player_order:, **params)
     consequences << Turn::Consequences::SubPhasePopped.new(prior_state: prior_state) if sub_phase.complete?
     consequences
+  end
+
+  def handle_mandatory_build(game:, row:, col:)
+    return [ error("no builds remaining this turn") ] if mandatory_remaining <= 0
+
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+
+    terrain = gp.hand&.first
+    return [ error("no terrain card in hand") ] unless terrain
+
+    game.instantiate
+    return [ error("not a valid mandatory build target") ] unless
+      game.board_contents.can_mandatory_build?(game.board, player_order, terrain, row, col)
+
+    [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: terrain),
+      Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: mandatory_remaining)
+    ]
   end
 
   def error(msg)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -8,6 +8,7 @@ class Turn
               when "tile_picked_up" then TilePickedUp
               when "sub_phase_pushed" then SubPhasePushed
               when "sub_phase_popped" then SubPhasePopped
+              when "mandatory_remaining_decremented" then MandatoryRemainingDecremented
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences/mandatory_remaining_decremented.rb
+++ b/app/models/turn/consequences/mandatory_remaining_decremented.rb
@@ -1,0 +1,25 @@
+class Turn
+  module Consequences
+    MandatoryRemainingDecremented = Data.define(:prior_remaining) do
+      def apply!(game)
+        game.current_action ||= {}
+        game.current_action["turn"] ||= {}
+        game.current_action["turn"]["mandatory_remaining"] = prior_remaining - 1
+      end
+
+      def unapply!(game)
+        game.current_action ||= {}
+        game.current_action["turn"] ||= {}
+        game.current_action["turn"]["mandatory_remaining"] = prior_remaining
+      end
+
+      def to_h
+        { "type" => "mandatory_remaining_decremented", "prior_remaining" => prior_remaining }
+      end
+
+      def self.from_h(h)
+        new(prior_remaining: h["prior_remaining"])
+      end
+    end
+  end
+end

--- a/test/models/board_state_test.rb
+++ b/test/models/board_state_test.rb
@@ -267,4 +267,60 @@ class BoardStateTest < ActiveSupport::TestCase
     state.place_ship(3, 4, 0)
     assert_includes state.settlements_for(0), [ 3, 4 ]
   end
+
+  # can_mandatory_build? — Kingdom Builder mandatory adjacency rule.
+  # Use a minimal Board stub that returns whatever terrain we want per-coordinate.
+  class TerrainStub
+    def initialize(default: "G", overrides: {})
+      @default = default
+      @overrides = overrides
+    end
+    def terrain_at(row, col) = @overrides[[ row, col ]] || @default
+  end
+
+  test "can_mandatory_build? allows any empty matching-terrain hex when player has no adjacencies" do
+    state = BoardState.new
+    board = TerrainStub.new(default: "G")
+    assert state.can_mandatory_build?(board, 0, "G", 5, 5)
+  end
+
+  test "can_mandatory_build? rejects non-matching terrain" do
+    state = BoardState.new
+    board = TerrainStub.new(default: "G", overrides: { [ 5, 5 ] => "F" })
+    refute state.can_mandatory_build?(board, 0, "G", 5, 5)
+  end
+
+  test "can_mandatory_build? rejects occupied hex" do
+    state = BoardState.new
+    state.place_settlement(5, 5, 1)
+    board = TerrainStub.new(default: "G")
+    refute state.can_mandatory_build?(board, 0, "G", 5, 5)
+  end
+
+  test "can_mandatory_build? rejects warrior-blocked hex" do
+    state = BoardState.new
+    state.place_warrior(5, 5, 1)  # warrior at (5,5)
+    board = TerrainStub.new(default: "G")
+    # (5,4) is adjacent to the warrior and so is warrior-blocked
+    refute state.can_mandatory_build?(board, 0, "G", 5, 4)
+  end
+
+  test "can_mandatory_build? requires adjacency once a player adjacency exists" do
+    state = BoardState.new
+    state.place_settlement(5, 5, 0)  # player 0 has a settlement
+    board = TerrainStub.new(default: "G")
+    # An adjacent G hex is buildable; a far G hex is not.
+    adj_r, adj_c = state.neighbors(5, 5).first
+    far_r, far_c = 15, 15
+    assert state.can_mandatory_build?(board, 0, "G", adj_r, adj_c)
+    refute state.can_mandatory_build?(board, 0, "G", far_r, far_c)
+  end
+
+  test "can_mandatory_build? ignores other players' adjacencies" do
+    state = BoardState.new
+    state.place_settlement(5, 5, 1)  # opponent settlement only
+    board = TerrainStub.new(default: "G")
+    # Player 0 has no adjacencies, so any G hex is buildable.
+    assert state.can_mandatory_build?(board, 0, "G", 15, 15)
+  end
 end

--- a/test/models/turn/consequences/mandatory_remaining_decremented_test.rb
+++ b/test/models/turn/consequences/mandatory_remaining_decremented_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class Turn::Consequences::MandatoryRemainingDecrementedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+  end
+
+  test "apply! decrements current_action.turn.mandatory_remaining" do
+    @game.current_action = { "turn" => { "mandatory_remaining" => 3 } }
+    Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: 3).apply!(@game)
+    assert_equal 2, @game.current_action.dig("turn", "mandatory_remaining")
+  end
+
+  test "apply! creates the turn key when missing" do
+    @game.current_action = nil
+    Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: 3).apply!(@game)
+    assert_equal 2, @game.current_action.dig("turn", "mandatory_remaining")
+  end
+
+  test "unapply! restores prior_remaining" do
+    @game.current_action = { "turn" => { "mandatory_remaining" => 3 } }
+    c = Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: 3)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal 3, @game.current_action.dig("turn", "mandatory_remaining")
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: 3)
+    assert_equal({ "type" => "mandatory_remaining_decremented", "prior_remaining" => 3 }, c.to_h)
+    assert_equal c, Turn::Consequences::MandatoryRemainingDecremented.from_h(c.to_h)
+  end
+
+  test "equality is by value" do
+    a = Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: 3)
+    b = Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: 3)
+    assert_equal a, b
+  end
+end

--- a/test/models/turn/consequences_test.rb
+++ b/test/models/turn/consequences_test.rb
@@ -7,9 +7,10 @@ class Turn::ConsequencesTest < ActiveSupport::TestCase
     picked = Turn::Consequences::TilePickedUp.new(from: Coordinate.new(3, 4), klass: "FarmTile", player: 0)
     pushed = Turn::Consequences::SubPhasePushed.new(phase_type: "tile_build", state: { "x" => "y" })
     popped = Turn::Consequences::SubPhasePopped.new(prior_state: { "type" => "tile_build", "state" => {} })
+    decremented = Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: 3)
     err = Turn::Consequences::Error.new(message: "nope")
 
-    [ placed, consumed, picked, pushed, popped, err ].each do |c|
+    [ placed, consumed, picked, pushed, popped, decremented, err ].each do |c|
       assert_equal c, Turn::Consequences.from_h(c.to_h)
     end
   end

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -79,9 +79,49 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal "G", consequences.last.prior_state.dig("state", "restricted_terrain")
   end
 
-  test "build with no active sub_phase returns Error" do
-    consequences = turn.handle(:build, game: @game, row: 0, col: 0)
-    assert_kind_of Turn::Consequences::Error, consequences.first
+  test "from_game defaults mandatory_remaining to 3 when current_action is empty" do
+    @game.current_action = {}
+    assert_equal 3, Turn.from_game(@game).mandatory_remaining
+  end
+
+  test "from_game reads mandatory_remaining from current_action.turn" do
+    @game.current_action = { "turn" => { "mandatory_remaining" => 1 } }
+    assert_equal 1, Turn.from_game(@game).mandatory_remaining
+  end
+
+  test "build with no sub_phase emits SettlementPlaced + MandatoryRemainingDecremented" do
+    row, col = first_empty_terrain(@player.hand.first)
+    cs = turn.handle(:build, game: @game, row: row, col: col)
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::SettlementPlaced) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::MandatoryRemainingDecremented) })
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+  end
+
+  test "build errors when mandatory_remaining is 0" do
+    @game.current_action = { "turn" => { "mandatory_remaining" => 0 } }
+    row, col = first_empty_terrain(@player.hand.first)
+    cs = turn.handle(:build, game: @game, row: row, col: col)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "build errors when terrain does not match player hand" do
+    hand_terrain = @player.hand.first
+    row, col = first_empty_terrain_other_than(hand_terrain)
+    cs = turn.handle(:build, game: @game, row: row, col: col)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "build errors when target is not adjacency-valid" do
+    hand_terrain = @player.hand.first
+    seed = first_empty_terrain(hand_terrain)
+    @game.board_contents.place_settlement(seed[0], seed[1], 0)
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    far = first_empty_terrain_not_adjacent_to(seed, hand_terrain)
+    cs = turn.handle(:build, game: @game, row: far[0], col: far[1])
+    assert_kind_of Turn::Consequences::Error, cs.first
   end
 
   test "build that errors does not append SubPhasePopped" do
@@ -106,12 +146,42 @@ class TurnTest < ActiveSupport::TestCase
   private
 
   def first_empty_grass
+    first_empty_terrain("G")
+  end
+
+  def first_empty_terrain(terrain)
     20.times do |row|
       20.times do |col|
-        next unless @game.board.terrain_at(row, col) == "G"
+        next unless @game.board.terrain_at(row, col) == terrain
         return [ row, col ] if @game.board_contents.empty?(row, col)
       end
     end
-    raise "no empty grass hex"
+    raise "no empty #{terrain} hex"
+  end
+
+  def first_empty_terrain_other_than(terrain)
+    20.times do |row|
+      20.times do |col|
+        t = @game.board.terrain_at(row, col)
+        next if t.nil? || t == terrain
+        return [ row, col ] if @game.board_contents.empty?(row, col)
+      end
+    end
+    raise "no empty non-#{terrain} hex"
+  end
+
+  def first_empty_terrain_not_adjacent_to(seed, terrain)
+    seed_r, seed_c = seed
+    neighbor_set = @game.board_contents.neighbors(seed_r, seed_c).to_set
+    20.times do |r|
+      20.times do |c|
+        next unless @game.board.terrain_at(r, c) == terrain
+        next unless @game.board_contents.empty?(r, c)
+        next if [ r, c ] == seed
+        next if neighbor_set.include?([ r, c ])
+        return [ r, c ]
+      end
+    end
+    raise "no far #{terrain} hex"
   end
 end

--- a/test/services/turn_mandatory_build_test.rb
+++ b/test/services/turn_mandatory_build_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class TurnMandatoryBuildTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @hand_terrain = @player.hand.first
+  end
+
+  test "three mandatory builds each write a TurnClick and decrement remaining" do
+    targets = three_buildable_targets
+
+    targets.each_with_index do |(row, col), i|
+      turn = Turn.from_game(@game.reload)
+      @game.instantiate
+      assert_equal 3 - i, turn.mandatory_remaining
+      ConsequenceApplier.apply!(@game, turn.handle(:build, game: @game, row: row, col: col))
+    end
+
+    assert_equal 3, TurnClick.where(game: @game).count
+    assert_equal 0, Turn.from_game(@game.reload).mandatory_remaining
+  end
+
+  test "4th build errors and does not write a click" do
+    @game.current_action = { "turn" => { "mandatory_remaining" => 0 } }
+    @game.save!
+
+    target = first_buildable_hex
+    turn = Turn.from_game(@game.reload)
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+
+    assert_kind_of Turn::Consequences::Error, cs.first
+    assert_raises(ConsequenceApplier::ApplyError) do
+      ConsequenceApplier.apply!(@game, cs)
+    end
+    assert_equal 0, TurnClick.where(game: @game).count
+  end
+
+  test "three unapply! calls fully reverse three builds" do
+    targets = three_buildable_targets
+
+    targets.each do |(row, col)|
+      turn = Turn.from_game(@game.reload)
+      @game.instantiate
+      ConsequenceApplier.apply!(@game, turn.handle(:build, game: @game, row: row, col: col))
+    end
+
+    3.times { ConsequenceApplier.unapply!(@game.reload) }
+
+    @game.reload
+    @game.instantiate
+    assert_equal 0, TurnClick.where(game: @game).count
+    assert_equal 3, Turn.from_game(@game).mandatory_remaining
+    targets.each do |(row, col)|
+      assert_nil @game.board_contents.player_at(row, col)
+    end
+  end
+
+  private
+
+  def first_buildable_hex
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == @hand_terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no buildable #{@hand_terrain}"
+  end
+
+  # First build can land anywhere on the matching terrain; subsequent builds must
+  # be adjacent to a previous player(0) settlement on the same terrain. Walk the
+  # board picking the next valid target after each placement.
+  def three_buildable_targets
+    placed = []
+    targets = []
+    seed = first_buildable_hex
+    targets << seed
+    placed << seed
+
+    until targets.size == 3
+      next_target = adjacent_buildable_for(placed)
+      raise "could not find adjacency-valid third build" unless next_target
+      targets << next_target
+      placed << next_target
+    end
+    targets
+  end
+
+  def adjacent_buildable_for(placed)
+    placed.each do |pr, pc|
+      @game.board_contents.neighbors(pr, pc).each do |nr, nc|
+        next unless @game.board.terrain_at(nr, nc) == @hand_terrain
+        next unless @game.board_contents.empty?(nr, nc)
+        next if placed.include?([ nr, nc ])
+        return [ nr, nc ]
+      end
+    end
+    nil
+  end
+end


### PR DESCRIPTION
## Summary

Slice 3b of the TurnEngine deepening project. Adds basic mandatory-build to the new `Turn` stack: when no sub-phase is active, `Turn#handle(:build, row, col)` validates terrain match + KB adjacency, then emits `SettlementPlaced` + `MandatoryRemainingDecremented`. Three builds per turn, 4th errors. Library-only — no controller wiring.

**Note:** This PR also includes slice 3a (PR #195) since it has not been merged to `main` yet.

## Slice 3b changes

- New predicate: `BoardState#can_mandatory_build?(board, player_order, terrain, row, col)` — encodes the canonical Kingdom Builder rule (empty + matching terrain + not warrior-blocked + adjacency-required-when-any-adjacency-exists). Logic ported from `TurnEngine#available_list` but expressed as small composable predicates (`any_player_adjacency_to_terrain?`, `adjacent_to_player?`).
- New consequence: `MandatoryRemainingDecremented` carries `prior_remaining` for invertibility (same schema-pressure pattern as `SubPhasePopped.prior_state`).
- `Turn` gains a `mandatory_remaining` field (default 3) serialized to `current_action["turn"]["mandatory_remaining"]`.
- `Turn#handle(:build)` splits into `handle_sub_phase_build` and `handle_mandatory_build`; the mandatory path is ~10 lines.
- Factory updated to know about the new consequence type.

## Out of scope (intentional, deferred to later sub-slices)

- Tile pickup on adjacent location hexes → slice 3c
- Goal scoring (Ambassadors / Shepherds / Families) → slice 3d
- End-trigger detection + `end_turn` in the new stack → later
- Chosen-terrain locking (only matters once tiles substitute terrain — pairs with slice 3c)
- Outpost / Fort / other mandatory-phase modifiers
- Controller wiring. Old `TurnEngine#build_settlement` still owns the user-facing build flow.

## Test plan

- [ ] `bin/rails test` — full suite green (867 runs locally, +19 new)
- [ ] Skim `test/services/turn_mandatory_build_test.rb` — 3 builds + 4th rejection + 3-click unwind
- [ ] Skim `test/models/board_state_test.rb` predicate tests — they use a `TerrainStub` for fixture-independence

🤖 Generated with [Claude Code](https://claude.com/claude-code)