### PR TITLE
Turn engine deepening: slice 3 — full mandatory turn flow (3c–3h.1)

### DIFF
--- a/app/models/board_state.rb
+++ b/app/models/board_state.rb
@@ -175,6 +175,15 @@ class BoardState
     neighbors(row, col).select { |nr, nc| block.call(nr, nc) }
   end
 
+  def pickup_targets_for(row, col, taken_from)
+    neighbors(row, col).filter_map do |nr, nc|
+      next if tile_qty(nr, nc) <= 0
+      key = "[#{nr}, #{nc}]"
+      next if taken_from&.include?(key)
+      [ Coordinate.new(nr, nc), tile_klass(nr, nc) ]
+    end
+  end
+
   def locations_with_remaining_tiles
     @cells.filter_map { |(row, col), cell| [ row, col ] if cell["klass"] != "Settlement" && cell["qty"].to_i > 0 }
   end

--- a/app/models/board_state.rb
+++ b/app/models/board_state.rb
@@ -82,9 +82,10 @@ class BoardState
     empty?(row, col) && !warrior_blocked?(row, col)
   end
 
-  def can_mandatory_build?(board, player_order, terrain, row, col)
+  def can_mandatory_build?(board, player_order, terrain, row, col, skip_adjacency: false)
     return false unless available_for_building?(row, col)
     return false unless board.terrain_at(row, col) == terrain
+    return true if skip_adjacency
 
     if any_player_adjacency_to_terrain?(board, player_order, terrain)
       adjacent_to_player?(player_order, row, col)

--- a/app/models/board_state.rb
+++ b/app/models/board_state.rb
@@ -184,6 +184,19 @@ class BoardState
     end
   end
 
+  def ambassadors_match?(player_order, row, col)
+    neighbors(row, col).any? do |nr, nc|
+      p = player_at(nr, nc)
+      p && p != player_order
+    end
+  end
+
+  def shepherds_match?(board, terrain, row, col)
+    neighbors(row, col).none? do |nr, nc|
+      empty?(nr, nc) && board.terrain_at(nr, nc) == terrain
+    end
+  end
+
   def locations_with_remaining_tiles
     @cells.filter_map { |(row, col), cell| [ row, col ] if cell["klass"] != "Settlement" && cell["qty"].to_i > 0 }
   end

--- a/app/models/game_player.rb
+++ b/app/models/game_player.rb
@@ -108,6 +108,11 @@ class GamePlayer < ApplicationRecord
     supply["wagons"] = wagons_remaining + 1
   end
 
+  def adjust_meeple_supply!(kind, delta)
+    key = kind.pluralize
+    supply[key] = supply[key].to_i + delta
+  end
+
   def return_piece_to_supply!(meeple)
     case meeple
     when "warrior" then increment_warrior_supply!

--- a/app/models/tiles/barracks_tile.rb
+++ b/app/models/tiles/barracks_tile.rb
@@ -5,6 +5,7 @@ module Tiles
 
     def places_meeple? = true
     def meeple_kind    = "warrior"
+    def meeple_grant   = { "kind" => "warrior", "qty" => 2 }
 
     def on_pickup(game_player:)
       game_player.add_warriors!(2)

--- a/app/models/tiles/lighthouse_tile.rb
+++ b/app/models/tiles/lighthouse_tile.rb
@@ -5,6 +5,7 @@ module Tiles
 
     def places_meeple? = true
     def meeple_kind    = "ship"
+    def meeple_grant   = { "kind" => "ship", "qty" => 1 }
 
     def on_pickup(game_player:)
       game_player.add_ships!(1)

--- a/app/models/tiles/nomad/treasure_tile.rb
+++ b/app/models/tiles/nomad/treasure_tile.rb
@@ -3,6 +3,8 @@ module Tiles
     class TreasureTile < Tiles::NomadTile
       CREATOR = "Icon by Vector Place".freeze
       DESCRIPTION = "Immediately score 3 points when picked up.".freeze
+
+      def immediate_score = { "goal" => "treasure", "points" => 3 }
     end
   end
 end

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -80,6 +80,10 @@ module Tiles
     # Subclasses that grant meeples on pickup override this.
     def meeple_grant = nil
 
+    # Returns { "goal" => "...", "points" => n } or nil.
+    # Subclasses that score immediately on pickup (e.g. Treasure) override this.
+    def immediate_score = nil
+
     def on_pickup(game_player:)
       nil
     end

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -76,6 +76,10 @@ module Tiles
 
     def meeple_kind = nil
 
+    # Returns { "kind" => "warrior"|"ship"|"wagon", "qty" => n } or nil.
+    # Subclasses that grant meeples on pickup override this.
+    def meeple_grant = nil
+
     def on_pickup(game_player:)
       nil
     end

--- a/app/models/tiles/wagon_tile.rb
+++ b/app/models/tiles/wagon_tile.rb
@@ -7,6 +7,7 @@ module Tiles
 
     def places_meeple? = true
     def meeple_kind    = "wagon"
+    def meeple_grant   = { "kind" => "wagon", "qty" => 1 }
 
     def on_pickup(game_player:)
       game_player.add_wagons!(1)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -112,11 +112,20 @@ class Turn
       Turn::Consequences::TilePickedUp.new(from: coord, klass: klass, player: player_order)
     end
 
+    grants = pickups.flat_map { |pickup| meeple_grant_for(pickup) }
+
     [
       Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: terrain),
       *pickups,
+      *grants,
       Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: mandatory_remaining)
     ]
+  end
+
+  def meeple_grant_for(pickup)
+    grant = Tiles::Tile.for_klass(pickup.klass)&.new(0)&.meeple_grant
+    return [] unless grant
+    [ Turn::Consequences::MeepleGranted.new(player: player_order, kind: grant["kind"], qty: grant["qty"]) ]
   end
 
   def error(msg)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -227,6 +227,8 @@ class Turn
       case hash["type"]
       when Turn::SubPhases::TileBuildPhase::TYPE
         Turn::SubPhases::TileBuildPhase.from_h(hash["state"] || {})
+      when Turn::SubPhases::FortPhase::TYPE
+        Turn::SubPhases::FortPhase.from_h(hash["state"] || {})
       end
     end
 

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -108,8 +108,13 @@ class Turn
     return [ error("not a valid mandatory build target") ] unless
       game.board_contents.can_mandatory_build?(game.board, player_order, terrain, row, col)
 
+    pickups = game.board_contents.pickup_targets_for(row, col, gp.taken_from).map do |coord, klass|
+      Turn::Consequences::TilePickedUp.new(from: coord, klass: klass, player: player_order)
+    end
+
     [
       Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: terrain),
+      *pickups,
       Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: mandatory_remaining)
     ]
   end

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -10,14 +10,15 @@
 # (and the legacy storage layer it serializes to) ever sees the "[r, c]"
 # string form.
 class Turn
-  attr_reader :player_order, :sub_phase, :mandatory_remaining
+  attr_reader :player_order, :sub_phase, :mandatory_remaining, :builds_this_turn
 
   DEFAULT_MANDATORY = 3
 
-  def initialize(player_order:, sub_phase: nil, mandatory_remaining: DEFAULT_MANDATORY)
+  def initialize(player_order:, sub_phase: nil, mandatory_remaining: DEFAULT_MANDATORY, builds_this_turn: [])
     @player_order = player_order
     @sub_phase = sub_phase
     @mandatory_remaining = mandatory_remaining
+    @builds_this_turn = builds_this_turn
   end
 
   def self.from_game(game)
@@ -25,14 +26,16 @@ class Turn
     new(
       player_order: game.current_player&.order,
       sub_phase: parse_sub_phase(raw["sub_phase"]),
-      mandatory_remaining: raw.fetch("mandatory_remaining", DEFAULT_MANDATORY)
+      mandatory_remaining: raw.fetch("mandatory_remaining", DEFAULT_MANDATORY),
+      builds_this_turn: parse_builds(raw["builds"])
     )
   end
 
   def to_h
     {
       "sub_phase" => sub_phase ? sub_phase_payload(sub_phase) : nil,
-      "mandatory_remaining" => mandatory_remaining
+      "mandatory_remaining" => mandatory_remaining,
+      "builds_this_turn" => builds_this_turn.map { |r, c| Coordinate.new(r, c).to_key }
     }
   end
 
@@ -115,6 +118,7 @@ class Turn
     grants = pickups.flat_map { |pickup| meeple_grant_for(pickup) }
     immediate = pickups.flat_map { |pickup| immediate_score_for(pickup, gp) }
     goals = goal_scores_for(game, gp, terrain, row, col)
+    families = families_score_for(game, gp, row, col)
 
     [
       Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: terrain),
@@ -122,8 +126,34 @@ class Turn
       *grants,
       *immediate,
       *goals,
+      *families,
+      Turn::Consequences::BuildRecorded.new(at: Coordinate.new(row, col).to_key),
       Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: mandatory_remaining)
     ]
+  end
+
+  def families_score_for(game, gp, row, col)
+    return [] unless Array(game.goals).include?("families")
+    sequence = builds_this_turn + [ [ row, col ] ]
+    return [] unless sequence.size == 3
+    return [] unless straight_line?(sequence)
+    [ goal_scored(gp, "families", 2) ]
+  end
+
+  def straight_line?(positions)
+    a, b, c = positions
+    [ [ a, b, c ], [ a, c, b ], [ b, a, c ] ].any? { |p1, p2, p3| in_same_direction?(p1, p2, p3) }
+  end
+
+  def in_same_direction?(p1, p2, p3)
+    Tiles::PaddockTile::STRAIGHT_LINES.any? do |steps|
+      dr1, dc1 = steps[p1[0] % 2]
+      mid = [ p1[0] + dr1, p1[1] + dc1 ]
+      next false unless mid == p2
+      dr2, dc2 = steps[p2[0] % 2]
+      far = [ p2[0] + dr2, p2[1] + dc2 ]
+      far == p3
+    end
   end
 
   def goal_scores_for(game, gp, terrain, row, col)
@@ -178,6 +208,10 @@ class Turn
       when Turn::SubPhases::TileBuildPhase::TYPE
         Turn::SubPhases::TileBuildPhase.from_h(hash["state"] || {})
       end
+    end
+
+    def parse_builds(raw)
+      Array(raw).map { |key| coord = Coordinate.from_key(key); [ coord.row, coord.col ] }
     end
   end
 end

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -50,6 +50,8 @@ class Turn
       handle_build(game:, **params)
     when :activate_outpost
       handle_activate_outpost(game:)
+    when :activate_fort
+      handle_activate_fort(game:)
     else
       [ error("unsupported turn action: #{action_name}") ]
     end
@@ -101,6 +103,44 @@ class Turn
     consequences = sub_phase.handle(:build, game:, player_order:, **params)
     consequences << Turn::Consequences::SubPhasePopped.new(prior_state: prior_state) if sub_phase.complete?
     consequences
+  end
+
+  def handle_activate_fort(game:)
+    return [ error("a sub-phase is already active") ] if sub_phase
+
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+    return [ error("no unused FortTile") ] unless gp.find_unused_tile("FortTile")
+    return [ error("no settlements remaining") ] unless gp.settlements_remaining > 0
+
+    deck_before = (game.deck || []).dup
+    discard_before = (game.discard || []).dup
+    return [ error("deck is empty") ] if deck_before.empty? && discard_before.empty?
+
+    drawn = deck_before.first
+    remaining_deck = deck_before[1..]
+    if remaining_deck.empty?
+      remaining_deck = discard_before.shuffle
+      discard_after = [ drawn ]
+    else
+      discard_after = discard_before + [ drawn ]
+    end
+    deck_after = remaining_deck
+
+    pushed = Turn::SubPhases::FortPhase.new(fort_terrain: drawn, builds_remaining: 2)
+
+    [
+      Turn::Consequences::TileConsumed.new(klass: "FortTile", player: player_order),
+      Turn::Consequences::CardDrawn.new(
+        card: drawn,
+        deck_before: deck_before,
+        discard_before: discard_before,
+        deck_after: deck_after,
+        discard_after: discard_after
+      ),
+      Turn::Consequences::SubPhasePushed.new(phase_type: Turn::SubPhases::FortPhase::TYPE, state: pushed.to_h),
+      Turn::Consequences::IrreversibleBoundary.new
+    ]
   end
 
   def handle_activate_outpost(game:)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -10,15 +10,16 @@
 # (and the legacy storage layer it serializes to) ever sees the "[r, c]"
 # string form.
 class Turn
-  attr_reader :player_order, :sub_phase, :mandatory_remaining, :builds_this_turn
+  attr_reader :player_order, :sub_phase, :mandatory_remaining, :builds_this_turn, :outpost_active
 
   DEFAULT_MANDATORY = 3
 
-  def initialize(player_order:, sub_phase: nil, mandatory_remaining: DEFAULT_MANDATORY, builds_this_turn: [])
+  def initialize(player_order:, sub_phase: nil, mandatory_remaining: DEFAULT_MANDATORY, builds_this_turn: [], outpost_active: false)
     @player_order = player_order
     @sub_phase = sub_phase
     @mandatory_remaining = mandatory_remaining
     @builds_this_turn = builds_this_turn
+    @outpost_active = outpost_active
   end
 
   def self.from_game(game)
@@ -27,7 +28,8 @@ class Turn
       player_order: game.current_player&.order,
       sub_phase: parse_sub_phase(raw["sub_phase"]),
       mandatory_remaining: raw.fetch("mandatory_remaining", DEFAULT_MANDATORY),
-      builds_this_turn: parse_builds(raw["builds"])
+      builds_this_turn: parse_builds(raw["builds"]),
+      outpost_active: raw.fetch("outpost_active", false)
     )
   end
 
@@ -35,7 +37,8 @@ class Turn
     {
       "sub_phase" => sub_phase ? sub_phase_payload(sub_phase) : nil,
       "mandatory_remaining" => mandatory_remaining,
-      "builds_this_turn" => builds_this_turn.map { |r, c| Coordinate.new(r, c).to_key }
+      "builds_this_turn" => builds_this_turn.map { |r, c| Coordinate.new(r, c).to_key },
+      "outpost_active" => outpost_active
     }
   end
 
@@ -45,6 +48,8 @@ class Turn
       handle_select_action(game:, **params)
     when :build
       handle_build(game:, **params)
+    when :activate_outpost
+      handle_activate_outpost(game:)
     else
       [ error("unsupported turn action: #{action_name}") ]
     end
@@ -98,6 +103,19 @@ class Turn
     consequences
   end
 
+  def handle_activate_outpost(game:)
+    return [ error("outpost already active") ] if outpost_active
+
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+    return [ error("no unused OutpostTile") ] unless gp.find_unused_tile("OutpostTile")
+
+    [
+      Turn::Consequences::OutpostActivated.new(prior_active: outpost_active),
+      Turn::Consequences::TileConsumed.new(klass: "OutpostTile", player: player_order)
+    ]
+  end
+
   def handle_mandatory_build(game:, row:, col:)
     return [ error("no builds remaining this turn") ] if mandatory_remaining <= 0
 
