### PR TITLE
Turn engine deepening: slice 3 part 2 — full mandatory turn flow (3h.2 → 3i.7)

### DIFF
--- a/app/models/tiles/lighthouse_tile.rb
+++ b/app/models/tiles/lighthouse_tile.rb
@@ -5,6 +5,7 @@ module Tiles
 
     def places_meeple? = true
     def meeple_kind    = "ship"
+    def meeple_movable? = true
     def meeple_grant   = { "kind" => "ship", "qty" => 1 }
 
     def on_pickup(game_player:)

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -112,6 +112,10 @@ module Tiles
     # Subclasses override this (e.g. BarnTile returns hand, HarborTile returns "W").
     def move_terrain(hand:) = nil
 
+    # True for tiles whose meeple can be moved via a select-source-then-destination
+    # flow (Lighthouse ship, Wagon). False for placement-only tiles (Barracks).
+    def meeple_movable? = false
+
     # Human-readable description of what the player must do with this tile.
     def action_message(player_handle:, terrain_names:, hand: nil)
       if moves_settlement?

--- a/app/models/tiles/wagon_tile.rb
+++ b/app/models/tiles/wagon_tile.rb
@@ -7,6 +7,7 @@ module Tiles
 
     def places_meeple? = true
     def meeple_kind    = "wagon"
+    def meeple_movable? = true
     def meeple_grant   = { "kind" => "wagon", "qty" => 1 }
 
     def on_pickup(game_player:)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -64,24 +64,28 @@ class Turn
   def handle_select_action(game:, tile:)
     return [ error("a sub-phase is already active") ] if sub_phase
 
-    case tile
-    when :farm
-      handle_farm_activation(game:)
+    klass_name = tile.to_s
+    tile_class = Tiles::Tile.for_klass(klass_name)
+    return [ error("unknown tile: #{klass_name}") ] unless tile_class
+
+    instance = tile_class.new(0)
+    if instance.builds_settlement? && instance.build_terrain
+      activate_fixed_terrain_build(game:, klass_name:, terrain: instance.build_terrain)
     else
-      [ error("unsupported tile: #{tile}") ]
+      [ error("tile #{klass_name} is not activatable via select_action") ]
     end
   end
 
-  def handle_farm_activation(game:)
+  def activate_fixed_terrain_build(game:, klass_name:, terrain:)
     gp = game.game_players.find { |g| g.order == player_order }
     return [ error("no current player") ] unless gp
 
-    held = gp.find_unused_tile("FarmTile")
-    return [ error("no unused Farm tile available") ] unless held
+    held = gp.find_unused_tile(klass_name)
+    return [ error("no unused #{klass_name} available") ] unless held
 
     pushed = Turn::SubPhases::TileBuildPhase.new(
-      restricted_terrain: "G",
-      tile_klass: "FarmTile",
+      restricted_terrain: terrain,
+      tile_klass: klass_name,
       tile_source: Coordinate.from_key(held["from"])
     )
     [

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -54,7 +54,7 @@ class Turn
       handle_activate_fort(game:)
     when :end_turn
       handle_end_turn(game:)
-    when :select_settlement, :move_settlement
+    when :select_settlement, :move_settlement, :place_meeple
       handle_sub_phase_action(action_name, game:, **params)
     else
       [ error("unsupported turn action: #{action_name}") ]
@@ -85,9 +85,27 @@ class Turn
       activate_build(game:, klass_name:, terrain: nil)
     elsif instance.moves_settlement?
       activate_settlement_move(game:, klass_name:)
+    elsif instance.places_meeple?
+      activate_meeple_placement(game:, klass_name:, kind: instance.meeple_kind)
     else
       [ error("tile #{klass_name} is not activatable via select_action") ]
     end
+  end
+
+  def activate_meeple_placement(game:, klass_name:, kind:)
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+
+    held = gp.find_unused_tile(klass_name)
+    return [ error("no unused #{klass_name} available") ] unless held
+
+    pushed = Turn::SubPhases::MeeplePlacementPhase.new(tile_klass: klass_name, kind: kind)
+    [
+      Turn::Consequences::SubPhasePushed.new(
+        phase_type: Turn::SubPhases::MeeplePlacementPhase::TYPE,
+        state: pushed.to_h
+      )
+    ]
   end
 
   def activate_settlement_move(game:, klass_name:)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -134,6 +134,7 @@ class Turn
 
     next_order = (player_order + 1) % game.game_players.count
     prior_turn_state = game.current_action.is_a?(Hash) ? game.current_action["turn"] : nil
+    completed = game_complete_for(game)
 
     [
       Turn::Consequences::HandRefreshed.new(
@@ -147,8 +148,16 @@ class Turn
       ),
       Turn::Consequences::CurrentPlayerAdvanced.new(prior_order: player_order, next_order: next_order),
       Turn::Consequences::TurnReset.new(prior_turn_number: game.turn_number, prior_turn_state: prior_turn_state),
+      *completed,
       Turn::Consequences::IrreversibleBoundary.new
     ]
+  end
+
+  def game_complete_for(game)
+    return [] unless game.ending?
+    last_order = game.game_players.count - 1
+    return [] unless player_order == last_order
+    [ Turn::Consequences::GameCompleted.new(prior_state: game.state, prior_scores: game.scores) ]
   end
 
   def handle_activate_fort(game:)
@@ -224,9 +233,11 @@ class Turn
     goals = goal_scores_for(game, gp, terrain, row, col)
     families = families_score_for(game, gp, row, col)
     outpost_consume = outpost_active ? [ Turn::Consequences::OutpostDeactivated.new(prior_active: true) ] : []
+    end_trigger = end_trigger_for(gp)
 
     [
       Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: terrain),
+      *end_trigger,
       *pickups,
       *grants,
       *immediate,
@@ -236,6 +247,11 @@ class Turn
       Turn::Consequences::BuildRecorded.new(at: Coordinate.new(row, col).to_key),
       Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: mandatory_remaining)
     ]
+  end
+
+  def end_trigger_for(gp)
+    return [] unless gp.settlements_remaining == 1  # this build will drop to 0
+    [ Turn::Consequences::EndTriggered.new(player: player_order) ]
   end
 
   def families_score_for(game, gp, row, col)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -70,13 +70,15 @@ class Turn
 
     instance = tile_class.new(0)
     if instance.builds_settlement? && instance.build_terrain
-      activate_fixed_terrain_build(game:, klass_name:, terrain: instance.build_terrain)
+      activate_build(game:, klass_name:, terrain: instance.build_terrain)
+    elsif instance.builds_settlement?
+      activate_build(game:, klass_name:, terrain: nil)
     else
       [ error("tile #{klass_name} is not activatable via select_action") ]
     end
   end
 
-  def activate_fixed_terrain_build(game:, klass_name:, terrain:)
+  def activate_build(game:, klass_name:, terrain:)
     gp = game.game_players.find { |g| g.order == player_order }
     return [ error("no current player") ] unless gp
 

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -383,6 +383,8 @@ class Turn
         Turn::SubPhases::FortPhase.from_h(hash["state"] || {})
       when Turn::SubPhases::SettlementMovePhase::TYPE
         Turn::SubPhases::SettlementMovePhase.from_h(hash["state"] || {})
+      when Turn::SubPhases::MeeplePlacementPhase::TYPE
+        Turn::SubPhases::MeeplePlacementPhase.from_h(hash["state"] || {})
       end
     end
 

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -115,22 +115,28 @@ class Turn
     deck_before = (game.deck || []).dup
     discard_before = (game.discard || []).dup
 
-    # Discard the player's hand, then draw one card. If the deck is empty after
-    # the draw, reshuffle from discard. Randomness is decided here so the
-    # consequence carries deterministic before/after state.
+    # Discard the player's hand, then draw one card (or two if they hold a
+    # CrossroadsTile). Reshuffle from discard whenever the deck would be empty.
+    # Randomness is decided here so the consequence carries deterministic
+    # before/after state.
+    draw_count = has_crossroads_tile?(gp) ? 2 : 1
     discard_after = discard_before + hand_before
-    pool = deck_before
-    if pool.empty?
-      pool = discard_after.shuffle
-      discard_after = []
+    pool = deck_before.dup
+    drawn = []
+    draw_count.times do
+      if pool.empty? && discard_after.any?
+        pool = discard_after.shuffle
+        discard_after = []
+      end
+      break if pool.empty?
+      drawn << pool.shift
     end
-    drawn = pool.first
-    deck_after = pool[1..]
+    deck_after = pool
     if deck_after.empty? && discard_after.any?
       deck_after = discard_after.shuffle
       discard_after = []
     end
-    hand_after = drawn.nil? ? [] : [ drawn ]
+    hand_after = drawn
 
     next_order = (player_order + 1) % game.game_players.count
     prior_turn_state = game.current_action.is_a?(Hash) ? game.current_action["turn"] : nil
@@ -151,6 +157,10 @@ class Turn
       *completed,
       Turn::Consequences::IrreversibleBoundary.new
     ]
+  end
+
+  def has_crossroads_tile?(gp)
+    (gp.tiles || []).any? { |t| t["klass"] == "CrossroadsTile" }
   end
 
   def game_complete_for(game)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -143,6 +143,7 @@ class Turn
     prior_turn_state = game.current_action.is_a?(Hash) ? game.current_action["turn"] : nil
     completed = game_complete_for(game)
     tiles_reset = next_player ? [ Turn::Consequences::TilesReset.new(player: next_order, prior_tiles: (next_player.tiles || []).deep_dup) ] : []
+    expired = expired_nomad_tiles_for(gp, game)
 
     [
       Turn::Consequences::HandRefreshed.new(
@@ -156,10 +157,17 @@ class Turn
       ),
       Turn::Consequences::CurrentPlayerAdvanced.new(prior_order: player_order, next_order: next_order),
       *tiles_reset,
+      *expired,
       Turn::Consequences::TurnReset.new(prior_turn_number: game.turn_number, prior_turn_state: prior_turn_state),
       *completed,
       Turn::Consequences::IrreversibleBoundary.new
     ]
+  end
+
+  def expired_nomad_tiles_for(gp, game)
+    expired = (gp.tiles || []).select { |t| t["expires_on_turn"] == game.turn_number }
+    return [] if expired.empty?
+    [ Turn::Consequences::NomadTilesExpired.new(player: player_order, expired_tiles: expired.deep_dup) ]
   end
 
   def has_crossroads_tile?(gp)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -139,8 +139,10 @@ class Turn
     hand_after = drawn
 
     next_order = (player_order + 1) % game.game_players.count
+    next_player = game.game_players.find { |g| g.order == next_order }
     prior_turn_state = game.current_action.is_a?(Hash) ? game.current_action["turn"] : nil
     completed = game_complete_for(game)
+    tiles_reset = next_player ? [ Turn::Consequences::TilesReset.new(player: next_order, prior_tiles: (next_player.tiles || []).deep_dup) ] : []
 
     [
       Turn::Consequences::HandRefreshed.new(
@@ -153,6 +155,7 @@ class Turn
         discard_after: discard_after
       ),
       Turn::Consequences::CurrentPlayerAdvanced.new(prior_order: player_order, next_order: next_order),
+      *tiles_reset,
       Turn::Consequences::TurnReset.new(prior_turn_number: game.turn_number, prior_turn_state: prior_turn_state),
       *completed,
       Turn::Consequences::IrreversibleBoundary.new

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -233,7 +233,7 @@ class Turn
     goals = goal_scores_for(game, gp, terrain, row, col)
     families = families_score_for(game, gp, row, col)
     outpost_consume = outpost_active ? [ Turn::Consequences::OutpostDeactivated.new(prior_active: true) ] : []
-    end_trigger = end_trigger_for(gp)
+    end_trigger = Turn::Consequences::EndTriggered.maybe(game: game, player_order: player_order)
 
     [
       Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: terrain),
@@ -247,11 +247,6 @@ class Turn
       Turn::Consequences::BuildRecorded.new(at: Coordinate.new(row, col).to_key),
       Turn::Consequences::MandatoryRemainingDecremented.new(prior_remaining: mandatory_remaining)
     ]
-  end
-
-  def end_trigger_for(gp)
-    return [] unless gp.settlements_remaining == 1  # this build will drop to 0
-    [ Turn::Consequences::EndTriggered.new(player: player_order) ]
   end
 
   def families_score_for(game, gp, row, col)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -54,12 +54,22 @@ class Turn
       handle_activate_fort(game:)
     when :end_turn
       handle_end_turn(game:)
+    when :select_settlement, :move_settlement
+      handle_sub_phase_action(action_name, game:, **params)
     else
       [ error("unsupported turn action: #{action_name}") ]
     end
   end
 
   private
+
+  def handle_sub_phase_action(action_name, game:, **params)
+    return [ error("no active sub-phase") ] unless sub_phase
+    prior_state = sub_phase_payload(sub_phase)
+    consequences = sub_phase.handle(action_name, game:, player_order:, **params)
+    consequences << Turn::Consequences::SubPhasePopped.new(prior_state: prior_state) if sub_phase.complete?
+    consequences
+  end
 
   def handle_select_action(game:, tile:)
     return [ error("a sub-phase is already active") ] if sub_phase
@@ -73,9 +83,27 @@ class Turn
       activate_build(game:, klass_name:, terrain: instance.build_terrain)
     elsif instance.builds_settlement?
       activate_build(game:, klass_name:, terrain: nil)
+    elsif instance.moves_settlement?
+      activate_settlement_move(game:, klass_name:)
     else
       [ error("tile #{klass_name} is not activatable via select_action") ]
     end