@@ -109,7 +127,7 @@ class Turn
 
     game.instantiate
     return [ error("not a valid mandatory build target") ] unless
-      game.board_contents.can_mandatory_build?(game.board, player_order, terrain, row, col)
+      game.board_contents.can_mandatory_build?(game.board, player_order, terrain, row, col, skip_adjacency: outpost_active)
 
     pickups = game.board_contents.pickup_targets_for(row, col, gp.taken_from).map do |coord, klass|
       Turn::Consequences::TilePickedUp.new(from: coord, klass: klass, player: player_order)
@@ -119,6 +137,7 @@ class Turn
     immediate = pickups.flat_map { |pickup| immediate_score_for(pickup, gp) }
     goals = goal_scores_for(game, gp, terrain, row, col)
     families = families_score_for(game, gp, row, col)
+    outpost_consume = outpost_active ? [ Turn::Consequences::OutpostDeactivated.new(prior_active: true) ] : []
 
     [
       Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: terrain),
@@ -127,6 +146,7 @@ class Turn
       *immediate,
       *goals,
       *families,
+      *outpost_consume,
       Turn::Consequences::BuildRecorded.new(at: Coordinate.new(row, col).to_key),
       Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: mandatory_remaining)
     ]

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -113,11 +113,13 @@ class Turn
     end
 
     grants = pickups.flat_map { |pickup| meeple_grant_for(pickup) }
+    immediate = pickups.flat_map { |pickup| immediate_score_for(pickup, gp) }
 
     [
       Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: terrain),
       *pickups,
       *grants,
+      *immediate,
       Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: mandatory_remaining)
     ]
   end
@@ -126,6 +128,16 @@ class Turn
     grant = Tiles::Tile.for_klass(pickup.klass)&.new(0)&.meeple_grant
     return [] unless grant
     [ Turn::Consequences::MeepleGranted.new(player: player_order, kind: grant["kind"], qty: grant["qty"]) ]
+  end
+
+  def immediate_score_for(pickup, gp)
+    score = Tiles::Tile.for_klass(pickup.klass)&.new(0)&.immediate_score
+    return [] unless score
+    prior = gp.bonus_scores&.dig(score["goal"]) || 0
+    [
+      Turn::Consequences::GoalScored.new(player: player_order, goal: score["goal"], points: score["points"], prior_score: prior),
+      Turn::Consequences::TileDiscarded.new(player: player_order, klass: pickup.klass, from: pickup.from.to_key, used: true)
+    ]
   end
 
   def error(msg)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -114,14 +114,33 @@ class Turn
 
     grants = pickups.flat_map { |pickup| meeple_grant_for(pickup) }
     immediate = pickups.flat_map { |pickup| immediate_score_for(pickup, gp) }
+    goals = goal_scores_for(game, gp, terrain, row, col)
 
     [
       Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: terrain),
       *pickups,
       *grants,
       *immediate,
+      *goals,
       Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: mandatory_remaining)
     ]
+  end
+
+  def goal_scores_for(game, gp, terrain, row, col)
+    active = Array(game.goals)
+    out = []
+    if active.include?("ambassadors") && game.board_contents.ambassadors_match?(player_order, row, col)
+      out << goal_scored(gp, "ambassadors", 1)
+    end
+    if active.include?("shepherds") && game.board_contents.shepherds_match?(game.board, terrain, row, col)
+      out << goal_scored(gp, "shepherds", 2)
+    end
+    out
+  end
+
+  def goal_scored(gp, goal, points)
+    prior = gp.bonus_scores&.dig(goal) || 0
+    Turn::Consequences::GoalScored.new(player: player_order, goal: goal, points: points, prior_score: prior)
   end
 
   def meeple_grant_for(pickup)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -111,7 +111,7 @@ class Turn
     gp = game.game_players.find { |g| g.order == player_order }
     return [ error("no current player") ] unless gp
 
-    hand_before = (gp.hand || []).dup
+    hand_before = Array(gp.hand)
     deck_before = (game.deck || []).dup
     discard_before = (game.discard || []).dup
 

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -52,6 +52,8 @@ class Turn
       handle_activate_outpost(game:)
     when :activate_fort
       handle_activate_fort(game:)
+    when :end_turn
+      handle_end_turn(game:)
     else
       [ error("unsupported turn action: #{action_name}") ]
     end
@@ -103,6 +105,50 @@ class Turn
     consequences = sub_phase.handle(:build, game:, player_order:, **params)
     consequences << Turn::Consequences::SubPhasePopped.new(prior_state: prior_state) if sub_phase.complete?
     consequences
+  end
+
+  def handle_end_turn(game:)
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+
+    hand_before = (gp.hand || []).dup
+    deck_before = (game.deck || []).dup
+    discard_before = (game.discard || []).dup
+
+    # Discard the player's hand, then draw one card. If the deck is empty after
+    # the draw, reshuffle from discard. Randomness is decided here so the
+    # consequence carries deterministic before/after state.
+    discard_after = discard_before + hand_before
+    pool = deck_before
+    if pool.empty?
+      pool = discard_after.shuffle
+      discard_after = []
+    end
+    drawn = pool.first
+    deck_after = pool[1..]
+    if deck_after.empty? && discard_after.any?
+      deck_after = discard_after.shuffle
+      discard_after = []
+    end
+    hand_after = drawn.nil? ? [] : [ drawn ]
+
+    next_order = (player_order + 1) % game.game_players.count
+    prior_turn_state = game.current_action.is_a?(Hash) ? game.current_action["turn"] : nil
+
+    [
+      Turn::Consequences::HandRefreshed.new(
+        player: player_order,
+        hand_before: hand_before,
+        hand_after: hand_after,
+        deck_before: deck_before,
+        deck_after: deck_after,
+        discard_before: discard_before,
+        discard_after: discard_after
+      ),
+      Turn::Consequences::CurrentPlayerAdvanced.new(prior_order: player_order, next_order: next_order),
+      Turn::Consequences::TurnReset.new(prior_turn_number: game.turn_number, prior_turn_state: prior_turn_state),
+      Turn::Consequences::IrreversibleBoundary.new
+    ]
   end
 
   def handle_activate_fort(game:)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -13,6 +13,8 @@ class Turn
               when "goal_scored" then GoalScored
               when "tile_discarded" then TileDiscarded
               when "build_recorded" then BuildRecorded
+              when "outpost_activated" then OutpostActivated
+              when "outpost_deactivated" then OutpostDeactivated
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -19,6 +19,7 @@ class Turn
               when "card_drawn" then CardDrawn
               when "sub_phase_state_updated" then SubPhaseStateUpdated
               when "hand_refreshed" then HandRefreshed
+              when "current_player_advanced" then CurrentPlayerAdvanced
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -20,6 +20,7 @@ class Turn
               when "sub_phase_state_updated" then SubPhaseStateUpdated
               when "hand_refreshed" then HandRefreshed
               when "current_player_advanced" then CurrentPlayerAdvanced
+              when "turn_reset" then TurnReset
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -10,6 +10,7 @@ class Turn
               when "sub_phase_popped" then SubPhasePopped
               when "mandatory_remaining_decremented" then MandatoryRemainingDecremented
               when "meeple_granted" then MeepleGranted
+              when "goal_scored" then GoalScored
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -9,6 +9,7 @@ class Turn
               when "sub_phase_pushed" then SubPhasePushed
               when "sub_phase_popped" then SubPhasePopped
               when "mandatory_remaining_decremented" then MandatoryRemainingDecremented
+              when "meeple_granted" then MeepleGranted
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -15,6 +15,7 @@ class Turn
               when "build_recorded" then BuildRecorded
               when "outpost_activated" then OutpostActivated
               when "outpost_deactivated" then OutpostDeactivated
+              when "irreversible_boundary" then IrreversibleBoundary
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -17,6 +17,7 @@ class Turn
               when "outpost_deactivated" then OutpostDeactivated
               when "irreversible_boundary" then IrreversibleBoundary
               when "card_drawn" then CardDrawn
+              when "sub_phase_state_updated" then SubPhaseStateUpdated
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -18,6 +18,7 @@ class Turn
               when "irreversible_boundary" then IrreversibleBoundary
               when "card_drawn" then CardDrawn
               when "sub_phase_state_updated" then SubPhaseStateUpdated
+              when "hand_refreshed" then HandRefreshed
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -11,6 +11,7 @@ class Turn
               when "mandatory_remaining_decremented" then MandatoryRemainingDecremented
               when "meeple_granted" then MeepleGranted
               when "goal_scored" then GoalScored
+              when "tile_discarded" then TileDiscarded
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -16,6 +16,7 @@ class Turn
               when "outpost_activated" then OutpostActivated
               when "outpost_deactivated" then OutpostDeactivated
               when "irreversible_boundary" then IrreversibleBoundary
+              when "card_drawn" then CardDrawn
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -12,6 +12,7 @@ class Turn
               when "meeple_granted" then MeepleGranted
               when "goal_scored" then GoalScored
               when "tile_discarded" then TileDiscarded
+              when "build_recorded" then BuildRecorded
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences/build_recorded.rb
+++ b/app/models/turn/consequences/build_recorded.rb
@@ -1,0 +1,31 @@
+class Turn
+  module Consequences
+    BuildRecorded = Data.define(:at) do
+      def apply!(game)
+        game.current_action ||= {}
+        game.current_action["turn"] ||= {}
+        builds = game.current_action["turn"]["builds"] || []
+        game.current_action["turn"]["builds"] = builds + [ at ]
+      end
+
+      def unapply!(game)
+        return unless game.current_action.is_a?(Hash) && game.current_action["turn"].is_a?(Hash)
+        builds = (game.current_action["turn"]["builds"] || []).dup
+        builds.pop
+        if builds.empty?
+          game.current_action["turn"].delete("builds")
+        else
+          game.current_action["turn"]["builds"] = builds
+        end
+      end
+
+      def to_h
+        { "type" => "build_recorded", "at" => at }
+      end
+
+      def self.from_h(h)
+        new(at: h["at"])
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/card_drawn.rb
+++ b/app/models/turn/consequences/card_drawn.rb
@@ -1,0 +1,40 @@
+class Turn
+  module Consequences
+    # Records a deck draw as a complete state replacement: deck/discard before
+    # and after are both captured. Apply slams the *_after values; unapply
+    # restores the *_before values. Randomness (reshuffle) is decided at
+    # consequence-construction time, never at apply time.
+    CardDrawn = Data.define(:card, :deck_before, :discard_before, :deck_after, :discard_after) do
+      def apply!(game)
+        game.deck = deck_after.dup
+        game.discard = discard_after.dup
+      end
+
+      def unapply!(game)
+        game.deck = deck_before.dup
+        game.discard = discard_before.dup
+      end
+
+      def to_h
+        {
+          "type" => "card_drawn",
+          "card" => card,
+          "deck_before" => deck_before,
+          "discard_before" => discard_before,
+          "deck_after" => deck_after,
+          "discard_after" => discard_after
+        }
+      end
+
+      def self.from_h(h)
+        new(
+          card: h["card"],
+          deck_before: h["deck_before"],
+          discard_before: h["discard_before"],
+          deck_after: h["deck_after"],
+          discard_after: h["discard_after"]
+        )
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/current_player_advanced.rb
+++ b/app/models/turn/consequences/current_player_advanced.rb
@@ -1,0 +1,21 @@
+class Turn
+  module Consequences
+    CurrentPlayerAdvanced = Data.define(:prior_order, :next_order) do
+      def apply!(game)
+        game.current_player = game.game_players.find { |g| g.order == next_order }
+      end
+
+      def unapply!(game)
+        game.current_player = game.game_players.find { |g| g.order == prior_order }
+      end
+
+      def to_h
+        { "type" => "current_player_advanced", "prior_order" => prior_order, "next_order" => next_order }
+      end
+
+      def self.from_h(h)
+        new(prior_order: h["prior_order"], next_order: h["next_order"])
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/goal_scored.rb
+++ b/app/models/turn/consequences/goal_scored.rb
@@ -1,0 +1,34 @@
+class Turn
+  module Consequences
+    GoalScored = Data.define(:player, :goal, :points, :prior_score) do
+      def apply!(game)
+        bonus = gp(game).bonus_scores || {}
+        gp(game).bonus_scores = bonus.merge(goal => prior_score + points)
+      end
+
+      def unapply!(game)
+        bonus = (gp(game).bonus_scores || {}).dup
+        if prior_score.zero?
+          bonus.delete(goal)
+        else
+          bonus[goal] = prior_score
+        end
+        gp(game).bonus_scores = bonus
+      end
+
+      def to_h
+        { "type" => "goal_scored", "player" => player, "goal" => goal, "points" => points, "prior_score" => prior_score }
+      end
+
+      def self.from_h(h)
+        new(player: h["player"], goal: h["goal"], points: h["points"], prior_score: h["prior_score"])
+      end
+
+      private
+
+      def gp(game)
+        game.game_players.find { |g| g.order == player }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/hand_refreshed.rb
+++ b/app/models/turn/consequences/hand_refreshed.rb
@@ -1,0 +1,48 @@
+class Turn
+  module Consequences
+    HandRefreshed = Data.define(:player, :hand_before, :hand_after, :deck_before, :deck_after, :discard_before, :discard_after) do
+      def apply!(game)
+        gp(game).hand = hand_after.dup
+        game.deck = deck_after.dup
+        game.discard = discard_after.dup
+      end
+
+      def unapply!(game)
+        gp(game).hand = hand_before.dup
+        game.deck = deck_before.dup
+        game.discard = discard_before.dup
+      end
+
+      def to_h
+        {
+          "type" => "hand_refreshed",
+          "player" => player,
+          "hand_before" => hand_before,
+          "hand_after" => hand_after,
+          "deck_before" => deck_before,
+          "deck_after" => deck_after,
+          "discard_before" => discard_before,
+          "discard_after" => discard_after
+        }
+      end
+
+      def self.from_h(h)
+        new(
+          player: h["player"],
+          hand_before: h["hand_before"],
+          hand_after: h["hand_after"],
+          deck_before: h["deck_before"],
+          deck_after: h["deck_after"],
+          discard_before: h["discard_before"],
+          discard_after: h["discard_after"]
+        )
+      end
+
+      private
+
+      def gp(game)
+        game.game_players.find { |g| g.order == player }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/irreversible_boundary.rb
+++ b/app/models/turn/consequences/irreversible_boundary.rb
@@ -1,0 +1,23 @@
+class Turn
+  module Consequences
+    # Marker consequence: when present in a click's consequence list, the click
+    # is recorded with reversible: false. Apply/unapply are no-ops; the applier
+    # raises on attempting to unapply a non-reversible click.
+    class IrreversibleBoundary
+      def apply!(_game); end
+      def unapply!(_game); end
+
+      def to_h
+        { "type" => "irreversible_boundary" }
+      end
+
+      def self.from_h(_h)
+        new
+      end
+
+      def ==(other) = other.is_a?(IrreversibleBoundary)
+      def eql?(other) = self == other
+      def hash = self.class.hash
+    end
+  end
+end

--- a/app/models/turn/consequences/meeple_granted.rb
+++ b/app/models/turn/consequences/meeple_granted.rb
@@ -1,0 +1,27 @@
+class Turn
+  module Consequences
+    MeepleGranted = Data.define(:player, :kind, :qty) do
+      def apply!(game)
+        gp(game).adjust_meeple_supply!(kind, qty)
+      end
+
+      def unapply!(game)
+        gp(game).adjust_meeple_supply!(kind, -qty)
+      end
+
+      def to_h
+        { "type" => "meeple_granted", "player" => player, "kind" => kind, "qty" => qty }
+      end
+
+      def self.from_h(h)
+        new(player: h["player"], kind: h["kind"], qty: h["qty"])
+      end
+
+      private
+
+      def gp(game)
+        game.game_players.find { |g| g.order == player }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/outpost_activated.rb
+++ b/app/models/turn/consequences/outpost_activated.rb
@@ -1,0 +1,24 @@
+class Turn
+  module Consequences
+    OutpostActivated = Data.define(:prior_active) do
+      def apply!(game)
+        game.current_action ||= {}
+        game.current_action["turn"] ||= {}
+        game.current_action["turn"]["outpost_active"] = true
+      end
+
+      def unapply!(game)
+        return unless game.current_action.is_a?(Hash) && game.current_action["turn"].is_a?(Hash)
+        game.current_action["turn"]["outpost_active"] = prior_active
+      end
+
+      def to_h
+        { "type" => "outpost_activated", "prior_active" => prior_active }
+      end
+
+      def self.from_h(h)
+        new(prior_active: h["prior_active"])
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/outpost_activated.rb
+++ b/app/models/turn/consequences/outpost_activated.rb
@@ -9,7 +9,11 @@ class Turn
 
       def unapply!(game)
         return unless game.current_action.is_a?(Hash) && game.current_action["turn"].is_a?(Hash)
-        game.current_action["turn"]["outpost_active"] = prior_active
+        if prior_active
+          game.current_action["turn"]["outpost_active"] = true
+        else
+          game.current_action["turn"].delete("outpost_active")
+        end
       end
 
       def to_h

--- a/app/models/turn/consequences/outpost_deactivated.rb
+++ b/app/models/turn/consequences/outpost_deactivated.rb
@@ -1,0 +1,24 @@
+class Turn
+  module Consequences
+    OutpostDeactivated = Data.define(:prior_active) do
+      def apply!(game)
+        game.current_action ||= {}
+        game.current_action["turn"] ||= {}
+        game.current_action["turn"]["outpost_active"] = false
+      end
+
+      def unapply!(game)
+        return unless game.current_action.is_a?(Hash) && game.current_action["turn"].is_a?(Hash)
+        game.current_action["turn"]["outpost_active"] = prior_active
+      end
+
+      def to_h
+        { "type" => "outpost_deactivated", "prior_active" => prior_active }
+      end
+
+      def self.from_h(h)
+        new(prior_active: h["prior_active"])
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/sub_phase_state_updated.rb
+++ b/app/models/turn/consequences/sub_phase_state_updated.rb
@@ -1,0 +1,33 @@
+class Turn
+  module Consequences
+    # Replaces the active sub_phase's state in-place. Used when a multi-step
+    # sub-phase (like FortPhase across two builds) needs to persist a counter
+    # decrement without popping/re-pushing.
+    SubPhaseStateUpdated = Data.define(:prior_state, :new_state) do
+      def apply!(game)
+        return unless sub_phase(game)
+        sub_phase(game)["state"] = new_state
+      end
+
+      def unapply!(game)
+        return unless sub_phase(game)
+        sub_phase(game)["state"] = prior_state
+      end
+
+      def to_h
+        { "type" => "sub_phase_state_updated", "prior_state" => prior_state, "new_state" => new_state }
+      end
+
+      def self.from_h(h)
+        new(prior_state: h["prior_state"], new_state: h["new_state"])
+      end
+
+      private
+
+      def sub_phase(game)
+        return nil unless game.current_action.is_a?(Hash) && game.current_action["turn"].is_a?(Hash)
+        game.current_action["turn"]["sub_phase"]
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/tile_discarded.rb
+++ b/app/models/turn/consequences/tile_discarded.rb
@@ -1,0 +1,30 @@
+class Turn
+  module Consequences
+    TileDiscarded = Data.define(:player, :klass, :from, :used) do
+      def apply!(game)
+        tiles = (gp(game).tiles || []).dup
+        idx = tiles.index { |t| t["klass"] == klass && t["from"] == from }
+        tiles.delete_at(idx) if idx
+        gp(game).tiles = tiles
+      end
+
+      def unapply!(game)
+        gp(game).restore_tile!(klass, from: from, used: used)
+      end
+
+      def to_h
+        { "type" => "tile_discarded", "player" => player, "klass" => klass, "from" => from, "used" => used }
+      end
+
+      def self.from_h(h)
+        new(player: h["player"], klass: h["klass"], from: h["from"], used: h["used"])
+      end
+
+      private
+
+      def gp(game)
+        game.game_players.find { |g| g.order == player }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/turn_reset.rb
+++ b/app/models/turn/consequences/turn_reset.rb
@@ -1,0 +1,31 @@
+class Turn
+  module Consequences
+    # Marks the end of a turn: increments turn_number and clears the per-turn
+    # state under current_action["turn"]. The next player's turn starts fresh.
+    TurnReset = Data.define(:prior_turn_number, :prior_turn_state) do
+      def apply!(game)
+        game.turn_number = prior_turn_number + 1
+        game.current_action ||= {}
+        game.current_action.delete("turn")
+      end
+
+      def unapply!(game)
+        game.turn_number = prior_turn_number
+        game.current_action ||= {}
+        if prior_turn_state.nil?
+          game.current_action.delete("turn")
+        else
+          game.current_action["turn"] = prior_turn_state
+        end
+      end
+
+      def to_h
+        { "type" => "turn_reset", "prior_turn_number" => prior_turn_number, "prior_turn_state" => prior_turn_state }
+      end
+
+      def self.from_h(h)
+        new(prior_turn_number: h["prior_turn_number"], prior_turn_state: h["prior_turn_state"])
+      end
+    end
+  end
+end

--- a/app/models/turn/sub_phases/fort_phase.rb
+++ b/app/models/turn/sub_phases/fort_phase.rb
@@ -1,0 +1,60 @@
+class Turn
+  module SubPhases
+    class FortPhase < Turn::SubPhase
+      TYPE = "fort".freeze
+
+      attr_reader :fort_terrain, :builds_remaining
+
+      def initialize(fort_terrain:, builds_remaining: 2)
+        super()
+        @fort_terrain = fort_terrain
+        @builds_remaining = builds_remaining
+        @complete = false
+      end
+
+      def to_h
+        { "fort_terrain" => fort_terrain, "builds_remaining" => builds_remaining }
+      end
+
+      def self.from_h(hash)
+        new(fort_terrain: hash["fort_terrain"], builds_remaining: hash["builds_remaining"])
+      end
+
+      def handle(action_name, game:, player_order:, **params)
+        case action_name
+        when :build
+          handle_build(game:, player_order:, row: params[:row], col: params[:col])
+        else
+          [ Turn::Consequences::Error.new(message: "unsupported action: #{action_name}") ]
+        end
+      end
+
+      private
+
+      def handle_build(game:, player_order:, row:, col:)
+        game.instantiate_board unless game.board
+
+        return error("hex outside fort terrain #{fort_terrain}") unless game.board.terrain_at(row, col) == fort_terrain
+        return error("hex (#{row}, #{col}) is not empty") unless game.board_contents.empty?(row, col)
+
+        prior = to_h
+        @builds_remaining -= 1
+        @complete = (@builds_remaining <= 0)
+
+        consequences = [
+          Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: fort_terrain)
+        ]
+        # Only emit SubPhaseStateUpdated if not completing — the completion path
+        # emits SubPhasePopped at the Turn layer, which restores prior state on undo.
+        unless @complete
+          consequences << Turn::Consequences::SubPhaseStateUpdated.new(prior_state: prior, new_state: to_h)
+        end
+        consequences
+      end
+
+      def error(msg)
+        [ Turn::Consequences::Error.new(message: msg) ]
+      end
+    end
+  end
+end

--- a/app/models/turn_click.rb
+++ b/app/models/turn_click.rb
@@ -5,6 +5,7 @@
 #  id           :bigint           not null, primary key
 #  consequences :json             not null
 #  order        :integer          not null
+#  reversible   :boolean          default(TRUE), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  game_id      :bigint           not null

--- a/app/services/consequence_applier.rb
+++ b/app/services/consequence_applier.rb
@@ -8,6 +8,8 @@ class ConsequenceApplier
     end
   end
 
+  class NotReversibleError < StandardError; end
+
   def self.apply!(game, consequences)
     new(game, consequences).apply!
   end
@@ -37,6 +39,7 @@ class ConsequenceApplier
   def unapply!
     click = TurnClick.most_recent_for(@game)
     return @game unless click
+    raise NotReversibleError, "click ##{click.order} is non-reversible" unless click.reversible
 
     consequences = click.consequences.map { |h| Turn::Consequences.from_h(h) }
 
@@ -53,6 +56,7 @@ class ConsequenceApplier
 
   def record_click!
     next_order = (TurnClick.where(game_id: @game.id).maximum(:order) || 0) + 1
-    TurnClick.create!(game: @game, order: next_order, consequences: @consequences.map(&:to_h))
+    reversible = @consequences.none? { |c| c.is_a?(Turn::Consequences::IrreversibleBoundary) }
+    TurnClick.create!(game: @game, order: next_order, consequences: @consequences.map(&:to_h), reversible: reversible)
   end
 end

--- a/db/migrate/20260508031655_add_reversible_to_turn_clicks.rb
+++ b/db/migrate/20260508031655_add_reversible_to_turn_clicks.rb
@@ -1,0 +1,5 @@
+class AddReversibleToTurnClicks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :turn_clicks, :reversible, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_07_214153) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_031655) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -224,6 +224,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_214153) do
     t.datetime "created_at", null: false
     t.bigint "game_id", null: false
     t.integer "order", null: false
+    t.boolean "reversible", default: true, null: false
     t.datetime "updated_at", null: false
     t.index ["game_id", "order"], name: "index_turn_clicks_on_game_id_and_order", unique: true
     t.index ["game_id"], name: "index_turn_clicks_on_game_id"

--- a/test/models/board_state_test.rb
+++ b/test/models/board_state_test.rb
@@ -323,4 +323,47 @@ class BoardStateTest < ActiveSupport::TestCase
     # Player 0 has no adjacencies, so any G hex is buildable.
     assert state.can_mandatory_build?(board, 0, "G", 15, 15)
   end
+
+  # pickup_targets_for — adjacent location hexes with qty > 0 and not in taken_from.
+
+  test "pickup_targets_for returns adjacent location hexes with qty > 0" do
+    state = BoardState.new
+    nr, nc = state.neighbors(5, 5).first
+    state.place_tile(nr, nc, "FarmTile", 2)
+    targets = state.pickup_targets_for(5, 5, nil)
+    assert_equal 1, targets.size
+    coord, klass = targets.first
+    assert_equal Coordinate.new(nr, nc), coord
+    assert_equal "FarmTile", klass
+  end
+
+  test "pickup_targets_for skips hexes already in taken_from" do
+    state = BoardState.new
+    nr, nc = state.neighbors(5, 5).first
+    state.place_tile(nr, nc, "FarmTile", 2)
+    targets = state.pickup_targets_for(5, 5, [ "[#{nr}, #{nc}]" ])
+    assert_empty targets
+  end
+
+  test "pickup_targets_for skips hexes with qty 0" do
+    state = BoardState.new
+    nr, nc = state.neighbors(5, 5).first
+    state.place_tile(nr, nc, "FarmTile", 0)
+    assert_empty state.pickup_targets_for(5, 5, nil)
+  end
+
+  test "pickup_targets_for skips settlement neighbors (non-tile cells)" do
+    state = BoardState.new
+    nr, nc = state.neighbors(5, 5).first
+    state.place_settlement(nr, nc, 0)
+    assert_empty state.pickup_targets_for(5, 5, nil)
+  end
+
+  test "pickup_targets_for handles multiple adjacent tiles" do
+    state = BoardState.new
+    nbrs = state.neighbors(5, 5).first(2)
+    nbrs.each { |r, c| state.place_tile(r, c, "OracleTile", 1) }
+    targets = state.pickup_targets_for(5, 5, nil)
+    assert_equal 2, targets.size
+  end
 end

--- a/test/models/board_state_test.rb
+++ b/test/models/board_state_test.rb
@@ -366,4 +366,46 @@ class BoardStateTest < ActiveSupport::TestCase
     targets = state.pickup_targets_for(5, 5, nil)
     assert_equal 2, targets.size
   end
+
+  # ambassadors_match? — true iff the build is adjacent to any opponent's settlement.
+
+  test "ambassadors_match? is true when an opponent settlement is adjacent" do
+    state = BoardState.new
+    nr, nc = state.neighbors(5, 5).first
+    state.place_settlement(nr, nc, 1)
+    assert state.ambassadors_match?(0, 5, 5)
+  end
+
+  test "ambassadors_match? is false when the only adjacent settlement is the player's own" do
+    state = BoardState.new
+    nr, nc = state.neighbors(5, 5).first
+    state.place_settlement(nr, nc, 0)
+    refute state.ambassadors_match?(0, 5, 5)
+  end
+
+  test "ambassadors_match? is false when no neighbors are settled" do
+    refute BoardState.new.ambassadors_match?(0, 5, 5)
+  end
+
+  # shepherds_match? — true iff no adjacent hex on the same terrain is empty.
+  # Intent: built settlement has no further matching-terrain growth space.
+
+  test "shepherds_match? is true when no adjacent matching-terrain hex is empty" do
+    state = BoardState.new
+    board = TerrainStub.new(default: "F")  # no neighbors are G
+    assert state.shepherds_match?(board, "G", 5, 5)
+  end
+
+  test "shepherds_match? is false when an adjacent matching-terrain hex is empty" do
+    state = BoardState.new
+    board = TerrainStub.new(default: "G")
+    refute state.shepherds_match?(board, "G", 5, 5)
+  end
+
+  test "shepherds_match? is true when adjacent matching hexes are all occupied" do
+    state = BoardState.new
+    board = TerrainStub.new(default: "G")
+    state.neighbors(5, 5).each { |r, c| state.place_settlement(r, c, 1) }
+    assert state.shepherds_match?(board, "G", 5, 5)
+  end
 end