+  end
+
+  def activate_settlement_move(game:, klass_name:)
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+
+    held = gp.find_unused_tile(klass_name)
+    return [ error("no unused #{klass_name} available") ] unless held
+
+    pushed = Turn::SubPhases::SettlementMovePhase.new(tile_klass: klass_name, source: nil)
+    [
+      Turn::Consequences::SubPhasePushed.new(
+        phase_type: Turn::SubPhases::SettlementMovePhase::TYPE,
+        state: pushed.to_h
+      )
+    ]
   end
 
   def activate_build(game:, klass_name:, terrain:)

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -353,6 +353,8 @@ class Turn
         Turn::SubPhases::TileBuildPhase.from_h(hash["state"] || {})
       when Turn::SubPhases::FortPhase::TYPE
         Turn::SubPhases::FortPhase.from_h(hash["state"] || {})
+      when Turn::SubPhases::SettlementMovePhase::TYPE
+        Turn::SubPhases::SettlementMovePhase.from_h(hash["state"] || {})
       end
     end
 

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -26,6 +26,7 @@ class Turn
               when "tiles_reset" then TilesReset
               when "nomad_tiles_expired" then NomadTilesExpired
               when "settlement_moved" then SettlementMoved
+              when "meeple_placed" then MeeplePlaced
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -21,6 +21,7 @@ class Turn
               when "hand_refreshed" then HandRefreshed
               when "current_player_advanced" then CurrentPlayerAdvanced
               when "turn_reset" then TurnReset
+              when "end_triggered" then EndTriggered
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -27,6 +27,7 @@ class Turn
               when "nomad_tiles_expired" then NomadTilesExpired
               when "settlement_moved" then SettlementMoved
               when "meeple_placed" then MeeplePlaced
+              when "meeple_removed" then MeepleRemoved
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -25,6 +25,7 @@ class Turn
               when "game_completed" then GameCompleted
               when "tiles_reset" then TilesReset
               when "nomad_tiles_expired" then NomadTilesExpired
+              when "settlement_moved" then SettlementMoved
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -24,6 +24,7 @@ class Turn
               when "end_triggered" then EndTriggered
               when "game_completed" then GameCompleted
               when "tiles_reset" then TilesReset
+              when "nomad_tiles_expired" then NomadTilesExpired
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -23,6 +23,7 @@ class Turn
               when "turn_reset" then TurnReset
               when "end_triggered" then EndTriggered
               when "game_completed" then GameCompleted
+              when "tiles_reset" then TilesReset
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -22,6 +22,7 @@ class Turn
               when "current_player_advanced" then CurrentPlayerAdvanced
               when "turn_reset" then TurnReset
               when "end_triggered" then EndTriggered
+              when "game_completed" then GameCompleted
               else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
               end
       klass.from_h(hash)

--- a/app/models/turn/consequences/end_triggered.rb
+++ b/app/models/turn/consequences/end_triggered.rb
@@ -1,0 +1,21 @@
+class Turn
+  module Consequences
+    EndTriggered = Data.define(:player) do
+      def apply!(game)
+        game.end_trigger_count += 1
+      end
+
+      def unapply!(game)
+        game.end_trigger_count -= 1
+      end
+
+      def to_h
+        { "type" => "end_triggered", "player" => player }
+      end
+
+      def self.from_h(h)
+        new(player: h["player"])
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/end_triggered.rb
+++ b/app/models/turn/consequences/end_triggered.rb
@@ -16,6 +16,14 @@ class Turn
       def self.from_h(h)
         new(player: h["player"])
       end
+
+      # Returns [EndTriggered] if the named player's next build will exhaust their settlement
+      # supply, else []. Caller appends the result to a build's consequence list.
+      def self.maybe(game:, player_order:)
+        gp = game.game_players.find { |g| g.order == player_order }
+        return [] unless gp && gp.settlements_remaining == 1
+        [ new(player: player_order) ]
+      end
     end
   end
 end

--- a/app/models/turn/consequences/game_completed.rb
+++ b/app/models/turn/consequences/game_completed.rb
@@ -1,0 +1,23 @@
+class Turn
+  module Consequences
+    GameCompleted = Data.define(:prior_state, :prior_scores) do
+      def apply!(game)
+        game.state = "completed"
+        game.scores = Scoring.new(game).compute
+      end
+
+      def unapply!(game)
+        game.state = prior_state
+        game.scores = prior_scores
+      end
+
+      def to_h
+        { "type" => "game_completed", "prior_state" => prior_state, "prior_scores" => prior_scores }
+      end
+
+      def self.from_h(h)
+        new(prior_state: h["prior_state"], prior_scores: h["prior_scores"])
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/meeple_placed.rb
+++ b/app/models/turn/consequences/meeple_placed.rb
@@ -1,0 +1,31 @@
+class Turn
+  module Consequences
+    MeeplePlaced = Data.define(:at, :kind, :player) do
+      def apply!(game)
+        game.board_contents_will_change!
+        game.board_contents.restore_piece(kind, at.row, at.col, player)
+        gp(game).adjust_meeple_supply!(kind, -1)
+      end
+
+      def unapply!(game)
+        game.board_contents_will_change!
+        game.board_contents.remove(at.row, at.col)
+        gp(game).adjust_meeple_supply!(kind, 1)
+      end
+
+      def to_h
+        { "type" => "meeple_placed", "at" => at.to_key, "kind" => kind, "player" => player }
+      end
+
+      def self.from_h(h)
+        new(at: Coordinate.from_key(h["at"]), kind: h["kind"], player: h["player"])
+      end
+
+      private
+
+      def gp(game)
+        game.game_players.find { |g| g.order == player }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/meeple_removed.rb
+++ b/app/models/turn/consequences/meeple_removed.rb
@@ -1,0 +1,31 @@
+class Turn
+  module Consequences
+    MeepleRemoved = Data.define(:at, :kind, :player) do
+      def apply!(game)
+        game.board_contents_will_change!
+        game.board_contents.remove(at.row, at.col)
+        gp(game).adjust_meeple_supply!(kind, 1)
+      end
+
+      def unapply!(game)
+        game.board_contents_will_change!
+        game.board_contents.restore_piece(kind, at.row, at.col, player)
+        gp(game).adjust_meeple_supply!(kind, -1)
+      end
+
+      def to_h
+        { "type" => "meeple_removed", "at" => at.to_key, "kind" => kind, "player" => player }
+      end
+
+      def self.from_h(h)
+        new(at: Coordinate.from_key(h["at"]), kind: h["kind"], player: h["player"])
+      end
+
+      private
+
+      def gp(game)
+        game.game_players.find { |g| g.order == player }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/nomad_tiles_expired.rb
+++ b/app/models/turn/consequences/nomad_tiles_expired.rb
@@ -1,0 +1,28 @@
+class Turn
+  module Consequences
+    # Removes the named expired_tiles from the named player's hand.
+    # Emitted at end_turn for tiles whose `expires_on_turn` matches the turn
+    # being ended. The expired tiles are carried for invertibility.
+    NomadTilesExpired = Data.define(:player, :expired_tiles) do
+      def apply!(game)
+        gp = game.game_players.find { |g| g.order == player }
+        gp.tiles = (gp.tiles || []).reject do |tile|
+          expired_tiles.any? { |e| e["klass"] == tile["klass"] && e["from"] == tile["from"] }
+        end
+      end
+
+      def unapply!(game)
+        gp = game.game_players.find { |g| g.order == player }
+        gp.tiles = (gp.tiles || []) + expired_tiles.deep_dup
+      end
+
+      def to_h
+        { "type" => "nomad_tiles_expired", "player" => player, "expired_tiles" => expired_tiles }
+      end
+
+      def self.from_h(h)
+        new(player: h["player"], expired_tiles: h["expired_tiles"])
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/settlement_moved.rb
+++ b/app/models/turn/consequences/settlement_moved.rb
@@ -1,0 +1,23 @@
+class Turn
+  module Consequences
+    SettlementMoved = Data.define(:from, :to, :player) do
+      def apply!(game)
+        game.board_contents_will_change!
+        game.board_contents.move_settlement(from.row, from.col, to.row, to.col)
+      end
+
+      def unapply!(game)
+        game.board_contents_will_change!
+        game.board_contents.move_settlement(to.row, to.col, from.row, from.col)
+      end
+
+      def to_h
+        { "type" => "settlement_moved", "from" => from.to_key, "to" => to.to_key, "player" => player }
+      end
+
+      def self.from_h(h)
+        new(from: Coordinate.from_key(h["from"]), to: Coordinate.from_key(h["to"]), player: h["player"])
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/tiles_reset.rb
+++ b/app/models/turn/consequences/tiles_reset.rb
@@ -1,0 +1,26 @@
+class Turn
+  module Consequences
+    # Marks all non-permanent tiles on the named player as used: false.
+    # Emitted at end_turn and applied to the *next* player so they can activate
+    # their tiles on the upcoming turn.
+    TilesReset = Data.define(:player, :prior_tiles) do
+      def apply!(game)
+        gp = game.game_players.find { |g| g.order == player }
+        gp.reset_tiles!
+      end
+
+      def unapply!(game)
+        gp = game.game_players.find { |g| g.order == player }
+        gp.tiles = prior_tiles.deep_dup
+      end
+
+      def to_h
+        { "type" => "tiles_reset", "player" => player, "prior_tiles" => prior_tiles }
+      end
+
+      def self.from_h(h)
+        new(player: h["player"], prior_tiles: h["prior_tiles"])
+      end
+    end
+  end
+end

--- a/app/models/turn/sub_phases/fort_phase.rb
+++ b/app/models/turn/sub_phases/fort_phase.rb
@@ -42,7 +42,8 @@ class Turn
         @complete = (@builds_remaining <= 0)
 
         consequences = [
-          Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: fort_terrain)
+          Turn::Consequences::SettlementPlaced.new(at: Coordinate.new(row, col), player: player_order, terrain: fort_terrain),
+          *Turn::Consequences::EndTriggered.maybe(game: game, player_order: player_order)
         ]
         # Only emit SubPhaseStateUpdated if not completing — the completion path
         # emits SubPhasePopped at the Turn layer, which restores prior state on undo.

--- a/app/models/turn/sub_phases/meeple_placement_phase.rb
+++ b/app/models/turn/sub_phases/meeple_placement_phase.rb
@@ -1,33 +1,41 @@
 class Turn
   module SubPhases
-    # Single-click sub-phase for meeple-placing tiles (Barracks, Lighthouse,
-    # Wagon — the placement subset). Validates target ∈ tile.valid_destinations
-    # AND target is empty (placement only — move/remove of own meeples is a
-    # separate slice).
+    # Sub-phase for meeple-action tiles (Barracks, Lighthouse, Wagon).
+    # Dispatches by what's at the clicked hex and the tile's capabilities:
+    #   empty target, no source         → place (MeeplePlaced)
+    #   empty target, source set        → move  (SettlementMoved)
+    #   own meeple of `kind`, !movable  → remove (MeepleRemoved)
+    #   own meeple of `kind`, movable, no source → set source (SubPhaseStateUpdated)
     class MeeplePlacementPhase < Turn::SubPhase
       TYPE = "meeple_placement".freeze
 
-      attr_reader :tile_klass, :kind
+      attr_reader :tile_klass, :kind, :source
 
-      def initialize(tile_klass:, kind:)
+      def initialize(tile_klass:, kind:, source: nil)
         super()
         @tile_klass = tile_klass
         @kind = kind
+        @source = source
         @complete = false
       end
 
       def to_h
-        { "tile_klass" => tile_klass, "kind" => kind }
+        { "tile_klass" => tile_klass, "kind" => kind, "source" => source&.to_key }
       end
 
       def self.from_h(hash)
-        new(tile_klass: hash["tile_klass"], kind: hash["kind"])
+        source_key = hash["source"]
+        new(
+          tile_klass: hash["tile_klass"],
+          kind: hash["kind"],
+          source: source_key ? Coordinate.from_key(source_key) : nil
+        )
       end
 
       def handle(action_name, game:, player_order:, **params)
         case action_name
         when :place_meeple
-          handle_place(game:, player_order:, row: params[:row], col: params[:col])
+          handle_action(game:, player_order:, row: params[:row], col: params[:col])
         else
           [ Turn::Consequences::Error.new(message: "unsupported action: #{action_name}") ]
         end
@@ -35,19 +43,19 @@ class Turn
 
       private
 
-      def handle_place(game:, player_order:, row:, col:)
+      def handle_action(game:, player_order:, row:, col:)
         klass = Tiles::Tile.for_klass(tile_klass)
         return error("unknown tile #{tile_klass}") unless klass
         instance = klass.new(0)
 
         if game.board_contents.empty?(row, col)
-          handle_place_empty(game:, player_order:, instance:, row:, col:)
+          source ? handle_move(instance:, game:, player_order:, row:, col:) : handle_place(instance:, game:, player_order:, row:, col:)
         else
-          handle_click_on_occupied(game:, player_order:, instance:, row:, col:)
+          handle_click_on_occupied(instance:, game:, player_order:, row:, col:)
         end
       end
 
-      def handle_place_empty(game:, player_order:, instance:, row:, col:)
+      def handle_place(instance:, game:, player_order:, row:, col:)
         valid = instance.valid_destinations(
           board_contents: game.board_contents, board: game.board,
           player_order: player_order, supply: supply_hash_for(game, player_order)
@@ -61,11 +69,40 @@ class Turn
         ]
       end
 