--- a/test/models/board_state_test.rb
+++ b/test/models/board_state_test.rb
@@ -408,4 +408,24 @@ class BoardStateTest < ActiveSupport::TestCase
     state.neighbors(5, 5).each { |r, c| state.place_settlement(r, c, 1) }
     assert state.shepherds_match?(board, "G", 5, 5)
   end
+
+  # can_mandatory_build? with skip_adjacency:true bypasses the adjacency clause (Outpost).
+
+  test "can_mandatory_build? with skip_adjacency: true accepts a non-adjacent hex when player has adjacencies" do
+    state = BoardState.new
+    state.place_settlement(5, 5, 0)  # player 0 has a settlement; adjacency-required mode would activate
+    board = TerrainStub.new(default: "G")
+    far_r, far_c = 15, 15
+    refute state.can_mandatory_build?(board, 0, "G", far_r, far_c)
+    assert state.can_mandatory_build?(board, 0, "G", far_r, far_c, skip_adjacency: true)
+  end
+
+  test "can_mandatory_build? with skip_adjacency still requires terrain match and emptiness" do
+    state = BoardState.new
+    board = TerrainStub.new(default: "G", overrides: { [ 5, 5 ] => "F" })
+    refute state.can_mandatory_build?(board, 0, "G", 5, 5, skip_adjacency: true)
+
+    state.place_settlement(5, 6, 1)
+    refute state.can_mandatory_build?(board, 0, "G", 5, 6, skip_adjacency: true)
+  end
 end

--- a/test/models/tiles/nomad/treasure_tile_test.rb
+++ b/test/models/tiles/nomad/treasure_tile_test.rb
@@ -12,4 +12,8 @@ class Tiles::Nomad::TreasureTileTest < ActiveSupport::TestCase
   test "DESCRIPTION is set" do
     assert_includes Tiles::Nomad::TreasureTile::DESCRIPTION, "3 points"
   end
+
+  test "immediate_score returns 3 points for the treasure goal" do
+    assert_equal({ "goal" => "treasure", "points" => 3 }, @tile.immediate_score)
+  end
 end

--- a/test/models/turn/consequences/build_recorded_test.rb
+++ b/test/models/turn/consequences/build_recorded_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class Turn::Consequences::BuildRecordedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+  end
+
+  test "apply! appends the build coord key to current_action.turn.builds" do
+    @game.current_action = { "turn" => {} }
+    Turn::Consequences::BuildRecorded.new(at: "[5, 7]").apply!(@game)
+    assert_equal [ "[5, 7]" ], @game.current_action.dig("turn", "builds")
+  end
+
+  test "apply! creates the turn key when missing" do
+    @game.current_action = nil
+    Turn::Consequences::BuildRecorded.new(at: "[5, 7]").apply!(@game)
+    assert_equal [ "[5, 7]" ], @game.current_action.dig("turn", "builds")
+  end
+
+  test "apply! appends to existing builds list" do
+    @game.current_action = { "turn" => { "builds" => [ "[1, 2]" ] } }
+    Turn::Consequences::BuildRecorded.new(at: "[5, 7]").apply!(@game)
+    assert_equal [ "[1, 2]", "[5, 7]" ], @game.current_action.dig("turn", "builds")
+  end
+
+  test "unapply! pops the most recent build" do
+    @game.current_action = { "turn" => { "builds" => [ "[1, 2]" ] } }
+    c = Turn::Consequences::BuildRecorded.new(at: "[5, 7]")
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal [ "[1, 2]" ], @game.current_action.dig("turn", "builds")
+  end
+
+  test "unapply! clears the key when the list drains empty" do
+    @game.current_action = { "turn" => {} }
+    c = Turn::Consequences::BuildRecorded.new(at: "[5, 7]")
+    c.apply!(@game)
+    c.unapply!(@game)
+    refute @game.current_action.dig("turn").key?("builds")
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::BuildRecorded.new(at: "[5, 7]")
+    assert_equal({ "type" => "build_recorded", "at" => "[5, 7]" }, c.to_h)
+    assert_equal c, Turn::Consequences::BuildRecorded.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::BuildRecorded.new(at: "[5, 7]")
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/card_drawn_test.rb
+++ b/test/models/turn/consequences/card_drawn_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class Turn::Consequences::CardDrawnTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+  end
+
+  test "apply! sets game.deck and game.discard to the *_after values" do
+    @game.deck = [ "G", "F", "T" ]
+    @game.discard = [ "C" ]
+    Turn::Consequences::CardDrawn.new(
+      card: "G",
+      deck_before: [ "G", "F", "T" ],
+      discard_before: [ "C" ],
+      deck_after: [ "F", "T" ],
+      discard_after: [ "C", "G" ]
+    ).apply!(@game)
+    assert_equal [ "F", "T" ], @game.deck
+    assert_equal [ "C", "G" ], @game.discard
+  end
+
+  test "unapply! restores deck_before and discard_before" do
+    @game.deck = [ "G", "F", "T" ]
+    @game.discard = [ "C" ]
+    c = Turn::Consequences::CardDrawn.new(
+      card: "G",
+      deck_before: [ "G", "F", "T" ],
+      discard_before: [ "C" ],
+      deck_after: [ "F", "T" ],
+      discard_after: [ "C", "G" ]
+    )
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal [ "G", "F", "T" ], @game.deck
+    assert_equal [ "C" ], @game.discard
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::CardDrawn.new(
+      card: "G",
+      deck_before: [ "G", "F" ],
+      discard_before: [ "C" ],
+      deck_after: [ "F" ],
+      discard_after: [ "C", "G" ]
+    )
+    h = c.to_h
+    assert_equal "card_drawn", h["type"]
+    assert_equal "G", h["card"]
+    assert_equal c, Turn::Consequences::CardDrawn.from_h(h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::CardDrawn.new(
+      card: "G",
+      deck_before: [ "G" ],
+      discard_before: [],
+      deck_after: [],
+      discard_after: [ "G" ]
+    )
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/current_player_advanced_test.rb
+++ b/test/models/turn/consequences/current_player_advanced_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class Turn::Consequences::CurrentPlayerAdvancedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @gp0 = @game.game_players.find { |g| g.order == 0 }
+    @gp1 = @game.game_players.find { |g| g.order == 1 }
+    @game.current_player = @gp0
+    @game.save!
+  end
+
+  test "apply! sets current_player to the next-order GamePlayer" do
+    Turn::Consequences::CurrentPlayerAdvanced.new(prior_order: 0, next_order: 1).apply!(@game)
+    assert_equal @gp1, @game.current_player
+  end
+
+  test "unapply! restores prior current_player" do
+    c = Turn::Consequences::CurrentPlayerAdvanced.new(prior_order: 0, next_order: 1)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal @gp0, @game.current_player
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::CurrentPlayerAdvanced.new(prior_order: 0, next_order: 1)
+    assert_equal({ "type" => "current_player_advanced", "prior_order" => 0, "next_order" => 1 }, c.to_h)
+    assert_equal c, Turn::Consequences::CurrentPlayerAdvanced.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::CurrentPlayerAdvanced.new(prior_order: 0, next_order: 1)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/error_test.rb
+++ b/test/models/turn/consequences/error_test.rb
@@ -3,12 +3,16 @@ require "test_helper"
 class Turn::Consequences::ErrorTest < ActiveSupport::TestCase
   test "apply! is a no-op" do
     game = games(:game2player)
-    Turn::Consequences::Error.new(message: "nope").apply!(game)
+    assert_nothing_raised do
+      Turn::Consequences::Error.new(message: "nope").apply!(game)
+    end
   end
 
   test "unapply! is a no-op" do
     game = games(:game2player)
-    Turn::Consequences::Error.new(message: "nope").unapply!(game)
+    assert_nothing_raised do
+      Turn::Consequences::Error.new(message: "nope").unapply!(game)
+    end
   end
 
   test "error? is true" do

--- a/test/models/turn/consequences/goal_scored_test.rb
+++ b/test/models/turn/consequences/goal_scored_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class Turn::Consequences::GoalScoredTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @gp = @game.game_players.find { |g| g.order == 0 }
+    @gp.bonus_scores = {}
+  end
+
+  test "apply! adds points to bonus_scores under the goal key" do
+    Turn::Consequences::GoalScored.new(player: 0, goal: "treasure", points: 3, prior_score: 0).apply!(@game)
+    assert_equal 3, @gp.bonus_scores["treasure"]
+  end
+
+  test "apply! accumulates onto an existing score" do
+    @gp.bonus_scores = { "treasure" => 6 }
+    Turn::Consequences::GoalScored.new(player: 0, goal: "treasure", points: 3, prior_score: 6).apply!(@game)
+    assert_equal 9, @gp.bonus_scores["treasure"]
+  end
+
+  test "unapply! restores prior_score" do
+    @gp.bonus_scores = { "treasure" => 6 }
+    c = Turn::Consequences::GoalScored.new(player: 0, goal: "treasure", points: 3, prior_score: 6)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal 6, @gp.bonus_scores["treasure"]
+  end
+
+  test "unapply! removes the goal key when prior_score was 0" do
+    c = Turn::Consequences::GoalScored.new(player: 0, goal: "treasure", points: 3, prior_score: 0)
+    c.apply!(@game)
+    c.unapply!(@game)
+    refute @gp.bonus_scores.key?("treasure")
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::GoalScored.new(player: 0, goal: "treasure", points: 3, prior_score: 0)
+    assert_equal({ "type" => "goal_scored", "player" => 0, "goal" => "treasure", "points" => 3, "prior_score" => 0 }, c.to_h)
+    assert_equal c, Turn::Consequences::GoalScored.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::GoalScored.new(player: 0, goal: "treasure", points: 3, prior_score: 0)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/hand_refreshed_test.rb
+++ b/test/models/turn/consequences/hand_refreshed_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class Turn::Consequences::HandRefreshedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @gp = @game.game_players.find { |g| g.order == 0 }
+    @gp.hand = [ "G" ]
+    @game.deck = [ "F", "T", "C" ]
+    @game.discard = [ "D" ]
+  end
+
+  test "apply! sets player hand to hand_after and game deck/discard to *_after" do
+    Turn::Consequences::HandRefreshed.new(
+      player: 0,
+      hand_before: [ "G" ],
+      hand_after: [ "F" ],
+      deck_before: [ "F", "T", "C" ],
+      deck_after: [ "T", "C" ],
+      discard_before: [ "D" ],
+      discard_after: [ "D", "G" ]
+    ).apply!(@game)
+    assert_equal [ "F" ], @gp.hand
+    assert_equal [ "T", "C" ], @game.deck
+    assert_equal [ "D", "G" ], @game.discard
+  end
+
+  test "unapply! restores hand_before, deck_before, discard_before" do
+    c = Turn::Consequences::HandRefreshed.new(
+      player: 0,
+      hand_before: [ "G" ],
+      hand_after: [ "F" ],
+      deck_before: [ "F", "T", "C" ],
+      deck_after: [ "T", "C" ],
+      discard_before: [ "D" ],
+      discard_after: [ "D", "G" ]
+    )
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal [ "G" ], @gp.hand
+    assert_equal [ "F", "T", "C" ], @game.deck
+    assert_equal [ "D" ], @game.discard
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::HandRefreshed.new(
+      player: 0,
+      hand_before: [ "G" ],
+      hand_after: [ "F" ],
+      deck_before: [ "F" ],
+      deck_after: [],
+      discard_before: [],
+      discard_after: [ "G" ]
+    )
+    assert_equal "hand_refreshed", c.to_h["type"]
+    assert_equal c, Turn::Consequences::HandRefreshed.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::HandRefreshed.new(
+      player: 0,
+      hand_before: [ "G" ],
+      hand_after: [ "F" ],
+      deck_before: [ "F" ],
+      deck_after: [],
+      discard_before: [],
+      discard_after: [ "G" ]
+    )
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/irreversible_boundary_test.rb
+++ b/test/models/turn/consequences/irreversible_boundary_test.rb
@@ -6,11 +6,11 @@ class Turn::Consequences::IrreversibleBoundaryTest < ActiveSupport::TestCase
   end
 
   test "apply! is a no-op (marker only)" do
-    Turn::Consequences::IrreversibleBoundary.new.apply!(@game)
+    assert_nothing_raised { Turn::Consequences::IrreversibleBoundary.new.apply!(@game) }
   end
 
   test "unapply! is a no-op (caller should never reach this)" do
-    Turn::Consequences::IrreversibleBoundary.new.unapply!(@game)
+    assert_nothing_raised { Turn::Consequences::IrreversibleBoundary.new.unapply!(@game) }
   end
 
   test "to_h round-trips through from_h" do

--- a/test/models/turn/consequences/irreversible_boundary_test.rb
+++ b/test/models/turn/consequences/irreversible_boundary_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class Turn::Consequences::IrreversibleBoundaryTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+  end
+
+  test "apply! is a no-op (marker only)" do
+    Turn::Consequences::IrreversibleBoundary.new.apply!(@game)
+  end
+
+  test "unapply! is a no-op (caller should never reach this)" do
+    Turn::Consequences::IrreversibleBoundary.new.unapply!(@game)
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::IrreversibleBoundary.new
+    assert_equal({ "type" => "irreversible_boundary" }, c.to_h)
+    assert_equal c, Turn::Consequences::IrreversibleBoundary.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::IrreversibleBoundary.new
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+
+  test "two instances are equal" do
+    assert_equal Turn::Consequences::IrreversibleBoundary.new, Turn::Consequences::IrreversibleBoundary.new
+  end
+end

--- a/test/models/turn/consequences/meeple_granted_test.rb
+++ b/test/models/turn/consequences/meeple_granted_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class Turn::Consequences::MeepleGrantedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+  end
+
+  def player(order) = @game.game_players.find { |gp| gp.order == order }
+
+  test "apply! increments the named meeple supply for the named player" do
+    before = player(0).warriors_remaining
+    Turn::Consequences::MeepleGranted.new(player: 0, kind: "warrior", qty: 2).apply!(@game)
+    assert_equal before + 2, player(0).warriors_remaining
+  end
+
+  test "apply! routes by kind: ship updates ships, wagon updates wagons" do
+    ship_before = player(0).ships_remaining
+    wagon_before = player(0).wagons_remaining
+    Turn::Consequences::MeepleGranted.new(player: 0, kind: "ship", qty: 1).apply!(@game)
+    Turn::Consequences::MeepleGranted.new(player: 0, kind: "wagon", qty: 1).apply!(@game)
+    assert_equal ship_before + 1, player(0).ships_remaining
+    assert_equal wagon_before + 1, player(0).wagons_remaining
+  end
+
+  test "apply! does not affect other players" do
+    before = player(1).warriors_remaining
+    Turn::Consequences::MeepleGranted.new(player: 0, kind: "warrior", qty: 2).apply!(@game)
+    assert_equal before, player(1).warriors_remaining
+  end
+
+  test "unapply! restores the prior supply" do
+    before = player(0).warriors_remaining
+    c = Turn::Consequences::MeepleGranted.new(player: 0, kind: "warrior", qty: 2)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal before, player(0).warriors_remaining
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::MeepleGranted.new(player: 0, kind: "warrior", qty: 2)
+    assert_equal({ "type" => "meeple_granted", "player" => 0, "kind" => "warrior", "qty" => 2 }, c.to_h)
+    assert_equal c, Turn::Consequences::MeepleGranted.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::MeepleGranted.new(player: 0, kind: "ship", qty: 1)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+
+  test "equality is by value" do
+    a = Turn::Consequences::MeepleGranted.new(player: 0, kind: "warrior", qty: 2)
+    b = Turn::Consequences::MeepleGranted.new(player: 0, kind: "warrior", qty: 2)
+    assert_equal a, b
+  end
+end

--- a/test/models/turn/consequences/outpost_activated_test.rb
+++ b/test/models/turn/consequences/outpost_activated_test.rb
@@ -17,12 +17,20 @@ class Turn::Consequences::OutpostActivatedTest < ActiveSupport::TestCase
     assert_equal true, @game.current_action.dig("turn", "outpost_active")
   end
 
-  test "unapply! restores prior_active" do
+  test "unapply! deletes the key when prior_active was false (clean round-trip)" do
     @game.current_action = { "turn" => {} }
     c = Turn::Consequences::OutpostActivated.new(prior_active: false)
     c.apply!(@game)
     c.unapply!(@game)
-    assert_equal false, @game.current_action.dig("turn", "outpost_active")
+    refute @game.current_action.dig("turn").key?("outpost_active")
+  end
+
+  test "unapply! restores prior_active = true when it was previously active" do
+    @game.current_action = { "turn" => { "outpost_active" => true } }
+    c = Turn::Consequences::OutpostActivated.new(prior_active: true)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal true, @game.current_action.dig("turn", "outpost_active")
   end
 
   test "to_h round-trips through from_h" do

--- a/test/models/turn/consequences/outpost_activated_test.rb
+++ b/test/models/turn/consequences/outpost_activated_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Turn::Consequences::OutpostActivatedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+  end
+
+  test "apply! sets current_action.turn.outpost_active to true" do
+    @game.current_action = { "turn" => {} }
+    Turn::Consequences::OutpostActivated.new(prior_active: false).apply!(@game)
+    assert_equal true, @game.current_action.dig("turn", "outpost_active")
+  end
+
+  test "apply! creates the turn key when missing" do
+    @game.current_action = nil
+    Turn::Consequences::OutpostActivated.new(prior_active: false).apply!(@game)
+    assert_equal true, @game.current_action.dig("turn", "outpost_active")
+  end
+
+  test "unapply! restores prior_active" do
+    @game.current_action = { "turn" => {} }
+    c = Turn::Consequences::OutpostActivated.new(prior_active: false)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal false, @game.current_action.dig("turn", "outpost_active")
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::OutpostActivated.new(prior_active: false)
+    assert_equal({ "type" => "outpost_activated", "prior_active" => false }, c.to_h)
+    assert_equal c, Turn::Consequences::OutpostActivated.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::OutpostActivated.new(prior_active: false)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/outpost_deactivated_test.rb
+++ b/test/models/turn/consequences/outpost_deactivated_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class Turn::Consequences::OutpostDeactivatedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @game.current_action = { "turn" => { "outpost_active" => true } }
+  end
+
+  test "apply! sets current_action.turn.outpost_active to false" do
+    Turn::Consequences::OutpostDeactivated.new(prior_active: true).apply!(@game)
+    assert_equal false, @game.current_action.dig("turn", "outpost_active")
+  end
+
+  test "unapply! restores prior_active" do
+    c = Turn::Consequences::OutpostDeactivated.new(prior_active: true)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal true, @game.current_action.dig("turn", "outpost_active")
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::OutpostDeactivated.new(prior_active: true)
+    assert_equal({ "type" => "outpost_deactivated", "prior_active" => true }, c.to_h)
+    assert_equal c, Turn::Consequences::OutpostDeactivated.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::OutpostDeactivated.new(prior_active: true)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/sub_phase_state_updated_test.rb
+++ b/test/models/turn/consequences/sub_phase_state_updated_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class Turn::Consequences::SubPhaseStateUpdatedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @prior = { "fort_terrain" => "G", "builds_remaining" => 2 }
+    @new   = { "fort_terrain" => "G", "builds_remaining" => 1 }
+    @game.current_action = { "turn" => { "sub_phase" => { "type" => "fort", "state" => @prior } } }
+  end
+
+  test "apply! replaces the sub_phase state with new_state" do
+    Turn::Consequences::SubPhaseStateUpdated.new(prior_state: @prior, new_state: @new).apply!(@game)
+    assert_equal @new, @game.current_action.dig("turn", "sub_phase", "state")
+  end
+
+  test "unapply! restores prior_state" do
+    c = Turn::Consequences::SubPhaseStateUpdated.new(prior_state: @prior, new_state: @new)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal @prior, @game.current_action.dig("turn", "sub_phase", "state")
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::SubPhaseStateUpdated.new(prior_state: @prior, new_state: @new)
+    h = c.to_h
+    assert_equal "sub_phase_state_updated", h["type"]
+    assert_equal @prior, h["prior_state"]
+    assert_equal @new, h["new_state"]
+    assert_equal c, Turn::Consequences::SubPhaseStateUpdated.from_h(h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::SubPhaseStateUpdated.new(prior_state: @prior, new_state: @new)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/tile_discarded_test.rb
+++ b/test/models/turn/consequences/tile_discarded_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Turn::Consequences::TileDiscardedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @gp = @game.game_players.find { |g| g.order == 0 }
+  end
+
+  test "apply! removes the tile entry matching klass + from from the player's hand" do
+    @gp.tiles = [
+      { "klass" => "TreasureTile", "from" => "[3, 4]", "used" => false },
+      { "klass" => "FarmTile",     "from" => "[5, 6]", "used" => false }
+    ]
+    Turn::Consequences::TileDiscarded.new(player: 0, klass: "TreasureTile", from: "[3, 4]", used: false).apply!(@game)
+    refute(@gp.tiles.any? { |t| t["klass"] == "TreasureTile" })
+    assert(@gp.tiles.any? { |t| t["klass"] == "FarmTile" })
+  end
+
+  test "apply! removes only one matching entry when there are duplicates" do
+    @gp.tiles = [
+      { "klass" => "TreasureTile", "from" => "[3, 4]", "used" => false },
+      { "klass" => "TreasureTile", "from" => "[3, 4]", "used" => false }
+    ]
+    Turn::Consequences::TileDiscarded.new(player: 0, klass: "TreasureTile", from: "[3, 4]", used: false).apply!(@game)
+    assert_equal 1, @gp.tiles.size
+  end
+
+  test "unapply! restores the tile entry with original used state" do
+    @gp.tiles = [ { "klass" => "TreasureTile", "from" => "[3, 4]", "used" => false } ]
+    c = Turn::Consequences::TileDiscarded.new(player: 0, klass: "TreasureTile", from: "[3, 4]", used: false)
+    c.apply!(@game)
+    c.unapply!(@game)
+    restored = @gp.tiles.find { |t| t["klass"] == "TreasureTile" && t["from"] == "[3, 4]" }
+    refute_nil restored
+    assert_equal false, restored["used"]
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::TileDiscarded.new(player: 0, klass: "TreasureTile", from: "[3, 4]", used: false)
+    h = c.to_h
+    assert_equal "tile_discarded", h["type"]
+    assert_equal c, Turn::Consequences::TileDiscarded.from_h(h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::TileDiscarded.new(player: 0, klass: "TreasureTile", from: "[3, 4]", used: false)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/turn_reset_test.rb
+++ b/test/models/turn/consequences/turn_reset_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class Turn::Consequences::TurnResetTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @game.turn_number = 5
+    @game.current_action = { "turn" => { "mandatory_remaining" => 2, "builds" => [ "[5, 5]" ] } }
+  end
+
+  test "apply! increments turn_number and clears the turn key" do
+    Turn::Consequences::TurnReset.new(prior_turn_number: 5, prior_turn_state: @game.current_action["turn"]).apply!(@game)
+    assert_equal 6, @game.turn_number
+    refute @game.current_action.key?("turn")
+  end
+
+  test "unapply! restores prior_turn_number and prior_turn_state" do
+    prior_turn_state = @game.current_action["turn"]
+    c = Turn::Consequences::TurnReset.new(prior_turn_number: 5, prior_turn_state: prior_turn_state)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal 5, @game.turn_number
+    assert_equal prior_turn_state, @game.current_action["turn"]
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::TurnReset.new(prior_turn_number: 5, prior_turn_state: { "x" => "y" })
+    assert_equal "turn_reset", c.to_h["type"]
+    assert_equal c, Turn::Consequences::TurnReset.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::TurnReset.new(prior_turn_number: 5, prior_turn_state: nil)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/sub_phases/fort_phase_test.rb
+++ b/test/models/turn/sub_phases/fort_phase_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class Turn::SubPhases::FortPhaseTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  def fort_phase(builds_remaining: 2, fort_terrain: "G")
+    Turn::SubPhases::FortPhase.new(fort_terrain: fort_terrain, builds_remaining: builds_remaining)
+  end
+
+  test "to_h round-trips through from_h" do
+    phase = fort_phase
+    h = phase.to_h
+    assert_equal "G", h["fort_terrain"]
+    assert_equal 2, h["builds_remaining"]
+    rebuilt = Turn::SubPhases::FortPhase.from_h(h)
+    assert_equal phase.fort_terrain, rebuilt.fort_terrain
+    assert_equal phase.builds_remaining, rebuilt.builds_remaining
+  end
+
+  test "handle(:build) emits SettlementPlaced + SubPhaseStateUpdated when builds_remaining > 1" do
+    target = first_empty_terrain("G")
+    phase = fort_phase(fort_terrain: "G", builds_remaining: 2)
+    cs = phase.handle(:build, game: @game, player_order: 0, row: target[0], col: target[1])
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::SettlementPlaced) })
+    update = cs.find { |c| c.is_a?(Turn::Consequences::SubPhaseStateUpdated) }
+    refute_nil update
+    assert_equal 1, update.new_state["builds_remaining"]
+    refute phase.complete?
+  end
+
+  test "handle(:build) marks complete when last build is consumed" do
+    target = first_empty_terrain("G")
+    phase = fort_phase(builds_remaining: 1)
+    phase.handle(:build, game: @game, player_order: 0, row: target[0], col: target[1])
+    assert phase.complete?
+  end
+
+  test "handle(:build) errors when terrain doesn't match fort_terrain" do
+    target = first_empty_terrain_other_than("G")
+    phase = fort_phase(fort_terrain: "G", builds_remaining: 2)
+    cs = phase.handle(:build, game: @game, player_order: 0, row: target[0], col: target[1])
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "handle(:build) errors when target is occupied" do
+    target = first_empty_terrain("G")
+    @game.board_contents.place_settlement(target[0], target[1], 1)
+    phase = fort_phase(fort_terrain: "G", builds_remaining: 2)
+    cs = phase.handle(:build, game: @game, player_order: 0, row: target[0], col: target[1])
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  private
+
+  def first_empty_terrain(terrain)
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no empty #{terrain}"
+  end
+
+  def first_empty_terrain_other_than(terrain)
+    20.times do |r|
+      20.times do |c|
+        t = @game.board.terrain_at(r, c)
+        next if t.nil? || t == terrain
+        return [ r, c ] if @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no empty non-#{terrain} hex"
+  end
+end

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -79,6 +79,47 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal "G", consequences.last.prior_state.dig("state", "restricted_terrain")
   end
 
+  test "end_turn emits HandRefreshed + CurrentPlayerAdvanced + TurnReset + IrreversibleBoundary" do
+    @game.update!(deck: [ "G", "F", "T" ], discard: [ "C" ])
+    @player.update!(hand: [ "T" ])
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:end_turn, game: @game)
+
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::IrreversibleBoundary) })
+
+    refresh = cs.find { |c| c.is_a?(Turn::Consequences::HandRefreshed) }
+    refute_nil refresh
+    assert_equal [ "T" ], refresh.hand_before
+    assert_equal [ "G" ], refresh.hand_after
+    assert_equal [ "C", "T" ], refresh.discard_after
+
+    advance = cs.find { |c| c.is_a?(Turn::Consequences::CurrentPlayerAdvanced) }
+    refute_nil advance
+    assert_equal @player.order, advance.prior_order
+    assert_equal((@player.order + 1) % 2, advance.next_order)
+
+    reset = cs.find { |c| c.is_a?(Turn::Consequences::TurnReset) }
+    refute_nil reset
+  end
+
+  test "end_turn reshuffles when deck has only the drawn card" do
+    @game.update!(deck: [ "G" ], discard: [ "F", "T" ])
+    @player.update!(hand: [ "C" ])
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:end_turn, game: @game)
+    refresh = cs.find { |c| c.is_a?(Turn::Consequences::HandRefreshed) }
+    # After draw, deck would be empty; reshuffle from discard.
+    assert_equal [ "G" ], refresh.hand_after
+    assert_equal [ "F", "T", "C" ].sort, refresh.deck_after.sort + refresh.discard_after
+    # The drawn-card stays in discard for next reshuffle? Check existing pattern.
+    assert refresh.discard_after.empty?, "discard should be empty after reshuffle"
+  end
+
   test "activate_fort emits TileConsumed + CardDrawn + SubPhasePushed(FortPhase) + IrreversibleBoundary" do
     @player.update!(tiles: [ { "klass" => "FortTile", "from" => "[3, 4]", "used" => false } ])
     @game.update!(deck: [ "G", "F", "T" ], discard: [ "C" ])

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -146,6 +146,26 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal @player.order, grants.first.player
   end
 
+  test "build appends GoalScored + TileDiscarded for a Treasure pickup" do
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    nbr = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_tile(nbr[0], nbr[1], "TreasureTile", 1)
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+
+    score = cs.find { |c| c.is_a?(Turn::Consequences::GoalScored) }
+    discard = cs.find { |c| c.is_a?(Turn::Consequences::TileDiscarded) }
+    refute_nil score, "expected GoalScored for treasure"
+    refute_nil discard, "expected TileDiscarded for treasure"
+    assert_equal "treasure", score.goal
+    assert_equal 3, score.points
+    assert_equal "TreasureTile", discard.klass
+  end
+
   test "build does not append MeepleGranted for non-granting tiles" do
     hand_terrain = @player.hand.first
     target = first_empty_terrain(hand_terrain)

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -128,34 +128,6 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal Coordinate.new(nbr[0], nbr[1]), pickups.first.from
   end
 