-      def handle_click_on_occupied(game:, player_order:, instance:, row:, col:)
+      def handle_move(instance:, game:, player_order:, row:, col:)
+        valid = instance.valid_destinations(
+          from_row: source.row, from_col: source.col,
+          board_contents: game.board_contents, board: game.board,
+          player_order: player_order, supply: supply_hash_for(game, player_order)
+        )
+        return error("not a valid destination") unless valid.include?([ row, col ])
+
+        @complete = true
+        [
+          Turn::Consequences::SettlementMoved.new(from: source, to: Coordinate.new(row, col), player: player_order),
+          Turn::Consequences::TileConsumed.new(klass: tile_klass, player: player_order)
+        ]
+      end
+
+      def handle_click_on_occupied(instance:, game:, player_order:, row:, col:)
         return error("not your meeple") unless game.board_contents.player_at(row, col) == player_order
         return error("not a #{kind}") unless game.board_contents.meeple_at(row, col) == kind
-        return error("move flow not yet supported for #{tile_klass}") if instance.meeple_movable?
 
+        if instance.meeple_movable?
+          handle_set_source(row: row, col: col)
+        else
+          handle_remove(player_order:, row:, col:)
+        end
+      end
+
+      def handle_set_source(row:, col:)
+        return error("source already selected") if source
+        prior = to_h
+        @source = Coordinate.new(row, col)
+        [ Turn::Consequences::SubPhaseStateUpdated.new(prior_state: prior, new_state: to_h) ]
+      end
+
+      def handle_remove(player_order:, row:, col:)
         @complete = true
         [
           Turn::Consequences::MeepleRemoved.new(at: Coordinate.new(row, col), kind: kind, player: player_order),

--- a/app/models/turn/sub_phases/meeple_placement_phase.rb
+++ b/app/models/turn/sub_phases/meeple_placement_phase.rb
@@ -36,11 +36,19 @@ class Turn
       private
 
       def handle_place(game:, player_order:, row:, col:)
-        return error("hex (#{row}, #{col}) is not empty") unless game.board_contents.empty?(row, col)
-
         klass = Tiles::Tile.for_klass(tile_klass)
         return error("unknown tile #{tile_klass}") unless klass
-        valid = klass.new(0).valid_destinations(
+        instance = klass.new(0)
+
+        if game.board_contents.empty?(row, col)
+          handle_place_empty(game:, player_order:, instance:, row:, col:)
+        else
+          handle_click_on_occupied(game:, player_order:, instance:, row:, col:)
+        end
+      end
+
+      def handle_place_empty(game:, player_order:, instance:, row:, col:)
+        valid = instance.valid_destinations(
           board_contents: game.board_contents, board: game.board,
           player_order: player_order, supply: supply_hash_for(game, player_order)
         )
@@ -49,6 +57,18 @@ class Turn
         @complete = true
         [
           Turn::Consequences::MeeplePlaced.new(at: Coordinate.new(row, col), kind: kind, player: player_order),
+          Turn::Consequences::TileConsumed.new(klass: tile_klass, player: player_order)
+        ]
+      end
+
+      def handle_click_on_occupied(game:, player_order:, instance:, row:, col:)
+        return error("not your meeple") unless game.board_contents.player_at(row, col) == player_order
+        return error("not a #{kind}") unless game.board_contents.meeple_at(row, col) == kind
+        return error("move flow not yet supported for #{tile_klass}") if instance.meeple_movable?
+
+        @complete = true
+        [
+          Turn::Consequences::MeepleRemoved.new(at: Coordinate.new(row, col), kind: kind, player: player_order),
           Turn::Consequences::TileConsumed.new(klass: tile_klass, player: player_order)
         ]
       end

--- a/app/models/turn/sub_phases/meeple_placement_phase.rb
+++ b/app/models/turn/sub_phases/meeple_placement_phase.rb
@@ -1,0 +1,66 @@
+class Turn
+  module SubPhases
+    # Single-click sub-phase for meeple-placing tiles (Barracks, Lighthouse,
+    # Wagon — the placement subset). Validates target ∈ tile.valid_destinations
+    # AND target is empty (placement only — move/remove of own meeples is a
+    # separate slice).
+    class MeeplePlacementPhase < Turn::SubPhase
+      TYPE = "meeple_placement".freeze
+
+      attr_reader :tile_klass, :kind
+
+      def initialize(tile_klass:, kind:)
+        super()
+        @tile_klass = tile_klass
+        @kind = kind
+        @complete = false
+      end
+
+      def to_h
+        { "tile_klass" => tile_klass, "kind" => kind }
+      end
+
+      def self.from_h(hash)
+        new(tile_klass: hash["tile_klass"], kind: hash["kind"])
+      end
+
+      def handle(action_name, game:, player_order:, **params)
+        case action_name
+        when :place_meeple
+          handle_place(game:, player_order:, row: params[:row], col: params[:col])
+        else
+          [ Turn::Consequences::Error.new(message: "unsupported action: #{action_name}") ]
+        end
+      end
+
+      private
+
+      def handle_place(game:, player_order:, row:, col:)
+        return error("hex (#{row}, #{col}) is not empty") unless game.board_contents.empty?(row, col)
+
+        klass = Tiles::Tile.for_klass(tile_klass)
+        return error("unknown tile #{tile_klass}") unless klass
+        valid = klass.new(0).valid_destinations(
+          board_contents: game.board_contents, board: game.board,
+          player_order: player_order, supply: supply_hash_for(game, player_order)
+        )
+        return error("not a valid placement hex") unless valid.include?([ row, col ])
+
+        @complete = true
+        [
+          Turn::Consequences::MeeplePlaced.new(at: Coordinate.new(row, col), kind: kind, player: player_order),
+          Turn::Consequences::TileConsumed.new(klass: tile_klass, player: player_order)
+        ]
+      end
+
+      def supply_hash_for(game, player_order)
+        gp = game.game_players.find { |g| g.order == player_order }
+        gp&.supply_hash || Hash.new(0)
+      end
+
+      def error(msg)
+        [ Turn::Consequences::Error.new(message: msg) ]
+      end
+    end
+  end
+end

--- a/app/models/turn/sub_phases/settlement_move_phase.rb
+++ b/app/models/turn/sub_phases/settlement_move_phase.rb
@@ -1,0 +1,78 @@
+class Turn
+  module SubPhases
+    # Multi-click sub-phase for any tile that moves an existing settlement
+    # (Paddock, Wagon move, Ship move). Click 1 (already done = activation
+    # via SubPhasePushed) leaves source: nil. Click 2 selects the source.
+    # Click 3 chooses the destination, validated via tile.valid_destinations.
+    class SettlementMovePhase < Turn::SubPhase
+      TYPE = "settlement_move".freeze
+
+      attr_reader :tile_klass, :source
+
+      def initialize(tile_klass:, source: nil)
+        super()
+        @tile_klass = tile_klass
+        @source = source
+        @complete = false
+      end
+
+      def to_h
+        { "tile_klass" => tile_klass, "source" => source&.to_key }
+      end
+
+      def self.from_h(hash)
+        source_key = hash["source"]
+        new(
+          tile_klass: hash["tile_klass"],
+          source: source_key ? Coordinate.from_key(source_key) : nil
+        )
+      end
+
+      def handle(action_name, game:, player_order:, **params)
+        case action_name
+        when :select_settlement
+          handle_select(game:, player_order:, row: params[:row], col: params[:col])
+        when :move_settlement
+          handle_move(game:, player_order:, row: params[:row], col: params[:col])
+        else
+          [ Turn::Consequences::Error.new(message: "unsupported action: #{action_name}") ]
+        end
+      end
+
+      private
+
+      def handle_select(game:, player_order:, row:, col:)
+        return error("source already selected") if source
+        return error("hex (#{row}, #{col}) is empty") if game.board_contents.empty?(row, col)
+        return error("not your settlement") unless game.board_contents.player_at(row, col) == player_order
+
+        prior = to_h
+        @source = Coordinate.new(row, col)
+        [ Turn::Consequences::SubPhaseStateUpdated.new(prior_state: prior, new_state: to_h) ]
+      end
+
+      def handle_move(game:, player_order:, row:, col:)
+        return error("no source selected") unless source
+
+        klass = Tiles::Tile.for_klass(tile_klass)
+        return error("unknown tile #{tile_klass}") unless klass
+        valid = klass.new(0).valid_destinations(
+          from_row: source.row, from_col: source.col,
+          board_contents: game.board_contents, board: game.board,
+          player_order: player_order
+        )
+        return error("not a valid destination") unless valid.include?([ row, col ])
+
+        @complete = true
+        [
+          Turn::Consequences::SettlementMoved.new(from: source, to: Coordinate.new(row, col), player: player_order),
+          Turn::Consequences::TileConsumed.new(klass: tile_klass, player: player_order)
+        ]
+      end
+
+      def error(msg)
+        [ Turn::Consequences::Error.new(message: msg) ]
+      end
+    end
+  end
+end

--- a/app/models/turn/sub_phases/tile_build_phase.rb
+++ b/app/models/turn/sub_phases/tile_build_phase.rb
@@ -49,7 +49,8 @@ class Turn
         consequences = [
           Turn::Consequences::SettlementPlaced.new(
             at: Coordinate.new(row, col), player: player_order, terrain: restricted_terrain
-          )
+          ),
+          *Turn::Consequences::EndTriggered.maybe(game: game, player_order: player_order)
         ]
 
         game.board_contents.neighbors(row, col).each do |nr, nc|

--- a/app/models/turn/sub_phases/tile_build_phase.rb
+++ b/app/models/turn/sub_phases/tile_build_phase.rb
@@ -79,12 +79,14 @@ class Turn
       def valid_destination?(game, player_order, row, col)
         klass = Tiles::Tile.for_klass(tile_klass)
         return false unless klass
+        gp = game.game_players.find { |g| g.order == player_order }
+        hand = gp&.hand.is_a?(Array) ? gp.hand.first : gp&.hand
         instance = klass.new(0)
         instance.valid_destinations(
           board_contents: game.board_contents,
           board: game.board,
           player_order: player_order,
-          hand: nil
+          hand: hand
         ).include?([ row, col ])
       end
     end

--- a/app/models/turn/sub_phases/tile_build_phase.rb
+++ b/app/models/turn/sub_phases/tile_build_phase.rb
@@ -42,13 +42,18 @@ class Turn
 
       def handle_build(game:, player_order:, row:, col:)
         game.instantiate_board unless game.board
-
-        return error("hex outside restricted terrain #{restricted_terrain}") unless game.board.terrain_at(row, col) == restricted_terrain
         return error("hex (#{row}, #{col}) is not empty") unless game.board_contents.empty?(row, col)
 
+        if restricted_terrain
+          return error("hex outside restricted terrain #{restricted_terrain}") unless game.board.terrain_at(row, col) == restricted_terrain
+        else
+          return error("hex (#{row}, #{col}) not in #{tile_klass} valid_destinations") unless valid_destination?(game, player_order, row, col)
+        end
+
+        terrain = restricted_terrain || game.board.terrain_at(row, col)
         consequences = [
           Turn::Consequences::SettlementPlaced.new(
-            at: Coordinate.new(row, col), player: player_order, terrain: restricted_terrain
+            at: Coordinate.new(row, col), player: player_order, terrain: terrain
           ),
           *Turn::Consequences::EndTriggered.maybe(game: game, player_order: player_order)
         ]
@@ -69,6 +74,18 @@ class Turn
 
       def error(msg)
         [ Turn::Consequences::Error.new(message: msg) ]
+      end
+
+      def valid_destination?(game, player_order, row, col)
+        klass = Tiles::Tile.for_klass(tile_klass)
+        return false unless klass
+        instance = klass.new(0)
+        instance.valid_destinations(
+          board_contents: game.board_contents,
+          board: game.board,
+          player_order: player_order,
+          hand: nil
+        ).include?([ row, col ])
       end
     end
   end

--- a/test/integration/farm_slice_through_new_stack_test.rb
+++ b/test/integration/farm_slice_through_new_stack_test.rb
@@ -26,7 +26,7 @@ class FarmSliceThroughNewStackTest < ActiveSupport::TestCase
     settlements_before = @player.settlements_remaining
 
     # 1. Activate Farm.
-    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: :farm)
+    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: "FarmTile")
     ConsequenceApplier.apply!(@game, activation)
     Broadcaster.publish(@game, activation)
 
@@ -56,7 +56,7 @@ class FarmSliceThroughNewStackTest < ActiveSupport::TestCase
   end
 
   test "build emits a board broadcast" do
-    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: :farm)
+    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: "FarmTile")
     ConsequenceApplier.apply!(@game, activation)
     @game.reload
     @game.instantiate
@@ -75,7 +75,7 @@ class FarmSliceThroughNewStackTest < ActiveSupport::TestCase
     @game.reload
     settlements_before = @player.settlements_remaining
 
-    consequences = Turn.from_game(@game).handle(:select_action, game: @game, tile: :farm)
+    consequences = Turn.from_game(@game).handle(:select_action, game: @game, tile: "FarmTile")
     assert_kind_of Turn::Consequences::Error, consequences.first
     assert_raises(ConsequenceApplier::ApplyError) do
       ConsequenceApplier.apply!(@game, consequences)
@@ -87,7 +87,7 @@ class FarmSliceThroughNewStackTest < ActiveSupport::TestCase
   end
 
   test "build on a non-Grass hex during Farm sub-phase is rejected and sub-phase remains active" do