-  test "families: third build in a straight line emits GoalScored(families, 2)" do
-    @game.update!(goals: [ "families" ])
-    # Use raw current_action to inject 2 prior builds in a straight line; 3rd build will complete the line.
-    # East-direction line: (5,5) -> (5,6) -> (5,7). All 3 are in a row.
-    @game.current_action = {
-      "turn" => { "mandatory_remaining" => 1, "builds" => [ "[5, 5]", "[5, 6]" ] }
-    }
-    @game.save!
-    @game.reload
-    @game.instantiate
-
-    # Force-feed the test: set up board so (5,7) is buildable.
-    @player.update!(hand: [ "G" ])
-    # We can't easily ensure the board's terrain at (5,7) is "G", but we can mock the predicate's success
-    # by placing an own-settlement at (5,5) and (5,6) and a G hex at (5,7). For pure-unit purposes, just
-    # call the families_score_for path directly via Turn.from_game and a stubbed handle.
-    # Easier: set goals and simulate the third build via direct Turn invocation, accepting that the
-    # underlying can_mandatory_build? predicate may reject. Skip if so.
-    target = [ 5, 7 ]
-    skip "fixture board does not have G at (5,7)" unless @game.board.terrain_at(target[0], target[1]) == "G"
-    skip "(5,7) not empty in fixture" unless @game.board_contents.empty?(target[0], target[1])
-
-    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
-    families = cs.find { |c| c.is_a?(Turn::Consequences::GoalScored) && c.goal == "families" }
-    refute_nil families, "expected families GoalScored"
-    assert_equal 2, families.points
-  end
-
   test "families: third build NOT in a straight line does not score" do
     @game.update!(goals: [ "families" ])
     # Random scattered prior builds.
@@ -214,9 +186,14 @@ class TurnTest < ActiveSupport::TestCase
   test "build appends GoalScored(shepherds, 2) when no adjacent same-terrain empty and goal active" do
     @game.update!(goals: [ "shepherds" ])
     hand_terrain = @player.hand.first
-    # Find a hex of hand_terrain whose neighbors are all NOT hand_terrain (or all occupied).
-    target = first_isolated_terrain_hex(hand_terrain)
-    skip "no isolated #{hand_terrain} hex on this board" unless target
+    target = first_empty_terrain(hand_terrain)
+    # Force shepherds_match?: occupy every neighbor so none are empty matching-terrain.
+    @game.board_contents.neighbors(target[0], target[1]).each do |nr, nc|
+      @game.board_contents.place_settlement(nr, nc, 1)
+    end
+    @game.save!
+    @game.reload
+    @game.instantiate
 
     cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
     score = cs.find { |c| c.is_a?(Turn::Consequences::GoalScored) && c.goal == "shepherds" }

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -111,6 +111,37 @@ class TurnTest < ActiveSupport::TestCase
     assert_kind_of Turn::Consequences::Error, cs.first
   end
 
+  test "build appends a TilePickedUp for each adjacent location hex with qty > 0" do
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    nbr = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_tile(nbr[0], nbr[1], "OracleTile", 2)
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+
+    pickups = cs.select { |c| c.is_a?(Turn::Consequences::TilePickedUp) }
+    assert_equal 1, pickups.size
+    assert_equal "OracleTile", pickups.first.klass
+    assert_equal Coordinate.new(nbr[0], nbr[1]), pickups.first.from
+  end
+
+  test "build does not append TilePickedUp for tiles in player's taken_from" do
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    nbr = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_tile(nbr[0], nbr[1], "OracleTile", 2)
+    @game.save!
+    @player.update!(taken_from: [ "[#{nbr[0]}, #{nbr[1]}]" ])
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::TilePickedUp) })
+  end
+
   test "build errors when target is not adjacency-valid" do
     hand_terrain = @player.hand.first
     seed = first_empty_terrain(hand_terrain)
@@ -133,7 +164,8 @@ class TurnTest < ActiveSupport::TestCase
         }
       }
     }
-    consequences = turn.handle(:build, game: @game, row: 0, col: 0) # likely not Grass
+    far_r, far_c = first_empty_terrain_other_than("G")
+    consequences = turn.handle(:build, game: @game, row: far_r, col: far_c)
     assert_kind_of Turn::Consequences::Error, consequences.first
     refute(consequences.any? { |c| c.is_a?(Turn::Consequences::SubPhasePopped) })
   end

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -128,6 +128,59 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal Coordinate.new(nbr[0], nbr[1]), pickups.first.from
   end
 
+  test "families: third build in a straight line emits GoalScored(families, 2)" do
+    @game.update!(goals: [ "families" ])
+    # Use raw current_action to inject 2 prior builds in a straight line; 3rd build will complete the line.
+    # East-direction line: (5,5) -> (5,6) -> (5,7). All 3 are in a row.
+    @game.current_action = {
+      "turn" => { "mandatory_remaining" => 1, "builds" => [ "[5, 5]", "[5, 6]" ] }
+    }
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    # Force-feed the test: set up board so (5,7) is buildable.
+    @player.update!(hand: [ "G" ])
+    # We can't easily ensure the board's terrain at (5,7) is "G", but we can mock the predicate's success
+    # by placing an own-settlement at (5,5) and (5,6) and a G hex at (5,7). For pure-unit purposes, just
+    # call the families_score_for path directly via Turn.from_game and a stubbed handle.
+    # Easier: set goals and simulate the third build via direct Turn invocation, accepting that the
+    # underlying can_mandatory_build? predicate may reject. Skip if so.
+    target = [ 5, 7 ]
+    skip "fixture board does not have G at (5,7)" unless @game.board.terrain_at(target[0], target[1]) == "G"
+    skip "(5,7) not empty in fixture" unless @game.board_contents.empty?(target[0], target[1])
+
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    families = cs.find { |c| c.is_a?(Turn::Consequences::GoalScored) && c.goal == "families" }
+    refute_nil families, "expected families GoalScored"
+    assert_equal 2, families.points
+  end
+
+  test "families: third build NOT in a straight line does not score" do
+    @game.update!(goals: [ "families" ])
+    # Random scattered prior builds.
+    @game.current_action = {
+      "turn" => { "mandatory_remaining" => 1, "builds" => [ "[2, 2]", "[10, 10]" ] }
+    }
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    target = first_empty_terrain(@player.hand.first)
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::GoalScored) && c.goal == "families" })
+  end
+
+  test "build appends BuildRecorded carrying the placement coord" do
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+
+    rec = cs.find { |c| c.is_a?(Turn::Consequences::BuildRecorded) }
+    refute_nil rec
+    assert_equal "[#{target[0]}, #{target[1]}]", rec.at
+  end
+
   test "build appends GoalScored(ambassadors, 1) when adjacent to opponent and goal active" do
     @game.update!(goals: [ "ambassadors" ])
     hand_terrain = @player.hand.first

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -79,6 +79,50 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal "G", consequences.last.prior_state.dig("state", "restricted_terrain")
   end
 
+  test "activate_outpost emits OutpostActivated + TileConsumed when player owns an unused OutpostTile" do
+    @player.update!(tiles: [ { "klass" => "OutpostTile", "from" => "[3, 4]", "used" => false } ])
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:activate_outpost, game: @game)
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::OutpostActivated) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) && c.klass == "OutpostTile" })
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+  end
+
+  test "activate_outpost returns Error when player has no unused OutpostTile" do
+    @player.update!(tiles: [])
+    @game.reload
+    @game.instantiate
+    cs = turn.handle(:activate_outpost, game: @game)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "build with outpost_active skips adjacency and emits OutpostDeactivated" do
+    hand_terrain = @player.hand.first
+    seed = first_empty_terrain(hand_terrain)
+    @game.board_contents.place_settlement(seed[0], seed[1], 0)  # gives player adjacency, normally restricting builds
+    @game.current_action = { "turn" => { "outpost_active" => true } }
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    far = first_empty_terrain_not_adjacent_to(seed, hand_terrain)
+    cs = turn.handle(:build, game: @game, row: far[0], col: far[1])
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::SettlementPlaced) })
+    deactivate = cs.find { |c| c.is_a?(Turn::Consequences::OutpostDeactivated) }
+    refute_nil deactivate, "expected OutpostDeactivated"
+    assert_equal true, deactivate.prior_active
+  end
+
+  test "build without outpost_active does NOT emit OutpostDeactivated" do
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::OutpostDeactivated) })
+  end
+
   test "from_game defaults mandatory_remaining to 3 when current_action is empty" do
     @game.current_action = {}
     assert_equal 3, Turn.from_game(@game).mandatory_remaining

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -128,6 +128,37 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal Coordinate.new(nbr[0], nbr[1]), pickups.first.from
   end
 
+  test "build appends MeepleGranted when picking up a meeple-granting tile" do
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    nbr = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_tile(nbr[0], nbr[1], "BarracksTile", 1)
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+
+    grants = cs.select { |c| c.is_a?(Turn::Consequences::MeepleGranted) }
+    assert_equal 1, grants.size
+    assert_equal "warrior", grants.first.kind
+    assert_equal 2, grants.first.qty
+    assert_equal @player.order, grants.first.player
+  end
+
+  test "build does not append MeepleGranted for non-granting tiles" do
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    nbr = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_tile(nbr[0], nbr[1], "OracleTile", 1)
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::MeepleGranted) })
+  end
+
   test "build does not append TilePickedUp for tiles in player's taken_from" do
     hand_terrain = @player.hand.first
     target = first_empty_terrain(hand_terrain)

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -79,6 +79,52 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal "G", consequences.last.prior_state.dig("state", "restricted_terrain")
   end
 
+  test "activate_fort emits TileConsumed + CardDrawn + SubPhasePushed(FortPhase) + IrreversibleBoundary" do
+    @player.update!(tiles: [ { "klass" => "FortTile", "from" => "[3, 4]", "used" => false } ])
+    @game.update!(deck: [ "G", "F", "T" ], discard: [ "C" ])
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:activate_fort, game: @game)
+
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) && c.klass == "FortTile" })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::IrreversibleBoundary) })
+
+    drawn = cs.find { |c| c.is_a?(Turn::Consequences::CardDrawn) }
+    refute_nil drawn
+    assert_equal "G", drawn.card  # top of deck
+    assert_equal [ "F", "T" ], drawn.deck_after
+    assert_equal [ "C", "G" ], drawn.discard_after
+
+    pushed = cs.find { |c| c.is_a?(Turn::Consequences::SubPhasePushed) }
+    refute_nil pushed
+    assert_equal Turn::SubPhases::FortPhase::TYPE, pushed.phase_type
+    assert_equal "G", pushed.state["fort_terrain"]
+    assert_equal 2, pushed.state["builds_remaining"]
+  end
+
+  test "activate_fort returns Error when no unused FortTile" do
+    @player.update!(tiles: [])
+    @game.reload
+    @game.instantiate
+    cs = turn.handle(:activate_fort, game: @game)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "activate_fort reshuffles when deck has only the drawn card" do
+    @player.update!(tiles: [ { "klass" => "FortTile", "from" => "[3, 4]", "used" => false } ])
+    @game.update!(deck: [ "G" ], discard: [ "F", "T" ])
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:activate_fort, game: @game)
+    drawn = cs.find { |c| c.is_a?(Turn::Consequences::CardDrawn) }
+    assert_equal "G", drawn.card
+    assert_equal [ "F", "T" ].sort, drawn.deck_after.sort
+    assert_equal [ "G" ], drawn.discard_after
+  end
+
   test "activate_outpost emits OutpostActivated + TileConsumed when player owns an unused OutpostTile" do
     @player.update!(tiles: [ { "klass" => "OutpostTile", "from" => "[3, 4]", "used" => false } ])
     @game.reload

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -128,6 +128,49 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal Coordinate.new(nbr[0], nbr[1]), pickups.first.from
   end
 
+  test "build appends GoalScored(ambassadors, 1) when adjacent to opponent and goal active" do
+    @game.update!(goals: [ "ambassadors" ])
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    nbr = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_settlement(nbr[0], nbr[1], 1) # opponent
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    score = cs.find { |c| c.is_a?(Turn::Consequences::GoalScored) && c.goal == "ambassadors" }
+    refute_nil score
+    assert_equal 1, score.points
+  end
+
+  test "build does NOT score ambassadors when goal is inactive" do
+    @game.update!(goals: [])
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    nbr = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_settlement(nbr[0], nbr[1], 1)
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::GoalScored) && c.goal == "ambassadors" })
+  end
+
+  test "build appends GoalScored(shepherds, 2) when no adjacent same-terrain empty and goal active" do
+    @game.update!(goals: [ "shepherds" ])
+    hand_terrain = @player.hand.first
+    # Find a hex of hand_terrain whose neighbors are all NOT hand_terrain (or all occupied).
+    target = first_isolated_terrain_hex(hand_terrain)
+    skip "no isolated #{hand_terrain} hex on this board" unless target
+
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    score = cs.find { |c| c.is_a?(Turn::Consequences::GoalScored) && c.goal == "shepherds" }
+    refute_nil score
+    assert_equal 2, score.points
+  end
+
   test "build appends MeepleGranted when picking up a meeple-granting tile" do
     hand_terrain = @player.hand.first
     target = first_empty_terrain(hand_terrain)
@@ -251,6 +294,21 @@ class TurnTest < ActiveSupport::TestCase
       end
     end
     raise "no empty non-#{terrain} hex"
+  end
+
+  def first_isolated_terrain_hex(terrain)
+    20.times do |row|
+      20.times do |col|
+        next unless @game.board.terrain_at(row, col) == terrain
+        next unless @game.board_contents.empty?(row, col)
+        if @game.board_contents.neighbors(row, col).none? { |nr, nc|
+             @game.board.terrain_at(nr, nc) == terrain && @game.board_contents.empty?(nr, nc)
+           }
+          return [ row, col ]
+        end
+      end
+    end
+    nil
   end
 
   def first_empty_terrain_not_adjacent_to(seed, terrain)

--- a/test/models/turn_click_test.rb
+++ b/test/models/turn_click_test.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: turn_clicks
+#
+#  id           :bigint           not null, primary key
+#  consequences :json             not null
+#  order        :integer          not null
+#  reversible   :boolean          default(TRUE), not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  game_id      :bigint           not null
+#
+# Indexes
+#
+#  index_turn_clicks_on_game_id            (game_id)
+#  index_turn_clicks_on_game_id_and_order  (game_id,order) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (game_id => games.id)
+#
 require "test_helper"
 
 class TurnClickTest < ActiveSupport::TestCase