-    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: :farm)
+    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: "FarmTile")
     ConsequenceApplier.apply!(@game, activation)
     @game.reload
     @game.instantiate

--- a/test/integration/replay_consequence_stream_test.rb
+++ b/test/integration/replay_consequence_stream_test.rb
@@ -24,7 +24,7 @@ class ReplayConsequenceStreamTest < ActiveSupport::TestCase
     snapshot = @game.capture_snapshot
 
     stream = []
-    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: :farm)
+    activation = Turn.from_game(@game).handle(:select_action, game: @game, tile: "FarmTile")
     ConsequenceApplier.apply!(@game, activation)
     stream.concat(activation)
 

--- a/test/models/turn/consequences/end_triggered_test.rb
+++ b/test/models/turn/consequences/end_triggered_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Turn::Consequences::EndTriggeredTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @game.end_trigger_count = 0
+  end
+
+  test "apply! increments game.end_trigger_count" do
+    Turn::Consequences::EndTriggered.new(player: 0).apply!(@game)
+    assert_equal 1, @game.end_trigger_count
+  end
+
+  test "apply! adds to an existing trigger count" do
+    @game.end_trigger_count = 1
+    Turn::Consequences::EndTriggered.new(player: 0).apply!(@game)
+    assert_equal 2, @game.end_trigger_count
+  end
+
+  test "unapply! decrements game.end_trigger_count" do
+    @game.end_trigger_count = 2
+    c = Turn::Consequences::EndTriggered.new(player: 0)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal 2, @game.end_trigger_count
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::EndTriggered.new(player: 0)
+    assert_equal({ "type" => "end_triggered", "player" => 0 }, c.to_h)
+    assert_equal c, Turn::Consequences::EndTriggered.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::EndTriggered.new(player: 0)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/game_completed_test.rb
+++ b/test/models/turn/consequences/game_completed_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class Turn::Consequences::GameCompletedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @game.state = "playing"
+    @game.scores = nil
+  end
+
+  test "apply! sets game.state to completed" do
+    Turn::Consequences::GameCompleted.new(prior_state: "playing", prior_scores: nil).apply!(@game)
+    assert_equal "completed", @game.state
+  end
+
+  test "apply! computes and assigns scores" do
+    Turn::Consequences::GameCompleted.new(prior_state: "playing", prior_scores: nil).apply!(@game)
+    refute_nil @game.scores
+  end
+
+  test "unapply! restores prior state and scores" do
+    c = Turn::Consequences::GameCompleted.new(prior_state: "playing", prior_scores: { "x" => 1 })
+    @game.scores = { "x" => 1 }
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal "playing", @game.state
+    assert_equal({ "x" => 1 }, @game.scores)
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::GameCompleted.new(prior_state: "playing", prior_scores: nil)
+    assert_equal "game_completed", c.to_h["type"]
+    assert_equal c, Turn::Consequences::GameCompleted.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::GameCompleted.new(prior_state: "playing", prior_scores: nil)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/meeple_placed_test.rb
+++ b/test/models/turn/consequences/meeple_placed_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Turn::Consequences::MeeplePlacedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @gp = @game.game_players.find { |g| g.order == 0 }
+    @gp.update!(supply: { "settlements" => 40, "warriors" => 2, "ships" => 1, "wagons" => 1 })
+    @game.instantiate
+  end
+
+  test "apply! places a warrior and decrements warriors supply" do
+    Turn::Consequences::MeeplePlaced.new(at: Coordinate.new(5, 7), kind: "warrior", player: 0).apply!(@game)
+    assert_equal "warrior", @game.board_contents.meeple_at(5, 7)
+    assert_equal 0, @game.board_contents.player_at(5, 7)
+    assert_equal 1, @gp.warriors_remaining
+  end
+
+  test "apply! places a ship and decrements ships supply" do
+    Turn::Consequences::MeeplePlaced.new(at: Coordinate.new(5, 7), kind: "ship", player: 0).apply!(@game)
+    assert_equal "ship", @game.board_contents.meeple_at(5, 7)
+    assert_equal 0, @gp.ships_remaining
+  end
+
+  test "apply! places a wagon and decrements wagons supply" do
+    Turn::Consequences::MeeplePlaced.new(at: Coordinate.new(5, 7), kind: "wagon", player: 0).apply!(@game)
+    assert_equal "wagon", @game.board_contents.meeple_at(5, 7)
+    assert_equal 0, @gp.wagons_remaining
+  end
+
+  test "unapply! removes the meeple and restores the supply" do
+    c = Turn::Consequences::MeeplePlaced.new(at: Coordinate.new(5, 7), kind: "warrior", player: 0)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_nil @game.board_contents.player_at(5, 7)
+    assert_equal 2, @gp.warriors_remaining
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::MeeplePlaced.new(at: Coordinate.new(5, 7), kind: "warrior", player: 0)
+    h = c.to_h
+    assert_equal "meeple_placed", h["type"]
+    assert_equal c, Turn::Consequences::MeeplePlaced.from_h(h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::MeeplePlaced.new(at: Coordinate.new(5, 7), kind: "ship", player: 0)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/meeple_removed_test.rb
+++ b/test/models/turn/consequences/meeple_removed_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Turn::Consequences::MeepleRemovedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @gp = @game.game_players.find { |g| g.order == 0 }
+    @gp.update!(supply: { "settlements" => 40, "warriors" => 1, "ships" => 0, "wagons" => 0 })
+    @game.instantiate
+    @game.board_contents.place_warrior(5, 7, 0)
+  end
+
+  test "apply! removes the meeple and increments supply" do
+    Turn::Consequences::MeepleRemoved.new(at: Coordinate.new(5, 7), kind: "warrior", player: 0).apply!(@game)
+    assert_nil @game.board_contents.player_at(5, 7)
+    assert_equal 2, @gp.warriors_remaining
+  end
+
+  test "unapply! restores the meeple at the hex and decrements supply" do
+    c = Turn::Consequences::MeepleRemoved.new(at: Coordinate.new(5, 7), kind: "warrior", player: 0)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal "warrior", @game.board_contents.meeple_at(5, 7)
+    assert_equal 0, @gp.player_at_meeple_supply_count("warrior") if @gp.respond_to?(:player_at_meeple_supply_count)
+    assert_equal 1, @gp.warriors_remaining
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::MeepleRemoved.new(at: Coordinate.new(5, 7), kind: "warrior", player: 0)
+    h = c.to_h
+    assert_equal "meeple_removed", h["type"]
+    assert_equal c, Turn::Consequences::MeepleRemoved.from_h(h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::MeepleRemoved.new(at: Coordinate.new(5, 7), kind: "warrior", player: 0)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/nomad_tiles_expired_test.rb
+++ b/test/models/turn/consequences/nomad_tiles_expired_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class Turn::Consequences::NomadTilesExpiredTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @gp = @game.game_players.find { |g| g.order == 0 }
+  end
+
+  test "apply! removes the expired tiles from the player" do
+    @gp.tiles = [
+      { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true },
+      { "klass" => "DonationGrassTile", "from" => "[5, 6]", "used" => true, "expires_on_turn" => 4 }
+    ]
+    expired = [ @gp.tiles.last.deep_dup ]
+    Turn::Consequences::NomadTilesExpired.new(player: 0, expired_tiles: expired).apply!(@game)
+    assert_equal 1, @gp.tiles.size
+    assert_equal "FarmTile", @gp.tiles.first["klass"]
+  end
+
+  test "unapply! restores the expired tiles" do
+    @gp.tiles = [ { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true } ]
+    expired = [ { "klass" => "DonationGrassTile", "from" => "[5, 6]", "used" => true, "expires_on_turn" => 4 } ]
+    c = Turn::Consequences::NomadTilesExpired.new(player: 0, expired_tiles: expired)
+    c.apply!(@game)  # no-op since none of the player's tiles are expired
+    c.unapply!(@game)
+    assert_equal 2, @gp.tiles.size
+  end
+
+  test "to_h round-trips through from_h" do
+    expired = [ { "klass" => "X", "from" => "[0, 0]", "used" => true } ]
+    c = Turn::Consequences::NomadTilesExpired.new(player: 0, expired_tiles: expired)
+    assert_equal "nomad_tiles_expired", c.to_h["type"]
+    assert_equal c, Turn::Consequences::NomadTilesExpired.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::NomadTilesExpired.new(player: 0, expired_tiles: [])
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/settlement_moved_test.rb
+++ b/test/models/turn/consequences/settlement_moved_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class Turn::Consequences::SettlementMovedTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @game.instantiate
+  end
+
+  test "apply! moves the settlement from `from` to `to`" do
+    @game.board_contents.place_settlement(5, 5, 0)
+    Turn::Consequences::SettlementMoved.new(
+      from: Coordinate.new(5, 5), to: Coordinate.new(7, 7), player: 0
+    ).apply!(@game)
+    assert_nil @game.board_contents.player_at(5, 5)
+    assert_equal 0, @game.board_contents.player_at(7, 7)
+  end
+
+  test "unapply! moves the settlement back" do
+    @game.board_contents.place_settlement(5, 5, 0)
+    c = Turn::Consequences::SettlementMoved.new(
+      from: Coordinate.new(5, 5), to: Coordinate.new(7, 7), player: 0
+    )
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal 0, @game.board_contents.player_at(5, 5)
+    assert_nil @game.board_contents.player_at(7, 7)
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::SettlementMoved.new(from: Coordinate.new(5, 5), to: Coordinate.new(7, 7), player: 0)
+    h = c.to_h
+    assert_equal "settlement_moved", h["type"]
+    assert_equal "[5, 5]", h["from"]
+    assert_equal "[7, 7]", h["to"]
+    assert_equal c, Turn::Consequences::SettlementMoved.from_h(h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::SettlementMoved.new(from: Coordinate.new(5, 5), to: Coordinate.new(7, 7), player: 0)
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/consequences/tiles_reset_test.rb
+++ b/test/models/turn/consequences/tiles_reset_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class Turn::Consequences::TilesResetTest < ActiveSupport::TestCase
+  def setup
+    @game = games(:game2player)
+    @gp = @game.game_players.find { |g| g.order == 1 }
+  end
+
+  test "apply! marks all non-permanent tiles as used: false on the named player" do
+    @gp.tiles = [
+      { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true },
+      { "klass" => "OracleTile", "from" => "[5, 6]", "used" => true, "permanent" => true }
+    ]
+    Turn::Consequences::TilesReset.new(player: 1, prior_tiles: @gp.tiles.deep_dup).apply!(@game)
+    farm = @gp.tiles.find { |t| t["klass"] == "FarmTile" }
+    oracle = @gp.tiles.find { |t| t["klass"] == "OracleTile" }
+    assert_equal false, farm["used"]
+    assert_equal true, oracle["used"]  # permanent stays used
+  end
+
+  test "unapply! restores prior_tiles" do
+    prior = [
+      { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true },
+      { "klass" => "OracleTile", "from" => "[5, 6]", "used" => true }
+    ]
+    @gp.tiles = prior.deep_dup
+    c = Turn::Consequences::TilesReset.new(player: 1, prior_tiles: prior)
+    c.apply!(@game)
+    c.unapply!(@game)
+    assert_equal prior, @gp.tiles
+  end
+
+  test "to_h round-trips through from_h" do
+    c = Turn::Consequences::TilesReset.new(player: 1, prior_tiles: [ { "klass" => "FarmTile", "used" => true } ])
+    assert_equal "tiles_reset", c.to_h["type"]
+    assert_equal c, Turn::Consequences::TilesReset.from_h(c.to_h)
+  end
+
+  test "factory dispatches by type" do
+    c = Turn::Consequences::TilesReset.new(player: 1, prior_tiles: [])
+    assert_equal c, Turn::Consequences.from_h(c.to_h)
+  end
+end

--- a/test/models/turn/sub_phases/fort_phase_test.rb
+++ b/test/models/turn/sub_phases/fort_phase_test.rb
@@ -51,6 +51,26 @@ class Turn::SubPhases::FortPhaseTest < ActiveSupport::TestCase
     assert_kind_of Turn::Consequences::Error, cs.first
   end
 
+  test "handle(:build) appends EndTriggered when this build empties player supply" do
+    @player.update!(supply: { "settlements" => 1 })
+    target = first_empty_terrain("G")
+    phase = fort_phase(fort_terrain: "G", builds_remaining: 2)
+    cs = phase.handle(:build, game: @game, player_order: 0, row: target[0], col: target[1])
+
+    triggered = cs.find { |c| c.is_a?(Turn::Consequences::EndTriggered) }
+    refute_nil triggered
+    assert_equal 0, triggered.player
+  end
+
+  test "handle(:build) does NOT append EndTriggered when supply remains > 0" do
+    @player.update!(supply: { "settlements" => 5 })
+    target = first_empty_terrain("G")
+    phase = fort_phase(fort_terrain: "G", builds_remaining: 2)
+    cs = phase.handle(:build, game: @game, player_order: 0, row: target[0], col: target[1])
+
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::EndTriggered) })
+  end
+
   test "handle(:build) errors when target is occupied" do
     target = first_empty_terrain("G")
     @game.board_contents.place_settlement(target[0], target[1], 1)

--- a/test/models/turn/sub_phases/meeple_placement_phase_test.rb
+++ b/test/models/turn/sub_phases/meeple_placement_phase_test.rb
@@ -57,13 +57,55 @@ class Turn::SubPhases::MeeplePlacementPhaseTest < ActiveSupport::TestCase
     assert p.complete?
   end
 
-  test "place_meeple on own ship for movable tile (Lighthouse) errors (deferred to slice 3i.7)" do
-    target = first_buildable_hex
+  test "place_meeple on own ship for movable tile (Lighthouse) sets source via SubPhaseStateUpdated" do
+    target = first_water_hex
     @game.board_contents.place_ship(target[0], target[1], 0)
     @game.save!
 
     p = phase(tile_klass: "LighthouseTile", kind: "ship")
     cs = p.handle(:place_meeple, game: @game, player_order: 0, row: target[0], col: target[1])
+
+    update = cs.find { |c| c.is_a?(Turn::Consequences::SubPhaseStateUpdated) }
+    refute_nil update, "expected SubPhaseStateUpdated for source-set"
+    assert_equal "[#{target[0]}, #{target[1]}]", update.new_state["source"]
+    refute p.complete?, "phase should still be active waiting for destination"
+  end
+
+  test "with source set, empty-water target moves the ship (SettlementMoved + TileConsumed; complete)" do
+    src = first_water_hex
+    @game.board_contents.place_ship(src[0], src[1], 0)
+    @game.save!
+
+    # Find a valid move destination via Lighthouse's BFS.
+    instance = Tiles::LighthouseTile.new(0)
+    dst = instance.valid_destinations(
+      from_row: src[0], from_col: src[1],
+      board_contents: @game.board_contents, board: @game.board, player_order: 0
+    ).first
+    refute_nil dst
+
+    p = phase(tile_klass: "LighthouseTile", kind: "ship")
+    p.instance_variable_set(:@source, Coordinate.new(src[0], src[1]))
+
+    cs = p.handle(:place_meeple, game: @game, player_order: 0, row: dst[0], col: dst[1])
+    moved = cs.find { |c| c.is_a?(Turn::Consequences::SettlementMoved) }
+    consumed = cs.find { |c| c.is_a?(Turn::Consequences::TileConsumed) }
+    refute_nil moved
+    refute_nil consumed
+    assert p.complete?
+  end
+
+  test "with source set, click on a hex outside move-mode valid_destinations errors" do
+    src = first_water_hex
+    @game.board_contents.place_ship(src[0], src[1], 0)
+    @game.save!
+
+    p = phase(tile_klass: "LighthouseTile", kind: "ship")
+    p.instance_variable_set(:@source, Coordinate.new(src[0], src[1]))
+
+    # Find a hex very far from src that's empty water (probably outside BFS depth 3).
+    far = far_water_from(src) || [ 0, 0 ]
+    cs = p.handle(:place_meeple, game: @game, player_order: 0, row: far[0], col: far[1])
     assert_kind_of Turn::Consequences::Error, cs.first
   end
 
@@ -109,5 +151,16 @@ class Turn::SubPhases::MeeplePlacementPhaseTest < ActiveSupport::TestCase
       end
     end
     raise "no water hex"
+  end
+
+  def far_water_from(src)
+    20.times do |r|
+      20.times do |c|
+        next unless @game.board.terrain_at(r, c) == "W" && @game.board_contents.empty?(r, c)
+        next if (r - src[0]).abs <= 4 && (c - src[1]).abs <= 4
+        return [ r, c ]
+      end
+    end
+    nil
   end
 end

--- a/test/models/turn/sub_phases/meeple_placement_phase_test.rb
+++ b/test/models/turn/sub_phases/meeple_placement_phase_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class Turn::SubPhases::MeeplePlacementPhaseTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @gp = @game.game_players.find { |g| g.order == 0 }
+    @gp.update!(supply: { "settlements" => 40, "warriors" => 2 })
+  end
+
+  def phase(tile_klass: "BarracksTile", kind: "warrior")
+    Turn::SubPhases::MeeplePlacementPhase.new(tile_klass: tile_klass, kind: kind)
+  end
+
+  test "to_h round-trips through from_h" do
+    p = phase
+    h = p.to_h
+    rebuilt = Turn::SubPhases::MeeplePlacementPhase.from_h(h)
+    assert_equal "BarracksTile", rebuilt.tile_klass
+    assert_equal "warrior", rebuilt.kind
+  end
+
+  test "place_meeple at a valid placement hex emits MeeplePlaced + TileConsumed and completes" do
+    target = first_buildable_hex
+    p = phase
+    cs = p.handle(:place_meeple, game: @game, player_order: 0, row: target[0], col: target[1])
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::MeeplePlaced) && c.kind == "warrior" })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) && c.klass == "BarracksTile" })
+    assert p.complete?
+  end
+
+  test "place_meeple at a non-empty hex errors" do
+    target = first_buildable_hex
+    @game.board_contents.place_settlement(target[0], target[1], 0)
+    @game.save!
+
+    p = phase
+    cs = p.handle(:place_meeple, game: @game, player_order: 0, row: target[0], col: target[1])
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "place_meeple at a hex outside the tile's valid_destinations errors" do
+    p = phase
+    cs = p.handle(:place_meeple, game: @game, player_order: 0, row: 0, col: 0)
+    # (0, 0) on the board may not be buildable terrain; the check rejects either way.
+    assert_kind_of Turn::Consequences::Error, cs.first if cs.first.is_a?(Turn::Consequences::Error)
+  end
+
+  test "unsupported action returns Error" do
+    p = phase
+    cs = p.handle(:nonsense, game: @game, player_order: 0)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  private
+
+  def first_buildable_hex
+    20.times do |r|
+      20.times do |c|
+        next unless [ "C", "D", "F", "G", "T" ].include?(@game.board.terrain_at(r, c))
+        return [ r, c ] if @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no buildable hex"
+  end
+end

--- a/test/models/turn/sub_phases/meeple_placement_phase_test.rb
+++ b/test/models/turn/sub_phases/meeple_placement_phase_test.rb
@@ -34,9 +34,42 @@ class Turn::SubPhases::MeeplePlacementPhaseTest < ActiveSupport::TestCase
     assert p.complete?
   end
 
-  test "place_meeple at a non-empty hex errors" do
+  test "place_meeple at a non-empty non-meeple hex errors" do
     target = first_buildable_hex
     @game.board_contents.place_settlement(target[0], target[1], 0)
+    @game.save!
+
+    p = phase
+    cs = p.handle(:place_meeple, game: @game, player_order: 0, row: target[0], col: target[1])
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "place_meeple on own warrior emits MeepleRemoved + TileConsumed (Barracks remove)" do
+    target = first_buildable_hex
+    @game.board_contents.place_warrior(target[0], target[1], 0)
+    @game.save!
+
+    p = phase  # Barracks (warrior, !meeple_movable?)
+    cs = p.handle(:place_meeple, game: @game, player_order: 0, row: target[0], col: target[1])
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::MeepleRemoved) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) && c.klass == "BarracksTile" })
+    assert p.complete?
+  end
+
+  test "place_meeple on own ship for movable tile (Lighthouse) errors (deferred to slice 3i.7)" do
+    target = first_buildable_hex
+    @game.board_contents.place_ship(target[0], target[1], 0)
+    @game.save!
+
+    p = phase(tile_klass: "LighthouseTile", kind: "ship")
+    cs = p.handle(:place_meeple, game: @game, player_order: 0, row: target[0], col: target[1])
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "place_meeple on opponent meeple errors" do
+    target = first_buildable_hex
+    @game.board_contents.place_warrior(target[0], target[1], 1)
     @game.save!
 
     p = phase

--- a/test/models/turn/sub_phases/meeple_placement_phase_test.rb
+++ b/test/models/turn/sub_phases/meeple_placement_phase_test.rb
@@ -77,11 +77,11 @@ class Turn::SubPhases::MeeplePlacementPhaseTest < ActiveSupport::TestCase
     assert_kind_of Turn::Consequences::Error, cs.first
   end
 
-  test "place_meeple at a hex outside the tile's valid_destinations errors" do
+  test "place_meeple at an unbuildable (e.g. water) hex errors" do
+    target = first_water_hex
     p = phase
-    cs = p.handle(:place_meeple, game: @game, player_order: 0, row: 0, col: 0)
-    # (0, 0) on the board may not be buildable terrain; the check rejects either way.
-    assert_kind_of Turn::Consequences::Error, cs.first if cs.first.is_a?(Turn::Consequences::Error)
+    cs = p.handle(:place_meeple, game: @game, player_order: 0, row: target[0], col: target[1])
+    assert_kind_of Turn::Consequences::Error, cs.first
   end
 
   test "unsupported action returns Error" do
@@ -100,5 +100,14 @@ class Turn::SubPhases::MeeplePlacementPhaseTest < ActiveSupport::TestCase
       end
     end
     raise "no buildable hex"
+  end
+
+  def first_water_hex
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == "W" && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no water hex"
   end
 end

--- a/test/models/turn/sub_phases/settlement_move_phase_test.rb
+++ b/test/models/turn/sub_phases/settlement_move_phase_test.rb
@@ -1,0 +1,108 @@
+require "test_helper"
+
+class Turn::SubPhases::SettlementMovePhaseTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+  end
+
+  def phase(tile_klass: "PaddockTile", source: nil)
+    Turn::SubPhases::SettlementMovePhase.new(tile_klass: tile_klass, source: source)
+  end
+
+  test "to_h round-trips through from_h with nil source" do
+    p = phase
+    h = p.to_h
+    assert_nil h["source"]
+    rebuilt = Turn::SubPhases::SettlementMovePhase.from_h(h)
+    assert_nil rebuilt.source
+  end
+
+  test "to_h round-trips through from_h with a source" do
+    p = phase(source: Coordinate.new(5, 7))
+    h = p.to_h
+    assert_equal "[5, 7]", h["source"]
+    rebuilt = Turn::SubPhases::SettlementMovePhase.from_h(h)
+    assert_equal Coordinate.new(5, 7), rebuilt.source
+  end
+
+  test "select_settlement on own settlement emits SubPhaseStateUpdated with source set" do
+    @game.board_contents.place_settlement(5, 5, 0)
+    p = phase
+    cs = p.handle(:select_settlement, game: @game, player_order: 0, row: 5, col: 5)
+    update = cs.find { |c| c.is_a?(Turn::Consequences::SubPhaseStateUpdated) }
+    refute_nil update
+    assert_equal "[5, 5]", update.new_state["source"]
+  end
+
+  test "select_settlement on opponent settlement errors" do
+    @game.board_contents.place_settlement(5, 5, 1)
+    p = phase
+    cs = p.handle(:select_settlement, game: @game, player_order: 0, row: 5, col: 5)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "select_settlement on empty hex errors" do
+    p = phase
+    cs = p.handle(:select_settlement, game: @game, player_order: 0, row: 5, col: 5)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "move_settlement requires source already selected" do
+    p = phase
+    cs = p.handle(:move_settlement, game: @game, player_order: 0, row: 5, col: 5)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "move_settlement on a valid Paddock destination emits SettlementMoved + TileConsumed and completes" do
+    src = first_paddock_movable_source
+    dst = paddock_destination_for(src)
+
+    @game.board_contents.place_settlement(src[0], src[1], 0)
+    @game.save!
+
+    p = phase(source: Coordinate.new(src[0], src[1]))
+    cs = p.handle(:move_settlement, game: @game, player_order: 0, row: dst[0], col: dst[1])
+
+    moved = cs.find { |c| c.is_a?(Turn::Consequences::SettlementMoved) }
+    consumed = cs.find { |c| c.is_a?(Turn::Consequences::TileConsumed) }
+    refute_nil moved
+    refute_nil consumed
+    assert_equal "PaddockTile", consumed.klass
+    assert p.complete?
+  end
+
+  test "move_settlement to a non-valid destination errors" do
+    @game.board_contents.place_settlement(5, 5, 0)
+    p = phase(source: Coordinate.new(5, 5))
+    cs = p.handle(:move_settlement, game: @game, player_order: 0, row: 0, col: 0)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  private
+
+  def first_paddock_movable_source
+    20.times do |r|
+      20.times do |c|
+        next if @game.board.terrain_at(r, c).nil?
+        next unless @game.board_contents.empty?(r, c)
+        # Source needs to have a valid 2-step destination, i.e. PaddockTile.valid_destinations(from_row: r, from_col: c) is non-empty.
+        instance = Tiles::PaddockTile.new(0)
+        next unless instance.valid_destinations(from_row: r, from_col: c, board_contents: @game.board_contents, board: @game.board, player_order: 0).any?
+        return [ r, c ]
+      end
+    end
+    raise "no Paddock-movable source on this board"
+  end
+
+  def paddock_destination_for(src)
+    Tiles::PaddockTile.new(0).valid_destinations(
+      from_row: src[0], from_col: src[1],
+      board_contents: @game.board_contents, board: @game.board, player_order: 0
+    ).first
+  end
+end

--- a/test/models/turn/sub_phases/tile_build_phase_test.rb
+++ b/test/models/turn/sub_phases/tile_build_phase_test.rb
@@ -113,4 +113,46 @@ class Turn::SubPhases::TileBuildPhaseTest < ActiveSupport::TestCase
 
     refute(consequences.any? { |c| c.is_a?(Turn::Consequences::EndTriggered) })
   end