@@ -24,5 +45,15 @@ class TurnClickTest < ActiveSupport::TestCase
     assert_raises(ActiveRecord::RecordNotUnique) do
       TurnClick.create!(game: @game, order: 1, consequences: [])
     end
+  end
+
+  test "reversible defaults to true" do
+    click = TurnClick.create!(game: @game, order: 1, consequences: [])
+    assert_equal true, click.reload.reversible
+  end
+
+  test "reversible can be set to false" do
+    click = TurnClick.create!(game: @game, order: 1, consequences: [], reversible: false)
+    assert_equal false, click.reload.reversible
   end
 end

--- a/test/services/consequence_applier_test.rb
+++ b/test/services/consequence_applier_test.rb
@@ -152,6 +152,34 @@ class ConsequenceApplierTest < ActiveSupport::TestCase
     end
   end
 
+  test "apply! marks click reversible: false when IrreversibleBoundary is in the list" do
+    ConsequenceApplier.apply!(@game, [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G"),
+      Turn::Consequences::IrreversibleBoundary.new
+    ])
+    click = TurnClick.most_recent_for(@game)
+    assert_equal false, click.reversible
+  end
+
+  test "apply! marks click reversible: true by default" do
+    ConsequenceApplier.apply!(@game, [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G")
+    ])
+    assert_equal true, TurnClick.most_recent_for(@game).reversible
+  end
+
+  test "unapply! raises NotReversibleError on a non-reversible click" do
+    ConsequenceApplier.apply!(@game, [
+      Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G"),
+      Turn::Consequences::IrreversibleBoundary.new
+    ])
+    assert_raises(ConsequenceApplier::NotReversibleError) do
+      ConsequenceApplier.unapply!(@game.reload)
+    end
+    # Click stays — not consumed.
+    assert_equal 1, TurnClick.where(game: @game).count
+  end
+
   test "unapply! only consumes one click at a time" do
     ConsequenceApplier.apply!(@game, [ Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 7), player: 0, terrain: "G") ])
     ConsequenceApplier.apply!(@game, [ Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(5, 8), player: 0, terrain: "G") ])

--- a/test/services/turn_end_turn_flow_test.rb
+++ b/test/services/turn_end_turn_flow_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class TurnEndTurnFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "build then end_turn advances current_player; undo blocked at the end_turn boundary" do
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+
+    # Click 1: build (reversible).
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    ConsequenceApplier.apply!(@game, turn.handle(:build, game: @game, row: target[0], col: target[1]))
+
+    @game.reload
+    assert_equal @player.order, @game.current_player.order
+    assert_equal 2, @game.current_action.dig("turn", "mandatory_remaining")
+
+    # Click 2: end_turn (irreversible).
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    ConsequenceApplier.apply!(@game, turn.handle(:end_turn, game: @game))
+
+    @game.reload
+    refute_equal @player.order, @game.current_player.order
+    refute @game.current_action.key?("turn"), "turn state cleared after end_turn"
+    end_turn_click = TurnClick.most_recent_for(@game)
+    assert_equal false, end_turn_click.reversible
+
+    # Undo end_turn → blocked.
+    assert_raises(ConsequenceApplier::NotReversibleError) do
+      ConsequenceApplier.unapply!(@game.reload)
+    end
+  end
+
+  test "end_turn refreshes hand by drawing one card" do
+    @game.update!(deck: [ "G", "F" ], discard: [ "C" ])
+    @player.update!(hand: [ "T" ])
+    @game.reload
+    @game.instantiate
+
+    turn = Turn.from_game(@game)
+    ConsequenceApplier.apply!(@game, turn.handle(:end_turn, game: @game))
+
+    @player.reload
+    assert_equal [ "G" ], @player.hand
+    @game.reload
+    assert_equal [ "F" ], @game.deck
+    assert_equal [ "C", "T" ], @game.discard
+  end
+
+  private
+
+  def first_empty_terrain(terrain)
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no empty #{terrain}"
+  end
+end

--- a/test/services/turn_fort_flow_test.rb
+++ b/test/services/turn_fort_flow_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class TurnFortFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "activate fort, build twice, undo blocked at the activate boundary" do
+    @player.update!(tiles: [ { "klass" => "FortTile", "from" => "[3, 4]", "used" => false } ])
+    # Force the deck so we know what gets drawn.
+    @game.update!(deck: [ "G", "F", "T" ], discard: [ "C" ])
+
+    # Click 1: activate_fort (irreversible).
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:activate_fort, game: @game)
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "fort", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_equal 2, @game.current_action.dig("turn", "sub_phase", "state", "builds_remaining")
+    assert_equal "G", @game.current_action.dig("turn", "sub_phase", "state", "fort_terrain")
+    fort_click = TurnClick.most_recent_for(@game)
+    assert_equal false, fort_click.reversible
+
+    # Click 2: build #1 in fort phase.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    target1 = first_empty_terrain("G")
+    cs = turn.handle(:build, game: @game, row: target1[0], col: target1[1])
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal 1, @game.current_action.dig("turn", "sub_phase", "state", "builds_remaining")
+
+    # Click 3: build #2 — completes fort phase.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    target2 = first_empty_terrain("G")
+    cs = turn.handle(:build, game: @game, row: target2[0], col: target2[1])
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+    assert_equal 3, TurnClick.where(game: @game).count
+
+    # Undo build #2 → reversible. Undo build #1 → reversible. Undo activate_fort → blocked.
+    ConsequenceApplier.unapply!(@game.reload)
+    ConsequenceApplier.unapply!(@game.reload)
+    assert_raises(ConsequenceApplier::NotReversibleError) do
+      ConsequenceApplier.unapply!(@game.reload)
+    end
+
+    # Activate-fort click still in the log (not consumed).
+    assert_equal 1, TurnClick.where(game: @game).count
+    assert_equal false, TurnClick.most_recent_for(@game).reversible
+  end
+
+  private
+
+  def first_empty_terrain(terrain)
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no empty #{terrain}"
+  end
+end

--- a/test/services/turn_mandatory_build_with_families_test.rb
+++ b/test/services/turn_mandatory_build_with_families_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+
+class TurnMandatoryBuildWithFamiliesTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.update!(goals: [ "families" ])
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @hand_terrain = @player.hand.first
+  end
+
+  test "three builds in a straight line score Families on the third click and unwind cleanly" do
+    line = three_collinear_buildable_hexes
+    skip "no 3-collinear buildable line for #{@hand_terrain} on this fixture" unless line
+
+    score_before = @player.reload.bonus_scores&.dig("families") || 0
+
+    line.each do |row, col|
+      turn = Turn.from_game(@game.reload)
+      @game.instantiate
+      ConsequenceApplier.apply!(@game, turn.handle(:build, game: @game, row: row, col: col))
+    end
+
+    @player.reload
+    assert_equal score_before + 2, @player.bonus_scores["families"]
+    assert_equal 3, TurnClick.where(game: @game).count
+
+    3.times { ConsequenceApplier.unapply!(@game.reload) }
+
+    @player.reload
+    assert_equal score_before, (@player.bonus_scores&.dig("families") || 0)
+    assert_equal 0, TurnClick.where(game: @game).count
+  end
+
+  test "three builds NOT in a straight line do not score Families" do
+    target_a = first_empty_terrain(@hand_terrain)
+    target_b = neighbor_in_terrain(target_a, @hand_terrain)
+    skip "fixture lacks 2 connected #{@hand_terrain} hexes" unless target_b
+    target_c = non_collinear_neighbor_in_terrain(target_a, target_b, @hand_terrain)
+    skip "fixture lacks a 3rd non-collinear #{@hand_terrain} hex" unless target_c
+
+    [ target_a, target_b, target_c ].each do |row, col|
+      turn = Turn.from_game(@game.reload)
+      @game.instantiate
+      ConsequenceApplier.apply!(@game, turn.handle(:build, game: @game, row: row, col: col))
+    end
+
+    refute @player.reload.bonus_scores&.dig("families"), "should not have scored families"
+  end
+
+  private
+
+  def first_empty_terrain(terrain)
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no empty #{terrain}"
+  end
+
+  def neighbor_in_terrain(seed, terrain)
+    @game.board_contents.neighbors(seed[0], seed[1]).find do |nr, nc|
+      @game.board.terrain_at(nr, nc) == terrain && @game.board_contents.empty?(nr, nc)
+    end
+  end
+
+  def non_collinear_neighbor_in_terrain(a, b, terrain)
+    # Find a neighbor of b that's NOT on the line a→b extended.
+    line_extension = next_in_line(a, b)
+    @game.board_contents.neighbors(b[0], b[1]).find do |nr, nc|
+      [ nr, nc ] != a &&
+        [ nr, nc ] != line_extension &&
+        @game.board.terrain_at(nr, nc) == terrain &&
+        @game.board_contents.empty?(nr, nc)
+    end
+  end
+
+  def next_in_line(a, b)
+    Tiles::PaddockTile::STRAIGHT_LINES.each do |steps|
+      dr1, dc1 = steps[a[0] % 2]
+      next unless [ a[0] + dr1, a[1] + dc1 ] == b
+      dr2, dc2 = steps[b[0] % 2]
+      return [ b[0] + dr2, b[1] + dc2 ]
+    end
+    nil
+  end
+
+  def three_collinear_buildable_hexes
+    Tiles::PaddockTile::STRAIGHT_LINES.each do |steps|
+      20.times do |r|
+        20.times do |c|
+          a = [ r, c ]
+          dr1, dc1 = steps[r % 2]
+          b = [ r + dr1, c + dc1 ]
+          next unless (0..19).cover?(b[0]) && (0..19).cover?(b[1])
+          dr2, dc2 = steps[b[0] % 2]
+          c2 = [ b[0] + dr2, b[1] + dc2 ]
+          next unless (0..19).cover?(c2[0]) && (0..19).cover?(c2[1])
+          line = [ a, b, c2 ]
+          next unless line.all? { |row, col|
+            @game.board.terrain_at(row, col) == @hand_terrain && @game.board_contents.empty?(row, col)
+          }
+          return line
+        end
+      end
+    end
+    nil
+  end
+end

--- a/test/services/turn_mandatory_build_with_families_test.rb
+++ b/test/services/turn_mandatory_build_with_families_test.rb
@@ -14,8 +14,9 @@ class TurnMandatoryBuildWithFamiliesTest < ActiveSupport::TestCase
   end
 
   test "three builds in a straight line score Families on the third click and unwind cleanly" do
-    line = three_collinear_buildable_hexes
-    skip "no 3-collinear buildable line for #{@hand_terrain} on this fixture" unless line
+    line, terrain = any_three_collinear_empty_same_terrain
+    @player.update!(hand: [ terrain ])
+    @hand_terrain = terrain
 
     score_before = @player.reload.bonus_scores&.dig("families") || 0
 
@@ -37,13 +38,18 @@ class TurnMandatoryBuildWithFamiliesTest < ActiveSupport::TestCase
   end
 
   test "three builds NOT in a straight line do not score Families" do
-    target_a = first_empty_terrain(@hand_terrain)
-    target_b = neighbor_in_terrain(target_a, @hand_terrain)
-    skip "fixture lacks 2 connected #{@hand_terrain} hexes" unless target_b
-    target_c = non_collinear_neighbor_in_terrain(target_a, target_b, @hand_terrain)
-    skip "fixture lacks a 3rd non-collinear #{@hand_terrain} hex" unless target_c
+    line, terrain = any_three_collinear_empty_same_terrain
+    @player.update!(hand: [ terrain ])
+    @hand_terrain = terrain
 
-    [ target_a, target_b, target_c ].each do |row, col|
+    # Replace the third hex with one that breaks the line: take the first hex's neighbor in
+    # a different direction. Walk all of `a`'s neighbors and pick one whose `[a, b, neighbor]`
+    # is not a straight line, requiring it also be empty + matching terrain.
+    a, b, _c = line
+    bent = bent_third_for(a, b, terrain)
+    targets = [ a, b, bent ]
+
+    targets.each do |row, col|
       turn = Turn.from_game(@game.reload)
       @game.instantiate
       ConsequenceApplier.apply!(@game, turn.handle(:build, game: @game, row: row, col: col))
@@ -54,43 +60,9 @@ class TurnMandatoryBuildWithFamiliesTest < ActiveSupport::TestCase
 
   private
 
-  def first_empty_terrain(terrain)
-    20.times do |r|
-      20.times do |c|
-        return [ r, c ] if @game.board.terrain_at(r, c) == terrain && @game.board_contents.empty?(r, c)
-      end
-    end
-    raise "no empty #{terrain}"
-  end
-
-  def neighbor_in_terrain(seed, terrain)
-    @game.board_contents.neighbors(seed[0], seed[1]).find do |nr, nc|
-      @game.board.terrain_at(nr, nc) == terrain && @game.board_contents.empty?(nr, nc)
-    end
-  end
-
-  def non_collinear_neighbor_in_terrain(a, b, terrain)
-    # Find a neighbor of b that's NOT on the line a→b extended.
-    line_extension = next_in_line(a, b)
-    @game.board_contents.neighbors(b[0], b[1]).find do |nr, nc|
-      [ nr, nc ] != a &&
-        [ nr, nc ] != line_extension &&
-        @game.board.terrain_at(nr, nc) == terrain &&
-        @game.board_contents.empty?(nr, nc)
-    end
-  end
-
-  def next_in_line(a, b)
-    Tiles::PaddockTile::STRAIGHT_LINES.each do |steps|
-      dr1, dc1 = steps[a[0] % 2]
-      next unless [ a[0] + dr1, a[1] + dc1 ] == b
-      dr2, dc2 = steps[b[0] % 2]
-      return [ b[0] + dr2, b[1] + dc2 ]
-    end
-    nil
-  end
-
-  def three_collinear_buildable_hexes
+  # Find any 3-collinear empty hexes sharing the same terrain on the actual board.
+  # Returns [line, terrain]. With a 20x20 KB board this always finds a match.
+  def any_three_collinear_empty_same_terrain
     Tiles::PaddockTile::STRAIGHT_LINES.each do |steps|
       20.times do |r|
         20.times do |c|
@@ -101,13 +73,60 @@ class TurnMandatoryBuildWithFamiliesTest < ActiveSupport::TestCase
           dr2, dc2 = steps[b[0] % 2]
           c2 = [ b[0] + dr2, b[1] + dc2 ]
           next unless (0..19).cover?(c2[0]) && (0..19).cover?(c2[1])
+
           line = [ a, b, c2 ]