+
+  test "with restricted_terrain: nil, handle(:build) accepts a hex returned by tile.valid_destinations" do
+    # Set up a Village scenario: player(0) has 3 settlements clustered, build target adjacent to all 3.
+    cluster = three_clustered_grass_with_common_neighbor
+    cluster[:settlements].each { |r, c| @game.board_contents.place_settlement(r, c, 0) }
+    @game.save!
+
+    phase = Turn::SubPhases::TileBuildPhase.new(
+      restricted_terrain: nil, tile_klass: "VillageTile", tile_source: Coordinate.new(0, 0)
+    )
+    target_r, target_c = cluster[:target]
+    cs = phase.handle(:build, game: @game, player_order: 0, row: target_r, col: target_c)
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::SettlementPlaced) })
+  end
+
+  test "with restricted_terrain: nil, handle(:build) errors on a hex NOT in valid_destinations" do
+    phase = Turn::SubPhases::TileBuildPhase.new(
+      restricted_terrain: nil, tile_klass: "VillageTile", tile_source: Coordinate.new(0, 0)
+    )
+    # No player(0) settlements exist; Village requires adjacency to 3 → no valid targets anywhere.
+    cs = phase.handle(:build, game: @game, player_order: 0, row: 5, col: 5)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  private
+
+  # Find 3 grass hexes adjacent to a single common neighbor (also grass + empty),
+  # so a Village build at the common neighbor is valid.
+  def three_clustered_grass_with_common_neighbor
+    20.times do |r|
+      20.times do |c|
+        next unless @game.board.terrain_at(r, c) == "G"
+        next unless @game.board_contents.empty?(r, c)
+        nbrs = @game.board_contents.neighbors(r, c).select { |nr, nc|
+          @game.board.terrain_at(nr, nc) == "G" && @game.board_contents.empty?(nr, nc)
+        }
+        next if nbrs.size < 3
+        return { target: [ r, c ], settlements: nbrs.first(3) }
+      end
+    end
+    raise "no Village-eligible grass cluster on this board"
+  end
 end

--- a/test/models/turn/sub_phases/tile_build_phase_test.rb
+++ b/test/models/turn/sub_phases/tile_build_phase_test.rb
@@ -137,6 +137,38 @@ class Turn::SubPhases::TileBuildPhaseTest < ActiveSupport::TestCase
     assert_kind_of Turn::Consequences::Error, cs.first
   end
 
+  test "Oracle uses player's hand terrain via valid_destinations (adjacent-if-possible rule)" do
+    gp = @game.game_players.find { |g| g.order == 0 }
+    gp.update!(hand: "G")
+    target_r, target_c = nil, nil
+    20.times { |r| 20.times { |c|
+      target_r, target_c = r, c if @game.board.terrain_at(r, c) == "G" && @game.board_contents.empty?(r, c)
+    } }
+    refute_nil target_r
+
+    phase = Turn::SubPhases::TileBuildPhase.new(
+      restricted_terrain: nil, tile_klass: "OracleTile", tile_source: Coordinate.new(2, 3)
+    )
+    cs = phase.handle(:build, game: @game, player_order: 0, row: target_r, col: target_c)
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::SettlementPlaced) })
+  end
+
+  test "Oracle build on a non-hand-terrain hex errors" do
+    gp = @game.game_players.find { |g| g.order == 0 }
+    gp.update!(hand: "G")
+    far_r, far_c = nil, nil
+    20.times { |r| 20.times { |c|
+      far_r, far_c = r, c if @game.board.terrain_at(r, c) == "F" && @game.board_contents.empty?(r, c)
+    } }
+    refute_nil far_r
+
+    phase = Turn::SubPhases::TileBuildPhase.new(
+      restricted_terrain: nil, tile_klass: "OracleTile", tile_source: Coordinate.new(2, 3)
+    )
+    cs = phase.handle(:build, game: @game, player_order: 0, row: far_r, col: far_c)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
   private
 
   # Find 3 grass hexes adjacent to a single common neighbor (also grass + empty),

--- a/test/models/turn/sub_phases/tile_build_phase_test.rb
+++ b/test/models/turn/sub_phases/tile_build_phase_test.rb
@@ -95,4 +95,22 @@ class Turn::SubPhases::TileBuildPhaseTest < ActiveSupport::TestCase
     consequences = phase.handle(:nonsense, game: @game, player_order: 0)
     assert_kind_of Turn::Consequences::Error, consequences.first
   end
+
+  test "handle(:build) appends EndTriggered when this build empties player supply" do
+    gp = @game.game_players.find { |g| g.order == 0 }
+    gp.update!(supply: { "settlements" => 1 })
+    row, col = first_empty_grass
+    consequences = phase.handle(:build, game: @game, player_order: 0, row:, col:)
+
+    refute_nil consequences.find { |c| c.is_a?(Turn::Consequences::EndTriggered) }
+  end
+
+  test "handle(:build) does NOT append EndTriggered when supply remains > 0" do
+    gp = @game.game_players.find { |g| g.order == 0 }
+    gp.update!(supply: { "settlements" => 5 })
+    row, col = first_empty_grass
+    consequences = phase.handle(:build, game: @game, player_order: 0, row:, col:)
+
+    refute(consequences.any? { |c| c.is_a?(Turn::Consequences::EndTriggered) })
+  end
 end

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -77,6 +77,18 @@ class TurnTest < ActiveSupport::TestCase
     end
   end
 
+  test "select_action routes Village/Tower/Tavern to TileBuildPhase with restricted_terrain: nil" do
+    %w[VillageTile TowerTile TavernTile].each do |klass|
+      @player.update!(tiles: [ { "klass" => klass, "from" => "[2, 2]", "used" => false } ])
+      @game.reload
+      cs = turn.handle(:select_action, game: @game, tile: klass)
+      pushed = cs.find { |c| c.is_a?(Turn::Consequences::SubPhasePushed) }
+      refute_nil pushed, "expected SubPhasePushed for #{klass}"
+      assert_nil pushed.state["restricted_terrain"], "#{klass} should not have a fixed terrain"
+      assert_equal klass, pushed.state["tile_klass"]
+    end
+  end
+
   test "select_action errors for unknown tile klass" do
     consequences = turn.handle(:select_action, game: @game, tile: "NonsenseTile")
     assert_kind_of Turn::Consequences::Error, consequences.first

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -158,6 +158,36 @@ class TurnTest < ActiveSupport::TestCase
     refute_nil reset
   end
 
+  test "end_turn emits NomadTilesExpired for tiles whose expires_on_turn matches the ending turn" do
+    @game.update!(turn_number: 4)
+    @player.update!(tiles: [
+      { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true },
+      { "klass" => "DonationGrassTile", "from" => "[5, 6]", "used" => true, "expires_on_turn" => 4 }
+    ])
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:end_turn, game: @game)
+    expired = cs.find { |c| c.is_a?(Turn::Consequences::NomadTilesExpired) }
+    refute_nil expired
+    assert_equal @player.order, expired.player
+    assert_equal 1, expired.expired_tiles.size
+    assert_equal "DonationGrassTile", expired.expired_tiles.first["klass"]
+  end
+
+  test "end_turn does NOT emit NomadTilesExpired when no tiles have matching expires_on_turn" do
+    @game.update!(turn_number: 4)
+    @player.update!(tiles: [
+      { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true },
+      { "klass" => "DonationGrassTile", "from" => "[5, 6]", "used" => true, "expires_on_turn" => 7 }
+    ])
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:end_turn, game: @game)
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::NomadTilesExpired) })
+  end
+
   test "end_turn emits TilesReset for the next player" do
     next_player = @game.game_players.find { |g| g.order != @player.order }
     next_player.update!(tiles: [

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -79,6 +79,59 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal "G", consequences.last.prior_state.dig("state", "restricted_terrain")
   end
 
+  test "build that empties player supply appends EndTriggered" do
+    @player.update!(supply: { "settlements" => 1 })
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    triggered = cs.find { |c| c.is_a?(Turn::Consequences::EndTriggered) }
+    refute_nil triggered
+    assert_equal @player.order, triggered.player
+  end
+
+  test "build that does not empty supply does NOT append EndTriggered" do
+    @player.update!(supply: { "settlements" => 5 })
+    hand_terrain = @player.hand.first
+    target = first_empty_terrain(hand_terrain)
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::EndTriggered) })
+  end
+
+  test "end_turn at the last player's turn appends GameCompleted when ending?" do
+    @game.update!(end_trigger_count: 1)  # ending? is true
+    last_order = @game.game_players.count - 1
+    @game.current_player = @game.game_players.find { |gp| gp.order == last_order }
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    cs = Turn.from_game(@game).handle(:end_turn, game: @game)
+    completed = cs.find { |c| c.is_a?(Turn::Consequences::GameCompleted) }
+    refute_nil completed, "expected GameCompleted at last player's end_turn when ending?"
+  end
+
+  test "end_turn does NOT append GameCompleted when not ending?" do
+    last_order = @game.game_players.count - 1
+    @game.current_player = @game.game_players.find { |gp| gp.order == last_order }
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    cs = Turn.from_game(@game).handle(:end_turn, game: @game)
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::GameCompleted) })
+  end
+
+  test "end_turn does NOT append GameCompleted when ending? but not last player" do
+    @game.update!(end_trigger_count: 1)
+    @game.current_player = @game.game_players.find { |gp| gp.order == 0 }
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    cs = Turn.from_game(@game).handle(:end_turn, game: @game)
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::GameCompleted) })
+  end
+
   test "end_turn emits HandRefreshed + CurrentPlayerAdvanced + TurnReset + IrreversibleBoundary" do
     @game.update!(deck: [ "G", "F", "T" ], discard: [ "C" ])
     @player.update!(hand: [ "T" ])

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -158,6 +158,19 @@ class TurnTest < ActiveSupport::TestCase
     refute_nil reset
   end
 
+  test "end_turn draws 2 cards when player holds a CrossroadsTile" do
+    @game.update!(deck: [ "G", "F", "T" ], discard: [ "C" ])
+    @player.update!(hand: [ "T" ], tiles: [ { "klass" => "CrossroadsTile", "from" => "[5, 5]", "used" => false } ])
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:end_turn, game: @game)
+    refresh = cs.find { |c| c.is_a?(Turn::Consequences::HandRefreshed) }
+    assert_equal [ "G", "F" ], refresh.hand_after
+    assert_equal [ "T" ], refresh.deck_after
+    assert_equal [ "C", "T" ], refresh.discard_after
+  end
+
   test "end_turn reshuffles when deck has only the drawn card" do
     @game.update!(deck: [ "G" ], discard: [ "F", "T" ])
     @player.update!(hand: [ "C" ])

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -158,6 +158,22 @@ class TurnTest < ActiveSupport::TestCase
     refute_nil reset
   end
 
+  test "end_turn emits TilesReset for the next player" do
+    next_player = @game.game_players.find { |g| g.order != @player.order }
+    next_player.update!(tiles: [
+      { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true },
+      { "klass" => "OracleTile", "from" => "[5, 6]", "used" => true, "permanent" => true }
+    ])
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:end_turn, game: @game)
+    reset = cs.find { |c| c.is_a?(Turn::Consequences::TilesReset) }
+    refute_nil reset
+    assert_equal next_player.order, reset.player
+    assert_equal 2, reset.prior_tiles.size
+  end
+
   test "end_turn draws 2 cards when player holds a CrossroadsTile" do
     @game.update!(deck: [ "G", "F", "T" ], discard: [ "C" ])
     @player.update!(hand: [ "T" ], tiles: [ { "klass" => "CrossroadsTile", "from" => "[5, 5]", "used" => false } ])

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -94,6 +94,49 @@ class TurnTest < ActiveSupport::TestCase
     assert_kind_of Turn::Consequences::Error, consequences.first
   end
 
+  test "select_action(BarracksTile) emits SubPhasePushed with MeeplePlacementPhase state and kind: warrior" do
+    @player.update!(tiles: [ { "klass" => "BarracksTile", "from" => "[2, 3]", "used" => false } ])
+    @game.reload
+    @game.instantiate
+    cs = turn.handle(:select_action, game: @game, tile: "BarracksTile")
+    pushed = cs.find { |c| c.is_a?(Turn::Consequences::SubPhasePushed) }
+    refute_nil pushed
+    assert_equal Turn::SubPhases::MeeplePlacementPhase::TYPE, pushed.phase_type
+    assert_equal "BarracksTile", pushed.state["tile_klass"]
+    assert_equal "warrior", pushed.state["kind"]
+  end
+
+  test "select_action(LighthouseTile) routes through MeeplePlacementPhase with kind: ship" do
+    @player.update!(tiles: [ { "klass" => "LighthouseTile", "from" => "[2, 3]", "used" => false } ])
+    @game.reload
+    @game.instantiate
+    cs = turn.handle(:select_action, game: @game, tile: "LighthouseTile")
+    pushed = cs.find { |c| c.is_a?(Turn::Consequences::SubPhasePushed) }
+    refute_nil pushed
+    assert_equal "ship", pushed.state["kind"]
+  end
+
+  test "place_meeple is dispatched to active MeeplePlacementPhase" do
+    @player.update!(supply: { "settlements" => 40, "warriors" => 2 })
+    @game.current_action = {
+      "turn" => {
+        "sub_phase" => {
+          "type" => "meeple_placement",
+          "state" => { "tile_klass" => "BarracksTile", "kind" => "warrior" }
+        }
+      }
+    }
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    target = first_buildable_hex
+    cs = turn.handle(:place_meeple, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected place_meeple to succeed: #{cs.inspect}")
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::MeeplePlaced) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::SubPhasePopped) })
+  end
+
   test "select_action(PaddockTile) emits SubPhasePushed with SettlementMovePhase state" do
     @player.update!(tiles: [ { "klass" => "PaddockTile", "from" => "[2, 3]", "used" => false } ])
     @game.reload
@@ -633,6 +676,16 @@ class TurnTest < ActiveSupport::TestCase
       end
     end
     raise "no empty #{terrain} hex"
+  end
+
+  def first_buildable_hex
+    20.times do |r|
+      20.times do |c|
+        next unless [ "C", "D", "F", "G", "T" ].include?(@game.board.terrain_at(r, c))
+        return [ r, c ] if @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no buildable hex"
   end
 
   def first_empty_terrain_other_than(terrain)

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -21,8 +21,8 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal @player.order, turn.player_order
   end
 
-  test "select_action(:farm) emits SubPhasePushed with TileBuildPhase state" do
-    consequences = turn.handle(:select_action, game: @game, tile: :farm)
+  test "select_action(FarmTile) emits SubPhasePushed with TileBuildPhase state" do
+    consequences = turn.handle(:select_action, game: @game, tile: "FarmTile")
 
     assert_equal 1, consequences.size
     pushed = consequences.first
@@ -33,17 +33,17 @@ class TurnTest < ActiveSupport::TestCase
     assert_equal "[3, 4]", pushed.state["tile_source"]
   end
 
-  test "select_action(:farm) with no Farm tile returns Error" do
+  test "select_action(FarmTile) with no Farm tile returns Error" do
     @player.update!(tiles: [])
     @game.reload
-    consequences = turn.handle(:select_action, game: @game, tile: :farm)
+    consequences = turn.handle(:select_action, game: @game, tile: "FarmTile")
     assert_kind_of Turn::Consequences::Error, consequences.first
   end
 
-  test "select_action(:farm) when Farm already used returns Error" do
+  test "select_action(FarmTile) when Farm already used returns Error" do
     @player.update!(tiles: [ { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true } ])
     @game.reload
-    consequences = turn.handle(:select_action, game: @game, tile: :farm)
+    consequences = turn.handle(:select_action, game: @game, tile: "FarmTile")
     assert_kind_of Turn::Consequences::Error, consequences.first
   end
 
@@ -56,7 +56,37 @@ class TurnTest < ActiveSupport::TestCase
         }
       }
     }
-    consequences = turn.handle(:select_action, game: @game, tile: :farm)
+    consequences = turn.handle(:select_action, game: @game, tile: "FarmTile")
+    assert_kind_of Turn::Consequences::Error, consequences.first
+  end
+
+  test "select_action works for any builds_settlement? tile with fixed build_terrain" do
+    [
+      [ "OasisTile", "D" ],
+      [ "GardenTile", "F" ],
+      [ "MonasteryTile", "C" ],
+      [ "ForestersLodgeTile", "T" ]
+    ].each do |klass, terrain|
+      @player.update!(tiles: [ { "klass" => klass, "from" => "[2, 2]", "used" => false } ])
+      @game.reload
+      cs = turn.handle(:select_action, game: @game, tile: klass)
+      pushed = cs.find { |c| c.is_a?(Turn::Consequences::SubPhasePushed) }
+      refute_nil pushed, "expected SubPhasePushed for #{klass}"
+      assert_equal terrain, pushed.state["restricted_terrain"], "wrong terrain for #{klass}"
+      assert_equal klass, pushed.state["tile_klass"]
+    end
+  end
+
+  test "select_action errors for unknown tile klass" do
+    consequences = turn.handle(:select_action, game: @game, tile: "NonsenseTile")
+    assert_kind_of Turn::Consequences::Error, consequences.first
+  end
+
+  test "select_action errors for a tile that does not build_settlement" do
+    # OutpostTile has its own activate path; passing it through select_action should error.
+    @player.update!(tiles: [ { "klass" => "OutpostTile", "from" => "[2, 2]", "used" => false } ])
+    @game.reload
+    consequences = turn.handle(:select_action, game: @game, tile: "OutpostTile")
     assert_kind_of Turn::Consequences::Error, consequences.first
   end
 

--- a/test/models/turn/turn_test.rb
+++ b/test/models/turn/turn_test.rb
@@ -94,6 +94,41 @@ class TurnTest < ActiveSupport::TestCase
     assert_kind_of Turn::Consequences::Error, consequences.first
   end
 
+  test "select_action(PaddockTile) emits SubPhasePushed with SettlementMovePhase state" do
+    @player.update!(tiles: [ { "klass" => "PaddockTile", "from" => "[2, 3]", "used" => false } ])
+    @game.reload
+    @game.instantiate
+    cs = turn.handle(:select_action, game: @game, tile: "PaddockTile")
+    pushed = cs.find { |c| c.is_a?(Turn::Consequences::SubPhasePushed) }
+    refute_nil pushed
+    assert_equal Turn::SubPhases::SettlementMovePhase::TYPE, pushed.phase_type
+    assert_equal "PaddockTile", pushed.state["tile_klass"]
+    assert_nil pushed.state["source"]
+  end
+
+  test "select_settlement is dispatched to active SettlementMovePhase" do
+    @game.board_contents.place_settlement(5, 5, @player.order)
+    @game.current_action = {
+      "turn" => {
+        "sub_phase" => {
+          "type" => "settlement_move",
+          "state" => { "tile_klass" => "PaddockTile", "source" => nil }
+        }
+      }
+    }
+    @game.save!
+    @game.reload
+    @game.instantiate
+
+    cs = turn.handle(:select_settlement, game: @game, row: 5, col: 5)
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::SubPhaseStateUpdated) })
+  end
+
+  test "move_settlement without active SettlementMovePhase returns Error" do
+    cs = turn.handle(:move_settlement, game: @game, row: 5, col: 5)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
   test "select_action errors for a tile that does not build_settlement" do
     # OutpostTile has its own activate path; passing it through select_action should error.
     @player.update!(tiles: [ { "klass" => "OutpostTile", "from" => "[2, 2]", "used" => false } ])

--- a/test/services/turn_barracks_flow_test.rb
+++ b/test/services/turn_barracks_flow_test.rb
@@ -12,6 +12,37 @@ class TurnBarracksFlowTest < ActiveSupport::TestCase
     @player.update!(supply: { "settlements" => 40, "warriors" => 2 })
   end
 
+  test "activate Barracks on own warrior removes it (full E2E + unwind)" do
+    target = first_buildable_hex
+    @game.board_contents.place_warrior(target[0], target[1], @player.order)
+    @player.update!(
+      tiles: [ { "klass" => "BarracksTile", "from" => "[2, 3]", "used" => false } ],
+      supply: { "settlements" => 40, "warriors" => 0 }  # warrior is on the board
+    )
+    @game.save!
+
+    snapshot_before = snapshot
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    ConsequenceApplier.apply!(@game, turn.handle(:select_action, game: @game, tile: "BarracksTile"))
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:place_meeple, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(target[0], target[1])
+    @player.reload
+    assert_equal 1, @player.warriors_remaining
+
+    2.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
   test "activate Barracks, place warrior, full unwind" do
     @player.update!(tiles: [ { "klass" => "BarracksTile", "from" => "[2, 3]", "used" => false } ])
     snapshot_before = snapshot

--- a/test/services/turn_barracks_flow_test.rb
+++ b/test/services/turn_barracks_flow_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class TurnBarracksFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @player.update!(supply: { "settlements" => 40, "warriors" => 2 })
+  end
+
+  test "activate Barracks, place warrior, full unwind" do
+    @player.update!(tiles: [ { "klass" => "BarracksTile", "from" => "[2, 3]", "used" => false } ])
+    snapshot_before = snapshot
+
+    # Click 1: activate Barracks.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:select_action, game: @game, tile: "BarracksTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "meeple_placement", @game.current_action.dig("turn", "sub_phase", "type")
+
+    # Click 2: place warrior at a buildable hex.
+    target = first_buildable_hex
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:place_meeple, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_equal "warrior", @game.board_contents.meeple_at(target[0], target[1])
+    assert_equal @player.order, @game.board_contents.player_at(target[0], target[1])
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+    @player.reload
+    assert_equal 1, @player.warriors_remaining
+
+    2.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        {
+          order: g.order,
+          settlements: g.settlements_remaining,
+          warriors: g.warriors_remaining,
+          tiles: g.tiles&.deep_dup,
+          taken_from: g.taken_from&.dup
+        }
+      }
+    }
+  end
+
+  def first_buildable_hex
+    20.times do |r|
+      20.times do |c|
+        next unless [ "C", "D", "F", "G", "T" ].include?(@game.board.terrain_at(r, c))
+        return [ r, c ] if @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no buildable hex"
+  end
+end

--- a/test/services/turn_click_persistence_test.rb
+++ b/test/services/turn_click_persistence_test.rb
@@ -31,7 +31,7 @@ class TurnClickPersistenceTest < ActiveSupport::TestCase
     before = snapshot
 
     turn = Turn.from_game(@game)
-    cs = turn.handle(:select_action, game: @game, tile: :farm)
+    cs = turn.handle(:select_action, game: @game, tile: "FarmTile")
     ConsequenceApplier.apply!(@game, cs)
 
     @game.reload

--- a/test/services/turn_end_game_flow_test.rb
+++ b/test/services/turn_end_game_flow_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class TurnEndGameFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @hand_terrain = @player.hand.first
+  end
+
+  test "build that drops supply to 0 increments end_trigger_count via consequence" do
+    @player.update!(supply: { "settlements" => 1 })
+    target = first_empty_terrain(@hand_terrain)
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal 1, @game.end_trigger_count
+    assert @game.ending?
+  end
+
+  test "end_turn after end-trigger by last player completes the game" do
+    @game.update!(end_trigger_count: 1)
+    last_order = @game.game_players.count - 1
+    last_player = @game.game_players.find { |gp| gp.order == last_order }
+    @game.update!(current_player: last_player)
+    last_player.update!(hand: "G") if last_player.hand.is_a?(Array)
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:end_turn, game: @game)
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "completed", @game.state
+    refute_nil @game.scores
+  end
+
+  test "end_turn after end-trigger by a non-last player does NOT complete the game" do
+    @game.update!(end_trigger_count: 1)
+    @game.update!(current_player: @game.game_players.find { |gp| gp.order == 0 })
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:end_turn, game: @game)
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    refute_equal "completed", @game.state
+  end
+
+  test "undo of a build that triggered ending decrements end_trigger_count" do
+    @player.update!(supply: { "settlements" => 1 })
+    target = first_empty_terrain(@hand_terrain)
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    ConsequenceApplier.apply!(@game, turn.handle(:build, game: @game, row: target[0], col: target[1]))
+    assert_equal 1, @game.reload.end_trigger_count
+
+    ConsequenceApplier.unapply!(@game.reload)
+    assert_equal 0, @game.reload.end_trigger_count
+  end
+
+  private
+
+  def first_empty_terrain(terrain)
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no empty #{terrain}"
+  end
+end

--- a/test/services/turn_end_turn_flow_test.rb
+++ b/test/services/turn_end_turn_flow_test.rb
@@ -41,6 +41,41 @@ class TurnEndTurnFlowTest < ActiveSupport::TestCase
     end
   end
 
+  test "end_turn draws 2 cards when player holds CrossroadsTile and resets next player tiles" do
+    @game.update!(deck: [ "G", "F", "T" ], discard: [ "C" ])
+    @player.update!(hand: [ "T" ], tiles: [ { "klass" => "CrossroadsTile", "from" => "[5, 5]", "used" => false } ])
+    next_player = @game.game_players.find { |g| g.order != @player.order }
+    next_player.update!(tiles: [ { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true } ])
+    @game.reload
+    @game.instantiate
+
+    turn = Turn.from_game(@game)
+    ConsequenceApplier.apply!(@game, turn.handle(:end_turn, game: @game))
+
+    @player.reload
+    assert_equal [ "G", "F" ], @player.hand
+    next_player.reload
+    assert_equal false, next_player.tiles.first["used"]
+  end
+
+  test "end_turn drops nomad tiles whose expires_on_turn matches the ending turn" do
+    @game.update!(turn_number: 4)
+    @player.update!(tiles: [
+      { "klass" => "FarmTile", "from" => "[3, 4]", "used" => true },
+      { "klass" => "DonationGrassTile", "from" => "[5, 6]", "used" => true, "expires_on_turn" => 4 }
+    ])
+    @game.reload
+    @game.instantiate
+
+    turn = Turn.from_game(@game)
+    ConsequenceApplier.apply!(@game, turn.handle(:end_turn, game: @game))
+
+    @player.reload
+    klasses = @player.tiles.map { |t| t["klass"] }
+    assert_includes klasses, "FarmTile"
+    refute_includes klasses, "DonationGrassTile"
+  end
+
   test "end_turn refreshes hand by drawing one card" do
     @game.update!(deck: [ "G", "F" ], discard: [ "C" ])
     @player.update!(hand: [ "T" ])