-          next unless line.all? { |row, col|
-            @game.board.terrain_at(row, col) == @hand_terrain && @game.board_contents.empty?(row, col)
-          }
-          return line
+          terrains = line.map { |row, col| @game.board.terrain_at(row, col) }
+          next unless terrains.uniq.size == 1
+          terrain = terrains.first
+          next unless Tiles::Tile::BUILDABLE_TERRAIN.include?(terrain)
+          next unless line.all? { |row, col| @game.board_contents.empty?(row, col) }
+          return [ line, terrain ]
         end
       end
+    end
+    raise "no 3-collinear same-terrain buildable line on this board"
+  end
+
+  # Given two collinear hexes a,b on the board, find a third hex that is:
+  # - adjacent to b
+  # - matching `terrain`
+  # - empty
+  # - NOT the collinear extension of a→b
+  # Falls back to constructing a non-line by clearing a hex if necessary.
+  def bent_third_for(a, b, terrain)
+    line_extension = next_in_line(a, b)
+    candidate = @game.board_contents.neighbors(b[0], b[1]).find do |nr, nc|
+      [ nr, nc ] != a &&
+        [ nr, nc ] != line_extension &&
+        @game.board.terrain_at(nr, nc) == terrain &&
+        @game.board_contents.empty?(nr, nc)
+    end
+    return candidate if candidate
+
+    # No matching-terrain bent option exists naturally. Take any non-line empty neighbor
+    # of b and stub its terrain via singleton override on the board.
+    fallback = @game.board_contents.neighbors(b[0], b[1]).find do |nr, nc|
+      [ nr, nc ] != a && [ nr, nc ] != line_extension && @game.board_contents.empty?(nr, nc)
+    end
+    raise "no usable bent neighbor of #{b.inspect}" unless fallback
+    stub_terrain_at(fallback, terrain)
+    fallback
+  end
+
+  def stub_terrain_at(coord, terrain)
+    board = @game.board
+    original = board.method(:terrain_at)
+    board.define_singleton_method(:terrain_at) do |r, c|
+      ([ r, c ] == coord) ? terrain : original.call(r, c)
+    end
+  end
+
+  def next_in_line(a, b)
+    Tiles::PaddockTile::STRAIGHT_LINES.each do |steps|
+      dr1, dc1 = steps[a[0] % 2]
+      next unless [ a[0] + dr1, a[1] + dc1 ] == b
+      dr2, dc2 = steps[b[0] % 2]
+      return [ b[0] + dr2, b[1] + dc2 ]
     end
     nil
   end

--- a/test/services/turn_mandatory_build_with_goals_test.rb
+++ b/test/services/turn_mandatory_build_with_goals_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class TurnMandatoryBuildWithGoalsTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @hand_terrain = @player.hand.first
+  end
+
+  test "build adjacent to opponent scores ambassadors and unwinds cleanly" do
+    @game.update!(goals: [ "ambassadors" ])
+    target = first_buildable_hex
+    nbr_r, nbr_c = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_settlement(nbr_r, nbr_c, 1)
+    @game.save!
+
+    score_before = @player.reload.bonus_scores&.dig("ambassadors") || 0
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    ConsequenceApplier.apply!(@game, cs)
+
+    @player.reload
+    assert_equal score_before + 1, @player.bonus_scores["ambassadors"]
+
+    ConsequenceApplier.unapply!(@game.reload)
+
+    @player.reload
+    assert_equal score_before, (@player.bonus_scores&.dig("ambassadors") || 0)
+  end
+
+  private
+
+  def first_buildable_hex
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == @hand_terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no buildable #{@hand_terrain}"
+  end
+end

--- a/test/services/turn_mandatory_build_with_grant_test.rb
+++ b/test/services/turn_mandatory_build_with_grant_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class TurnMandatoryBuildWithGrantTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @hand_terrain = @player.hand.first
+  end
+
+  test "build adjacent to a Barracks tile grants 2 warriors and unwinds cleanly" do
+    target = first_buildable_hex
+    nbr_r, nbr_c = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_tile(nbr_r, nbr_c, "BarracksTile", 1)
+    @game.save!
+
+    warriors_before = @player.reload.warriors_remaining
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @player.reload
+    assert_equal warriors_before + 2, @player.warriors_remaining
+    assert_equal 1, TurnClick.where(game: @game).count
+
+    ConsequenceApplier.unapply!(@game.reload)
+
+    @player.reload
+    assert_equal warriors_before, @player.warriors_remaining
+    assert_equal 0, TurnClick.where(game: @game).count
+  end
+
+  test "build adjacent to a Lighthouse tile grants 1 ship" do
+    target = first_buildable_hex
+    nbr_r, nbr_c = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_tile(nbr_r, nbr_c, "LighthouseTile", 1)
+    @game.save!
+
+    ships_before = @player.reload.ships_remaining
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    ConsequenceApplier.apply!(@game, turn.handle(:build, game: @game, row: target[0], col: target[1]))
+
+    assert_equal ships_before + 1, @player.reload.ships_remaining
+  end
+
+  private
+
+  def first_buildable_hex
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == @hand_terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no buildable #{@hand_terrain}"
+  end
+end

--- a/test/services/turn_mandatory_build_with_pickup_test.rb
+++ b/test/services/turn_mandatory_build_with_pickup_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class TurnMandatoryBuildWithPickupTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @hand_terrain = @player.hand.first
+  end
+
+  test "build adjacent to a location tile picks it up in the same click and unwinds cleanly" do
+    target = first_buildable_hex
+    nbr_r, nbr_c = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_tile(nbr_r, nbr_c, "OracleTile", 2)
+    @game.save!
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::SettlementPlaced) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::TilePickedUp) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::MandatoryRemainingDecremented) })
+
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_equal 1, @game.board_contents.tile_qty(nbr_r, nbr_c)
+    assert(@player.reload.tiles.any? { |t| t["klass"] == "OracleTile" && t["from"] == "[#{nbr_r}, #{nbr_c}]" })
+    assert_equal 1, TurnClick.where(game: @game).count
+
+    ConsequenceApplier.unapply!(@game.reload)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(target[0], target[1])
+    assert_equal 2, @game.board_contents.tile_qty(nbr_r, nbr_c)
+    refute(@player.reload.tiles.any? { |t| t["klass"] == "OracleTile" })
+    assert_equal 0, TurnClick.where(game: @game).count
+  end
+
+  test "build skips pickup of tiles already in the player's taken_from" do
+    target = first_buildable_hex
+    nbr_r, nbr_c = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_tile(nbr_r, nbr_c, "OracleTile", 2)
+    @game.save!
+    @player.update!(taken_from: [ "[#{nbr_r}, #{nbr_c}]" ])
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::TilePickedUp) })
+  end
+
+  private
+
+  def first_buildable_hex
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == @hand_terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no buildable #{@hand_terrain}"
+  end
+end

--- a/test/services/turn_mandatory_build_with_treasure_test.rb
+++ b/test/services/turn_mandatory_build_with_treasure_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class TurnMandatoryBuildWithTreasureTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @hand_terrain = @player.hand.first
+  end
+
+  test "build adjacent to a Treasure tile scores 3 points and removes the tile, then unwinds cleanly" do
+    target = first_buildable_hex
+    nbr_r, nbr_c = @game.board_contents.neighbors(target[0], target[1]).first
+    @game.board_contents.place_tile(nbr_r, nbr_c, "TreasureTile", 1)
+    @game.save!
+
+    score_before = @player.reload.bonus_scores&.dig("treasure") || 0
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @player.reload
+    assert_equal score_before + 3, @player.bonus_scores["treasure"]
+    refute @player.tiles.any? { |t| t["klass"] == "TreasureTile" }, "treasure tile should be discarded after pickup"
+    assert_equal 0, @game.board_contents.tile_qty(nbr_r, nbr_c)
+
+    ConsequenceApplier.unapply!(@game.reload)
+
+    @game.reload
+    @player.reload
+    assert_equal score_before, (@player.bonus_scores&.dig("treasure") || 0)
+    refute @player.tiles.any? { |t| t["klass"] == "TreasureTile" }, "treasure tile fully gone after unwind"
+    assert_equal 1, @game.board_contents.tile_qty(nbr_r, nbr_c)
+    assert_equal 0, TurnClick.where(game: @game).count
+  end
+
+  private
+
+  def first_buildable_hex
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == @hand_terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no buildable #{@hand_terrain}"
+  end
+end

--- a/test/services/turn_outpost_flow_test.rb
+++ b/test/services/turn_outpost_flow_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class TurnOutpostFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @hand_terrain = @player.hand.first
+  end
+
+  test "activate outpost then build a non-adjacent hex; outpost flag clears; full unwind" do
+    @player.update!(tiles: [ { "klass" => "OutpostTile", "from" => "[2, 3]", "used" => false } ])
+    seed = first_empty_terrain(@hand_terrain)
+    @game.board_contents.place_settlement(seed[0], seed[1], 0)
+    @game.save!
+
+    far = first_empty_terrain_not_adjacent_to(seed, @hand_terrain)
+
+    # Click 1: activate outpost
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    ConsequenceApplier.apply!(@game, turn.handle(:activate_outpost, game: @game))
+    assert_equal true, @game.reload.current_action.dig("turn", "outpost_active")
+
+    # Click 2: build at non-adjacent hex (only allowed because outpost_active is true)
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: far[0], col: far[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected build success")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal false, @game.current_action.dig("turn", "outpost_active")
+    assert_equal 0, @game.board_contents.player_at(far[0], far[1])
+    assert_equal 2, TurnClick.where(game: @game).count
+
+    # Unwind both
+    2.times { ConsequenceApplier.unapply!(@game.reload) }
+
+    @game.reload
+    assert_equal 0, TurnClick.where(game: @game).count
+    @player.reload
+    refute @player.tiles.any? { |t| t["klass"] == "OutpostTile" && t["used"] }, "outpost should be unused after unwind"
+    refute @game.current_action.dig("turn", "outpost_active"), "outpost flag clean after full unwind"
+  end
+
+  private
+
+  def first_empty_terrain(terrain)
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no empty #{terrain}"
+  end
+
+  def first_empty_terrain_not_adjacent_to(seed, terrain)
+    seed_r, seed_c = seed
+    neighbor_set = @game.board_contents.neighbors(seed_r, seed_c).to_set
+    20.times do |r|
+      20.times do |c|
+        next unless @game.board.terrain_at(r, c) == terrain
+        next unless @game.board_contents.empty?(r, c)
+        next if [ r, c ] == seed
+        next if neighbor_set.include?([ r, c ])
+        return [ r, c ]
+      end
+    end
+    raise "no far #{terrain} hex"
+  end
+end


### PR DESCRIPTION
## Summary

Comprehensive slice 3 of the TurnEngine deepening project. Builds out the new `Turn` stack to handle the **full mandatory turn flow** in the new architecture:

- Settlement build with adjacency rule (slice 3b — already on main)
- Tile pickup chain
- Meeple grants (Wagon, Barracks, Lighthouse)
- Treasure auto-scoring
- Ambassadors + Shepherds + Families goal scoring
- Outpost tile (reversible)
- Fort tile (irreversible deck draw + 2-build sub-phase)
- End-turn (irreversible hand refresh + player advance)

37 commits, ~30 new files, 982 tests green (+~150 new). All work is **library-only** — no controller wiring; old `TurnEngine` still owns user-facing clicks.

## What's in this PR

### Slice 3c — Tile pickup
- `BoardState#pickup_targets_for(row, col, taken_from)`
- `Turn#handle_mandatory_build` appends `TilePickedUp` for adjacent location hexes

### Slice 3d — Meeple grants
- `Tile#meeple_grant` API (Wagon, Barracks, Lighthouse override)
- New `MeepleGranted` consequence + `GamePlayer#adjust_meeple_supply!(kind, delta)`

### Slice 3e — Treasure auto-scoring
- `Tile#immediate_score` API (TreasureTile overrides)
- New `GoalScored` (carries `prior_score` for invertibility)
- New `TileDiscarded` (removes a klass+from match from player hand)

### Slice 3f.1 — Ambassadors + Shepherds
- `BoardState#ambassadors_match?` and `#shepherds_match?`
- `Turn` filters by `Array(game.goals)` and emits `GoalScored` per match

### Slice 3f.2 — Families
- New `BuildRecorded` consequence (tracks per-turn build positions)
- `Turn.builds_this_turn` field; straight-line detection on third build via `Tiles::PaddockTile::STRAIGHT_LINES`

### Slice 3g.1 — Outpost
- `BoardState#can_mandatory_build?` gains `skip_adjacency:` keyword
- New `OutpostActivated` + `OutpostDeactivated` consequences
- `Turn#handle(:activate_outpost)` + outpost-aware `handle_mandatory_build`

### Slice 3g.2 — Fort + reversibility infra
- Migration: `reversible:boolean` on `turn_clicks`
- New `IrreversibleBoundary` marker — when present in a click's consequence list, applier writes `reversible: false`
- `ConsequenceApplier.unapply!` raises `NotReversibleError` on non-reversible click; click stays in log
- New consequences: `CardDrawn` (state-replacement, randomness baked in at construction), `SubPhaseStateUpdated` (in-place sub-phase counter update)
- New `Turn::SubPhases::FortPhase` (2 builds on drawn terrain; emits `SubPhaseStateUpdated` mid-flight)
- `Turn#handle(:activate_fort)` validates FortTile + settlements; emits `TileConsumed + CardDrawn + SubPhasePushed + IrreversibleBoundary`

### Slice 3h.1 — Basic end_turn
- New consequences: `HandRefreshed`, `CurrentPlayerAdvanced`, `TurnReset`
- `Turn#handle(:end_turn)` discards hand, draws one card, reshuffles when needed, advances current_player, resets turn state, emits `IrreversibleBoundary`
- NB: `gp.hand` is a String per `Game#deal_terrain_cards`; normalized via `Array(gp.hand)`

## Out of scope (not yet implemented; future slices)

- Crossroads double-draw on end_turn
- Tile reset for next player on end_turn
- Nomad tile expiration
- End-game detection (`game.ending?` → complete!)
- Controller cutover — old engine still owns the routes
- Fort phase tile-pickup chain on each fort build (currently just settlement placement)
- Outpost on first-build-of-turn shortcut behavior (currently any build)

## Test plan

- [x] `bin/rails test` — 982 runs, 0 failures
- [ ] Skim the round-trip / boundary tests:
  - `test/services/turn_mandatory_build_*_test.rb` (one per pickup/grant/Treasure/goals/families variant)
  - `test/services/turn_outpost_flow_test.rb` (apply + unapply across activate→build)
  - `test/services/turn_fort_flow_test.rb` (irreversible boundary; undo blocked at activate_fort)
  - `test/services/turn_end_turn_flow_test.rb` (irreversible end_turn boundary)
- [ ] Spot-check that nothing in the old `TurnEngine` path was modified — slice is library-additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)