--- a/test/services/turn_lighthouse_flow_test.rb
+++ b/test/services/turn_lighthouse_flow_test.rb
@@ -1,0 +1,94 @@
+require "test_helper"
+
+class TurnLighthouseFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @player.update!(supply: { "settlements" => 40, "ships" => 1 })
+  end
+
+  test "activate Lighthouse, click own ship to set source, click destination to move; full unwind" do
+    src = first_water_hex
+    @game.board_contents.place_ship(src[0], src[1], @player.order)
+    @player.update!(
+      tiles: [ { "klass" => "LighthouseTile", "from" => "[2, 3]", "used" => false } ],
+      supply: { "settlements" => 40, "ships" => 0 }
+    )
+    @game.save!
+
+    instance = Tiles::LighthouseTile.new(0)
+    dst = instance.valid_destinations(
+      from_row: src[0], from_col: src[1],
+      board_contents: @game.board_contents, board: @game.board, player_order: @player.order
+    ).first
+    refute_nil dst
+
+    snapshot_before = snapshot
+
+    # Click 1: activate Lighthouse.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    ConsequenceApplier.apply!(@game, turn.handle(:select_action, game: @game, tile: "LighthouseTile"))
+
+    # Click 2: select ship as source.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:place_meeple, game: @game, row: src[0], col: src[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "[#{src[0]}, #{src[1]}]", @game.current_action.dig("turn", "sub_phase", "state", "source")
+
+    # Click 3: move ship.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:place_meeple, game: @game, row: dst[0], col: dst[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected move to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(src[0], src[1])
+    assert_equal @player.order, @game.board_contents.player_at(dst[0], dst[1])
+    assert_equal "ship", @game.board_contents.meeple_at(dst[0], dst[1])
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+
+    3.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        {
+          order: g.order,
+          settlements: g.settlements_remaining,
+          ships: g.ships_remaining,
+          tiles: g.tiles&.deep_dup,
+          taken_from: g.taken_from&.dup
+        }
+      }
+    }
+  end
+
+  def first_water_hex
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == "W" && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no water hex"
+  end
+end

--- a/test/services/turn_oasis_flow_test.rb
+++ b/test/services/turn_oasis_flow_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class TurnOasisFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "activate Oasis tile, build on Desert, undo back to start" do
+    @player.update!(tiles: [ { "klass" => "OasisTile", "from" => "[2, 3]", "used" => false } ])
+    target = first_empty_terrain("D")
+
+    snapshot_before = snapshot
+
+    # Click 1: activate Oasis.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:select_action, game: @game, tile: "OasisTile")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "tile_build", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_equal "D", @game.current_action.dig("turn", "sub_phase", "state", "restricted_terrain")
+    assert_equal "OasisTile", @game.current_action.dig("turn", "sub_phase", "state", "tile_klass")
+
+    # Click 2: build at the Desert hex.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_equal 0, @game.board_contents.player_at(target[0], target[1])
+
+    # Two clicks → two unwind calls back to the starting snapshot.
+    2.times { ConsequenceApplier.unapply!(@game.reload) }
+
+    assert_equal snapshot_before, snapshot
+    assert_equal 0, TurnClick.where(game: @game).count
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.settlements_remaining, tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  def first_empty_terrain(terrain)
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no empty #{terrain}"
+  end
+end

--- a/test/services/turn_oracle_flow_test.rb
+++ b/test/services/turn_oracle_flow_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+
+class TurnOracleFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @hand_terrain = @player.hand.first
+  end
+
+  test "activate Oracle, build on a hex of hand-terrain, full unwind" do
+    @player.update!(tiles: [ { "klass" => "OracleTile", "from" => "[2, 3]", "used" => false } ])
+    target = first_empty_terrain(@hand_terrain)
+    snapshot_before = snapshot
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:select_action, game: @game, tile: "OracleTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "tile_build", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_nil @game.current_action.dig("turn", "sub_phase", "state", "restricted_terrain")
+    assert_equal "OracleTile", @game.current_action.dig("turn", "sub_phase", "state", "tile_klass")
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected build success at #{target.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_equal @player.order, @game.board_contents.player_at(target[0], target[1])
+
+    2.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  test "Oracle build on a non-hand-terrain hex errors" do
+    @player.update!(tiles: [ { "klass" => "OracleTile", "from" => "[2, 3]", "used" => false } ])
+    different_terrain_hex = first_empty_terrain_other_than(@hand_terrain)
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    ConsequenceApplier.apply!(@game, turn.handle(:select_action, game: @game, tile: "OracleTile"))
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: different_terrain_hex[0], col: different_terrain_hex[1])
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.settlements_remaining, tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  def first_empty_terrain(terrain)
+    20.times do |r|
+      20.times do |c|
+        return [ r, c ] if @game.board.terrain_at(r, c) == terrain && @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no empty #{terrain}"
+  end
+
+  def first_empty_terrain_other_than(terrain)
+    20.times do |r|
+      20.times do |c|
+        t = @game.board.terrain_at(r, c)
+        next if t.nil? || t == terrain
+        return [ r, c ] if @game.board_contents.empty?(r, c)
+      end
+    end
+    raise "no empty non-#{terrain} hex"
+  end
+end

--- a/test/services/turn_paddock_flow_test.rb
+++ b/test/services/turn_paddock_flow_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+class TurnPaddockFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "activate Paddock, select source, move destination, full unwind across 3 clicks" do
+    src = first_paddock_movable_source
+    dst = paddock_destination_for(src)
+
+    @game.board_contents.place_settlement(src[0], src[1], @player.order)
+    @player.update!(tiles: [ { "klass" => "PaddockTile", "from" => "[2, 3]", "used" => false } ])
+    @game.save!
+
+    snapshot_before = snapshot
+
+    # Click 1: activate Paddock.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:select_action, game: @game, tile: "PaddockTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "settlement_move", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_nil @game.current_action.dig("turn", "sub_phase", "state", "source")
+
+    # Click 2: select source.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:select_settlement, game: @game, row: src[0], col: src[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "[#{src[0]}, #{src[1]}]", @game.current_action.dig("turn", "sub_phase", "state", "source")
+
+    # Click 3: move to destination.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:move_settlement, game: @game, row: dst[0], col: dst[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected move_settlement to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(src[0], src[1])
+    assert_equal @player.order, @game.board_contents.player_at(dst[0], dst[1])
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+
+    # Three unapply calls roll all the way back.
+    3.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.settlements_remaining, tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  def first_paddock_movable_source
+    20.times do |r|
+      20.times do |c|
+        next if @game.board.terrain_at(r, c).nil?
+        next unless @game.board_contents.empty?(r, c)
+        instance = Tiles::PaddockTile.new(0)
+        next unless instance.valid_destinations(from_row: r, from_col: c, board_contents: @game.board_contents, board: @game.board, player_order: 0).any?
+        return [ r, c ]
+      end
+    end
+    raise "no Paddock-movable source on this board"
+  end
+
+  def paddock_destination_for(src)
+    Tiles::PaddockTile.new(0).valid_destinations(
+      from_row: src[0], from_col: src[1],
+      board_contents: @game.board_contents, board: @game.board, player_order: 0
+    ).first
+  end
+end

--- a/test/services/turn_round_trip_test.rb
+++ b/test/services/turn_round_trip_test.rb
@@ -36,7 +36,7 @@ class TurnRoundTripTest < ActiveSupport::TestCase
     before = snapshot
 
     turn = Turn.from_game(@game)
-    cs1 = turn.handle(:select_action, game: @game, tile: :farm)
+    cs1 = turn.handle(:select_action, game: @game, tile: "FarmTile")
     ConsequenceApplier.apply!(@game, cs1)
 
     @game.reload

--- a/test/services/turn_village_flow_test.rb
+++ b/test/services/turn_village_flow_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+class TurnVillageFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "activate Village tile, build adjacent to 3+ own settlements, full unwind" do
+    cluster = three_clustered_grass_with_common_neighbor
+    cluster[:settlements].each { |r, c| @game.board_contents.place_settlement(r, c, @player.order) }
+    @player.update!(tiles: [ { "klass" => "VillageTile", "from" => "[2, 3]", "used" => false } ])
+    @game.save!
+
+    target = cluster[:target]
+    snapshot_before = snapshot
+
+    # Click 1: activate Village.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:select_action, game: @game, tile: "VillageTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) })
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "tile_build", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_nil @game.current_action.dig("turn", "sub_phase", "state", "restricted_terrain")
+
+    # Click 2: build at the cluster-adjacent target.
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected build success at #{target.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_equal @player.order, @game.board_contents.player_at(target[0], target[1])
+
+    2.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  test "Village build at a hex NOT adjacent to 3+ settlements errors" do
+    @player.update!(tiles: [ { "klass" => "VillageTile", "from" => "[2, 3]", "used" => false } ])
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    ConsequenceApplier.apply!(@game, turn.handle(:select_action, game: @game, tile: "VillageTile"))
+
+    turn = Turn.from_game(@game.reload)
+    @game.instantiate
+    cs = turn.handle(:build, game: @game, row: 5, col: 5)  # no settlements anywhere yet
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.settlements_remaining, tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  def three_clustered_grass_with_common_neighbor
+    20.times do |r|
+      20.times do |c|
+        next unless @game.board.terrain_at(r, c) == "G"
+        next unless @game.board_contents.empty?(r, c)
+        nbrs = @game.board_contents.neighbors(r, c).select { |nr, nc|
+          @game.board.terrain_at(nr, nc) == "G" && @game.board_contents.empty?(nr, nc)
+        }
+        next if nbrs.size < 3
+        return { target: [ r, c ], settlements: nbrs.first(3) }
+      end
+    end
+    raise "no Village-eligible cluster on this board"
+  end
+end


### PR DESCRIPTION
## Summary

Continuation of slice 3 on top of the previously-merged PR. Brings the new `Turn` stack to **near-feature-parity with the old `TurnEngine`** for everything except Sword/Catapult, City Hall placement, and the controller cutover itself.

29 commits. 1074 tests green. All work is **library-only** — old `TurnEngine` still owns user-facing routes; nothing in this PR is exercised against live games yet.

## Slices included

### Slice 3h.2 — End-game detection
- New `EndTriggered(player)` consequence — fires from any build path that empties a player's settlement supply (mandatory, FortPhase, TileBuildPhase). Reversible.
- New `GameCompleted(prior_state, prior_scores)` consequence — fires from `:end_turn` when `game.ending?` AND last player. Sets state to `"completed"` and assigns scores via `Scoring.new(game).compute`.
- Shared `Turn::Consequences::EndTriggered.maybe(game:, player_order:)` helper used by all build paths.

### Slice 3h.3 — end_turn completeness
- end_turn draws **2 cards** when player holds a CrossroadsTile (per old engine `has_crossroads_tile?`).
- New `TilesReset(player, prior_tiles)` — calls `gp.reset_tiles!` on the *next* player.
- New `NomadTilesExpired(player, expired_tiles)` — drops tiles whose `expires_on_turn` matches `game.turn_number` from the *just-finished* player.

### Slice 3i.1 — Generalized tile-action activation
- `Turn#handle_select_action` now accepts a tile-klass string (\"FarmTile\") instead of a symbol.
- Looks up the class via `Tiles::Tile.for_klass`, dispatches by `tile.builds_settlement?` + `tile.build_terrain`.
- Farm/Oasis/Garden/Monastery/Forester all activate through the same TileBuildPhase code path.

### Slice 3i.2 — Variable-terrain build tiles
- TileBuildPhase delegates to `tile.valid_destinations(...)` when `restricted_terrain` is nil.
- Village/Tower/Tavern functional.

### Slice 3i.3 — Oracle
- TileBuildPhase passes the player's hand to `tile.valid_destinations`.
- Oracle inherits the base `Tile#valid_destinations` (uses hand as terrain when `build_terrain` is nil).

### Slice 3i.4 — Paddock + multi-click sub-phase pattern
- New `SettlementMoved(from, to, player)` consequence (uses `BoardState#move_settlement`).
- New `Turn::SubPhases::SettlementMovePhase(tile_klass, source: nil)` — multi-click: select source, then destination.
- Pattern is reusable for Wagon-move and Ship-move.

### Slice 3i.5 — Meeple placement
- New `MeeplePlaced(at, kind, player)` consequence (place_warrior/_ship/_wagon by kind via `BoardState#restore_piece`).
- New `Turn::SubPhases::MeeplePlacementPhase(tile_klass, kind)` — single-click placement.
- Routes `places_meeple?` tiles into this sub-phase using `tile.meeple_kind`.
- Barracks/Lighthouse/Wagon all place correctly.

### Slice 3i.6 — Meeple removal (non-movable tiles)
- New `MeepleRemoved(at, kind, player)` consequence.
- New `Tile#meeple_movable?` flag (default false; Lighthouse/Wagon override).
- MeeplePlacementPhase dispatch: empty target → place; own meeple + !movable → remove (Barracks).

### Slice 3i.7 — Meeple movement (movable tiles)
- MeeplePlacementPhase gained an optional `source: Coordinate | nil` field.
- Click on own meeple of `kind` for a movable tile → sets source via `SubPhaseStateUpdated`.
- Subsequent empty-target click validates via `tile.valid_destinations(from_row:, from_col:)` and emits `SettlementMoved + TileConsumed`.
- Lighthouse/Wagon now fully functional (place + move).

## Out of scope (explicit TODO for later sub-slices)

- **Sword** (per-opponent settlement removal) — TargetedRemovalPhase TBD
- **City Hall** placement (multi-hex cluster) — TBD
- **Move/remove of own meeple via movable tiles** — partially done, removal via movable still TODO
- **Controller cutover** — old TurnEngine still owns the routes
- Broadcasts on game completion (deferred to controller layer)

## Test plan

- [x] `bin/rails test` — 1074 runs, 0 failures
- [ ] Skim the per-tile flow tests in `test/services/turn_*_flow_test.rb` (Oasis, Village, Oracle, Paddock, Barracks, Lighthouse, end_turn, end_game, fort, outpost)
- [ ] Migration safety: this PR adds **no new migrations** (the `reversible` column on `turn_clicks` was in the prior merged PR)
- [ ] Verify nothing in old `TurnEngine` was modified — slice is library-additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)