### PR TITLE
Deepen Turn tile sub-phases

### DIFF
--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -54,7 +54,7 @@ class Turn
       handle_activate_fort(game:)
     when :end_turn
       handle_end_turn(game:)
-    when :select_settlement, :move_settlement, :place_meeple, :end_tile_action
+    when :select_settlement, :move_settlement, :place_meeple, :remove_settlement, :end_tile_action
       handle_sub_phase_action(action_name, game:, **params)
     else
       [ error("unsupported turn action: #{action_name}") ]
@@ -83,6 +83,8 @@ class Turn
       activate_build(game:, klass_name:, terrain: instance.build_terrain)
     elsif instance.builds_settlement?
       activate_build(game:, klass_name:, terrain: nil)
+    elsif instance.is_a?(Tiles::Nomad::SwordTile)
+      activate_targeted_removal(game:)
     elsif instance.is_a?(Tiles::Nomad::ResettlementTile)
       activate_resettlement(game:)
     elsif instance.moves_settlement?
@@ -137,6 +139,29 @@ class Turn
     [
       Turn::Consequences::SubPhasePushed.new(
         phase_type: Turn::SubPhases::ResettlementPhase::TYPE,
+        state: pushed.to_h
+      )
+    ]
+  end
+
+  def activate_targeted_removal(game:)
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+
+    held = gp.find_unused_tile(Turn::SubPhases::TargetedRemovalPhase::TILE_KLASS)
+    return [ error("no unused SwordTile available") ] unless held
+
+    pending_orders = game.game_players
+      .reject { |player| player.order == player_order }
+      .select { |player| game.board_contents.settlements_for(player.order).any? }
+      .map(&:order)
+      .sort
+    return [ error("no opponents with settlements") ] if pending_orders.empty?
+
+    pushed = Turn::SubPhases::TargetedRemovalPhase.new(pending_orders: pending_orders)
+    [
+      Turn::Consequences::SubPhasePushed.new(
+        phase_type: Turn::SubPhases::TargetedRemovalPhase::TYPE,
         state: pushed.to_h
       )
     ]
@@ -421,6 +446,8 @@ class Turn
         Turn::SubPhases::SettlementMovePhase.from_h(hash["state"] || {})
       when Turn::SubPhases::ResettlementPhase::TYPE
         Turn::SubPhases::ResettlementPhase.from_h(hash["state"] || {})
+      when Turn::SubPhases::TargetedRemovalPhase::TYPE
+        Turn::SubPhases::TargetedRemovalPhase.from_h(hash["state"] || {})
       when Turn::SubPhases::MeeplePlacementPhase::TYPE
         Turn::SubPhases::MeeplePlacementPhase.from_h(hash["state"] || {})
       end

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -54,7 +54,7 @@ class Turn
       handle_activate_fort(game:)
     when :end_turn
       handle_end_turn(game:)
-    when :select_settlement, :move_settlement, :place_meeple
+    when :select_settlement, :move_settlement, :place_meeple, :end_tile_action
       handle_sub_phase_action(action_name, game:, **params)
     else
       [ error("unsupported turn action: #{action_name}") ]
@@ -83,6 +83,8 @@ class Turn
       activate_build(game:, klass_name:, terrain: instance.build_terrain)
     elsif instance.builds_settlement?
       activate_build(game:, klass_name:, terrain: nil)
+    elsif instance.is_a?(Tiles::Nomad::ResettlementTile)
+      activate_resettlement(game:)
     elsif instance.moves_settlement?
       activate_settlement_move(game:, klass_name:)
     elsif instance.places_meeple?
@@ -119,6 +121,22 @@ class Turn
     [
       Turn::Consequences::SubPhasePushed.new(
         phase_type: Turn::SubPhases::SettlementMovePhase::TYPE,
+        state: pushed.to_h
+      )
+    ]
+  end
+
+  def activate_resettlement(game:)
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+
+    held = gp.find_unused_tile(Turn::SubPhases::ResettlementPhase::TILE_KLASS)
+    return [ error("no unused ResettlementTile available") ] unless held
+
+    pushed = Turn::SubPhases::ResettlementPhase.new
+    [
+      Turn::Consequences::SubPhasePushed.new(
+        phase_type: Turn::SubPhases::ResettlementPhase::TYPE,
         state: pushed.to_h
       )
     ]
@@ -401,6 +419,8 @@ class Turn
         Turn::SubPhases::FortPhase.from_h(hash["state"] || {})
       when Turn::SubPhases::SettlementMovePhase::TYPE
         Turn::SubPhases::SettlementMovePhase.from_h(hash["state"] || {})
+      when Turn::SubPhases::ResettlementPhase::TYPE
+        Turn::SubPhases::ResettlementPhase.from_h(hash["state"] || {})
       when Turn::SubPhases::MeeplePlacementPhase::TYPE
         Turn::SubPhases::MeeplePlacementPhase.from_h(hash["state"] || {})
       end

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -54,7 +54,7 @@ class Turn
       handle_activate_fort(game:)
     when :end_turn
       handle_end_turn(game:)
-    when :select_settlement, :move_settlement, :place_meeple, :remove_settlement, :end_tile_action
+    when :select_settlement, :move_settlement, :place_meeple, :remove_settlement, :place_wall, :end_tile_action
       handle_sub_phase_action(action_name, game:, **params)
     else
       [ error("unsupported turn action: #{action_name}") ]
@@ -83,6 +83,8 @@ class Turn
       activate_build(game:, klass_name:, terrain: instance.build_terrain)
     elsif instance.builds_settlement?
       activate_build(game:, klass_name:, terrain: nil)
+    elsif instance.places_wall?
+      activate_wall_placement(game:, klass_name:)
     elsif instance.is_a?(Tiles::Nomad::SwordTile)
       activate_targeted_removal(game:)
     elsif instance.is_a?(Tiles::Nomad::ResettlementTile)
@@ -162,6 +164,23 @@ class Turn
     [
       Turn::Consequences::SubPhasePushed.new(
         phase_type: Turn::SubPhases::TargetedRemovalPhase::TYPE,
+        state: pushed.to_h
+      )
+    ]
+  end
+
+  def activate_wall_placement(game:, klass_name:)
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+    return [ error("no stone walls left") ] if game.stone_walls <= 0
+
+    held = gp.find_unused_tile(klass_name)
+    return [ error("no unused #{klass_name} available") ] unless held
+
+    pushed = Turn::SubPhases::WallPlacementPhase.new
+    [
+      Turn::Consequences::SubPhasePushed.new(
+        phase_type: Turn::SubPhases::WallPlacementPhase::TYPE,
         state: pushed.to_h
       )
     ]
@@ -448,6 +467,8 @@ class Turn
         Turn::SubPhases::ResettlementPhase.from_h(hash["state"] || {})
       when Turn::SubPhases::TargetedRemovalPhase::TYPE
         Turn::SubPhases::TargetedRemovalPhase.from_h(hash["state"] || {})
+      when Turn::SubPhases::WallPlacementPhase::TYPE
+        Turn::SubPhases::WallPlacementPhase.from_h(hash["state"] || {})
       when Turn::SubPhases::MeeplePlacementPhase::TYPE
         Turn::SubPhases::MeeplePlacementPhase.from_h(hash["state"] || {})
       end

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -54,7 +54,7 @@ class Turn
       handle_activate_fort(game:)
     when :end_turn
       handle_end_turn(game:)
-    when :select_settlement, :move_settlement, :place_meeple, :remove_settlement, :place_wall, :end_tile_action
+    when :select_settlement, :move_settlement, :place_meeple, :remove_settlement, :place_wall, :place_city_hall, :end_tile_action
       handle_sub_phase_action(action_name, game:, **params)
     else
       [ error("unsupported turn action: #{action_name}") ]
@@ -83,6 +83,8 @@ class Turn
       activate_build(game:, klass_name:, terrain: instance.build_terrain)
     elsif instance.builds_settlement?
       activate_build(game:, klass_name:, terrain: nil)
+    elsif instance.places_city_hall?
+      activate_city_hall(game:, klass_name:)
     elsif instance.places_wall?
       activate_wall_placement(game:, klass_name:)
     elsif instance.is_a?(Tiles::Nomad::SwordTile)
@@ -181,6 +183,23 @@ class Turn
     [
       Turn::Consequences::SubPhasePushed.new(
         phase_type: Turn::SubPhases::WallPlacementPhase::TYPE,
+        state: pushed.to_h
+      )
+    ]
+  end
+
+  def activate_city_hall(game:, klass_name:)
+    gp = game.game_players.find { |g| g.order == player_order }
+    return [ error("no current player") ] unless gp
+
+    held = gp.find_unused_tile(klass_name)
+    return [ error("no unused #{klass_name} available") ] unless held
+    return [ error("no City Hall supply") ] unless gp.city_halls_remaining?
+
+    pushed = Turn::SubPhases::CityHallPhase.new
+    [
+      Turn::Consequences::SubPhasePushed.new(
+        phase_type: Turn::SubPhases::CityHallPhase::TYPE,
         state: pushed.to_h
       )
     ]
@@ -469,6 +488,8 @@ class Turn
         Turn::SubPhases::TargetedRemovalPhase.from_h(hash["state"] || {})
       when Turn::SubPhases::WallPlacementPhase::TYPE
         Turn::SubPhases::WallPlacementPhase.from_h(hash["state"] || {})
+      when Turn::SubPhases::CityHallPhase::TYPE
+        Turn::SubPhases::CityHallPhase.from_h(hash["state"] || {})
       when Turn::SubPhases::MeeplePlacementPhase::TYPE
         Turn::SubPhases::MeeplePlacementPhase.from_h(hash["state"] || {})
       end

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -2,34 +2,35 @@ class Turn
   module Consequences
     def self.from_h(hash)
       klass = case hash["type"]
-              when "error" then Error
-              when "settlement_placed" then SettlementPlaced
-              when "tile_consumed" then TileConsumed
-              when "tile_picked_up" then TilePickedUp
-              when "sub_phase_pushed" then SubPhasePushed
-              when "sub_phase_popped" then SubPhasePopped
-              when "mandatory_remaining_decremented" then MandatoryRemainingDecremented
-              when "meeple_granted" then MeepleGranted
-              when "goal_scored" then GoalScored
-              when "tile_discarded" then TileDiscarded
-              when "build_recorded" then BuildRecorded
-              when "outpost_activated" then OutpostActivated
-              when "outpost_deactivated" then OutpostDeactivated
-              when "irreversible_boundary" then IrreversibleBoundary
-              when "card_drawn" then CardDrawn
-              when "sub_phase_state_updated" then SubPhaseStateUpdated
-              when "hand_refreshed" then HandRefreshed
-              when "current_player_advanced" then CurrentPlayerAdvanced
-              when "turn_reset" then TurnReset
-              when "end_triggered" then EndTriggered
-              when "game_completed" then GameCompleted
-              when "tiles_reset" then TilesReset
-              when "nomad_tiles_expired" then NomadTilesExpired
-              when "settlement_moved" then SettlementMoved
-              when "meeple_placed" then MeeplePlaced
-              when "meeple_removed" then MeepleRemoved
-              else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
-              end
+      when "error" then Error
+      when "settlement_placed" then SettlementPlaced
+      when "tile_consumed" then TileConsumed
+      when "tile_picked_up" then TilePickedUp
+      when "sub_phase_pushed" then SubPhasePushed
+      when "sub_phase_popped" then SubPhasePopped
+      when "mandatory_remaining_decremented" then MandatoryRemainingDecremented
+      when "meeple_granted" then MeepleGranted
+      when "goal_scored" then GoalScored
+      when "tile_discarded" then TileDiscarded
+      when "build_recorded" then BuildRecorded
+      when "outpost_activated" then OutpostActivated
+      when "outpost_deactivated" then OutpostDeactivated
+      when "irreversible_boundary" then IrreversibleBoundary
+      when "card_drawn" then CardDrawn
+      when "sub_phase_state_updated" then SubPhaseStateUpdated
+      when "hand_refreshed" then HandRefreshed
+      when "current_player_advanced" then CurrentPlayerAdvanced
+      when "turn_reset" then TurnReset
+      when "end_triggered" then EndTriggered
+      when "game_completed" then GameCompleted
+      when "tiles_reset" then TilesReset
+      when "nomad_tiles_expired" then NomadTilesExpired
+      when "nomad_tile_expiry_set" then NomadTileExpirySet
+      when "settlement_moved" then SettlementMoved
+      when "meeple_placed" then MeeplePlaced
+      when "meeple_removed" then MeepleRemoved
+      else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"
+      end
       klass.from_h(hash)
     end
   end

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -29,6 +29,9 @@ class Turn
       when "settlement_moved" then SettlementMoved
       when "piece_removed" then PieceRemoved
       when "wall_placed" then WallPlaced
+      when "city_hall_placed" then CityHallPlaced
+      when "city_hall_supply_decremented" then CityHallSupplyDecremented
+      when "permanent_tile_consumed" then PermanentTileConsumed
       when "meeple_placed" then MeeplePlaced
       when "meeple_removed" then MeepleRemoved
       else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -27,6 +27,7 @@ class Turn
       when "nomad_tiles_expired" then NomadTilesExpired
       when "nomad_tile_expiry_set" then NomadTileExpirySet
       when "settlement_moved" then SettlementMoved
+      when "piece_removed" then PieceRemoved
       when "meeple_placed" then MeeplePlaced
       when "meeple_removed" then MeepleRemoved
       else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"

--- a/app/models/turn/consequences.rb
+++ b/app/models/turn/consequences.rb
@@ -28,6 +28,7 @@ class Turn
       when "nomad_tile_expiry_set" then NomadTileExpirySet
       when "settlement_moved" then SettlementMoved
       when "piece_removed" then PieceRemoved
+      when "wall_placed" then WallPlaced
       when "meeple_placed" then MeeplePlaced
       when "meeple_removed" then MeepleRemoved
       else raise ArgumentError, "unknown consequence type: #{hash["type"].inspect}"

--- a/app/models/turn/consequences/city_hall_placed.rb
+++ b/app/models/turn/consequences/city_hall_placed.rb
@@ -1,0 +1,23 @@
+class Turn
+  module Consequences
+    CityHallPlaced = Data.define(:cluster, :player) do
+      def apply!(game)
+        game.board_contents_will_change!
+        cluster.each { |coord| game.board_contents.place_city_hall_hex(coord.row, coord.col, player) }
+      end
+
+      def unapply!(game)
+        game.board_contents_will_change!
+        cluster.each { |coord| game.board_contents.remove(coord.row, coord.col) }
+      end
+
+      def to_h
+        { "type" => "city_hall_placed", "cluster" => cluster.map(&:to_key), "player" => player }
+      end
+
+      def self.from_h(hash)
+        new(cluster: Array(hash["cluster"]).map { |key| Coordinate.from_key(key) }, player: hash["player"])
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/city_hall_supply_decremented.rb
+++ b/app/models/turn/consequences/city_hall_supply_decremented.rb
@@ -1,0 +1,27 @@
+class Turn
+  module Consequences
+    CityHallSupplyDecremented = Data.define(:player) do
+      def apply!(game)
+        gp(game).decrement_city_hall_supply!
+      end
+
+      def unapply!(game)
+        gp(game).increment_city_hall_supply!
+      end
+
+      def to_h
+        { "type" => "city_hall_supply_decremented", "player" => player }
+      end
+
+      def self.from_h(hash)
+        new(player: hash["player"])
+      end
+
+      private
+
+      def gp(game)
+        game.game_players.find { |g| g.order == player }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/nomad_tile_expiry_set.rb
+++ b/app/models/turn/consequences/nomad_tile_expiry_set.rb
@@ -1,0 +1,48 @@
+class Turn
+  module Consequences
+    NomadTileExpirySet = Data.define(:player, :klass, :from, :expires_on_turn, :prior_expires_on_turn) do
+      def apply!(game)
+        tiles = (gp(game).tiles || []).map do |tile|
+          next tile unless tile["klass"] == klass && tile["from"] == from
+          tile.merge("expires_on_turn" => expires_on_turn)
+        end
+        gp(game).tiles = tiles
+      end
+
+      def unapply!(game)
+        tiles = (gp(game).tiles || []).map do |tile|
+          next tile unless tile["klass"] == klass && tile["from"] == from
+          prior_expires_on_turn ? tile.merge("expires_on_turn" => prior_expires_on_turn) : tile.except("expires_on_turn")
+        end
+        gp(game).tiles = tiles
+      end
+
+      def to_h
+        {
+          "type" => "nomad_tile_expiry_set",
+          "player" => player,
+          "klass" => klass,
+          "from" => from,
+          "expires_on_turn" => expires_on_turn,
+          "prior_expires_on_turn" => prior_expires_on_turn
+        }
+      end
+
+      def self.from_h(hash)
+        new(
+          player: hash["player"],
+          klass: hash["klass"],
+          from: hash["from"],
+          expires_on_turn: hash["expires_on_turn"],
+          prior_expires_on_turn: hash["prior_expires_on_turn"]
+        )
+      end
+
+      private
+
+      def gp(game)
+        game.game_players.find { |g| g.order == player }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/permanent_tile_consumed.rb
+++ b/app/models/turn/consequences/permanent_tile_consumed.rb
@@ -1,0 +1,27 @@
+class Turn
+  module Consequences
+    PermanentTileConsumed = Data.define(:klass, :player) do
+      def apply!(game)
+        gp(game).mark_tile_permanently_used!(klass)
+      end
+
+      def unapply!(game)
+        gp(game).mark_tile_unpermanent!(klass)
+      end
+
+      def to_h
+        { "type" => "permanent_tile_consumed", "klass" => klass, "player" => player }
+      end
+
+      def self.from_h(hash)
+        new(klass: hash["klass"], player: hash["player"])
+      end
+
+      private
+
+      def gp(game)
+        game.game_players.find { |g| g.order == player }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/piece_removed.rb
+++ b/app/models/turn/consequences/piece_removed.rb
@@ -1,0 +1,31 @@
+class Turn
+  module Consequences
+    PieceRemoved = Data.define(:at, :kind, :player) do
+      def apply!(game)
+        game.board_contents_will_change!
+        game.board_contents.remove(at.row, at.col)
+        gp(game).return_piece_to_supply!(kind)
+      end
+
+      def unapply!(game)
+        game.board_contents_will_change!
+        game.board_contents.restore_piece(kind, at.row, at.col, player)
+        gp(game).remove_piece_from_supply!(kind)
+      end
+
+      def to_h
+        { "type" => "piece_removed", "at" => at.to_key, "kind" => kind, "player" => player }
+      end
+
+      def self.from_h(hash)
+        new(at: Coordinate.from_key(hash["at"]), kind: hash["kind"], player: hash["player"])
+      end
+
+      private
+
+      def gp(game)
+        game.game_players.find { |g| g.order == player }
+      end
+    end
+  end
+end

--- a/app/models/turn/consequences/wall_placed.rb
+++ b/app/models/turn/consequences/wall_placed.rb
@@ -1,0 +1,25 @@
+class Turn
+  module Consequences
+    WallPlaced = Data.define(:at) do
+      def apply!(game)
+        game.board_contents_will_change!
+        game.board_contents.place_wall(at.row, at.col)
+        game.stone_walls -= 1
+      end
+
+      def unapply!(game)
+        game.board_contents_will_change!
+        game.board_contents.remove(at.row, at.col)
+        game.stone_walls += 1
+      end
+
+      def to_h
+        { "type" => "wall_placed", "at" => at.to_key }
+      end
+
+      def self.from_h(hash)
+        new(at: Coordinate.from_key(hash["at"]))
+      end
+    end
+  end
+end

--- a/app/models/turn/sub_phases/city_hall_phase.rb
+++ b/app/models/turn/sub_phases/city_hall_phase.rb
@@ -1,0 +1,56 @@
+class Turn
+  module SubPhases
+    class CityHallPhase < Turn::SubPhase
+      TYPE = "city_hall".freeze
+      TILE_KLASS = "CityHallTile".freeze
+
+      def to_h
+        {}
+      end
+
+      def self.from_h(_hash)
+        new
+      end
+
+      def handle(action_name, game:, player_order:, **params)
+        case action_name
+        when :place_city_hall
+          handle_place_city_hall(game:, player_order:, row: params[:row], col: params[:col])
+        else
+          [ error("unsupported action: #{action_name}") ]
+        end
+      end
+
+      private
+
+      def handle_place_city_hall(game:, player_order:, row:, col:)
+        player = game.game_players.find { |gp| gp.order == player_order }
+        return error("no current player") unless player
+
+        valid = tile.valid_destinations(
+          board_contents: game.board_contents,
+          board: game.board,
+          player_order: player_order,
+          supply: player.supply_hash
+        )
+        return error("not a valid City Hall center") unless valid.include?([ row, col ])
+
+        cluster = tile.cluster_hexes(row, col, game.board_contents).map { |r, c| Coordinate.new(r, c) }
+        @complete = true
+        [
+          Turn::Consequences::CityHallPlaced.new(cluster: cluster, player: player_order),
+          Turn::Consequences::CityHallSupplyDecremented.new(player: player_order),
+          Turn::Consequences::PermanentTileConsumed.new(klass: TILE_KLASS, player: player_order)
+        ]
+      end
+
+      def tile
+        Tiles::CityHallTile.new(0)
+      end
+
+      def error(message)
+        [ Turn::Consequences::Error.new(message: message) ]
+      end
+    end
+  end
+end

--- a/app/models/turn/sub_phases/resettlement_phase.rb
+++ b/app/models/turn/sub_phases/resettlement_phase.rb
@@ -1,0 +1,220 @@
+class Turn
+  module SubPhases
+    class ResettlementPhase < Turn::SubPhase
+      TYPE = "resettlement".freeze
+      TILE_KLASS = "ResettlementTile".freeze
+      STARTING_BUDGET = 4
+
+      attr_reader :budget, :vacated, :moves, :source
+
+      def initialize(budget: STARTING_BUDGET, vacated: [], moves: 0, source: nil)
+        super()
+        @budget = budget.to_i
+        @vacated = Array(vacated)
+        @moves = moves.to_i
+        @source = source
+        @complete = false
+      end
+
+      def to_h
+        {
+          "budget" => budget,
+          "vacated" => vacated,
+          "moves" => moves,
+          "source" => source&.to_key
+        }
+      end
+
+      def self.from_h(hash)
+        source_key = hash["source"] || hash["from"]
+        new(
+          budget: hash.fetch("budget", STARTING_BUDGET),
+          vacated: Array(hash["vacated"]),
+          moves: hash.fetch("moves", 0),
+          source: source_key ? Coordinate.from_key(source_key) : nil
+        )
+      end
+
+      def handle(action_name, game:, player_order:, **params)
+        case action_name
+        when :select_settlement
+          handle_select(game:, player_order:, row: params[:row], col: params[:col])
+        when :move_settlement
+          handle_move(game:, player_order:, row: params[:row], col: params[:col])
+        when :end_tile_action
+          handle_end_tile_action(player_order:)
+        else
+          [ error("unsupported action: #{action_name}") ]
+        end
+      end
+
+      private
+
+      def handle_select(game:, player_order:, row:, col:)
+        return error("source already selected") if source
+        return error("no movement budget remaining") if budget <= 0
+        return error("not a selectable settlement") unless tile.selectable_settlements(
+          player_order: player_order,
+          board_contents: game.board_contents,
+          board: game.board,
+          budget: budget,
+          vacated: vacated
+        ).include?([ row, col ])
+
+        prior = to_h
+        @source = Coordinate.new(row, col)
+        [ Turn::Consequences::SubPhaseStateUpdated.new(prior_state: prior, new_state: to_h) ]
+      end
+
+      def handle_move(game:, player_order:, row:, col:)
+        return error("no source selected") unless source
+
+        cost = tile.move_cost(
+          from_row: source.row,
+          from_col: source.col,
+          to_row: row,
+          to_col: col,
+          board_contents: game.board_contents,
+          board: game.board,
+          player_order: player_order,
+          budget: budget,
+          vacated: vacated
+        )
+        return error("not a valid destination") unless cost
+
+        destination = Coordinate.new(row, col)
+        consequences = [
+          Turn::Consequences::SettlementMoved.new(from: source, to: destination, player: player_order),
+          *tile_forfeits(game, player_order, destination),
+          *tile_pickup(game, player_order, destination)
+        ]
+
+        remaining_budget = budget - cost
+        if remaining_budget <= 0
+          @complete = true
+          consequences << Turn::Consequences::TileConsumed.new(klass: TILE_KLASS, player: player_order)
+        else
+          prior = to_h
+          @budget = remaining_budget
+          @vacated = vacated + [ source.to_key ]
+          @moves = moves + 1
+          @source = nil
+          consequences << Turn::Consequences::SubPhaseStateUpdated.new(prior_state: prior, new_state: to_h)
+        end
+
+        consequences
+      end
+
+      def handle_end_tile_action(player_order:)
+        return error("cannot end Resettlement before moving") if moves <= 0
+
+        @complete = true
+        [ Turn::Consequences::TileConsumed.new(klass: TILE_KLASS, player: player_order) ]
+      end
+
+      def tile_forfeits(game, player_order, destination)
+        gp = player_for(game, player_order)
+        settlement_positions = settlements_after_move(game, player_order, destination)
+
+        Array(gp&.tiles).filter_map do |held_tile|
+          next if Tiles::Tile.for_klass(held_tile["klass"])&.new(0)&.nomad_tile?
+          from_key = held_tile["from"]
+          next unless from_key
+          from = Coordinate.from_key(from_key)
+          next unless game.board_contents.tile_klass(from.row, from.col)
+
+          still_adjacent = settlement_positions.any? do |r, c|
+            game.board_contents.neighbors(r, c).any? { |nr, nc| Coordinate.new(nr, nc).to_key == from_key }
+          end
+          next if still_adjacent
+
+          Turn::Consequences::TileDiscarded.new(
+            player: player_order,
+            klass: held_tile["klass"],
+            from: from_key,
+            used: held_tile["used"]
+          )
+        end
+      end
+
+      def tile_pickup(game, player_order, destination)
+        gp = player_for(game, player_order)
+        pickup = pickup_target(game, gp, destination)
+        return [] unless pickup
+
+        consequences = [
+          Turn::Consequences::TilePickedUp.new(from: pickup[:from], klass: pickup[:klass], player: player_order)
+        ]
+        consequences.concat(meeple_grant_for(pickup[:klass], player_order))
+        consequences.concat(immediate_score_for(pickup[:klass], pickup[:from], game, gp, player_order))
+        consequences.concat(nomad_expiry_for(pickup[:klass], pickup[:from], game, gp, player_order))
+        consequences
+      end
+
+      def pickup_target(game, gp, destination)
+        held_locations = gp.held_tile_locations
+        taken_from = gp.taken_from || []
+        game.board_contents.neighbors(destination.row, destination.col).each do |row, col|
+          klass = game.board_contents.tile_klass(row, col)
+          next unless klass && game.board_contents.tile_qty(row, col) > 0
+          key = Coordinate.new(row, col).to_key
+          next if held_locations.include?(key)
+          next if taken_from.include?(key)
+          return { from: Coordinate.new(row, col), klass: klass }
+        end
+        nil
+      end
+
+      def meeple_grant_for(klass, player_order)
+        grant = Tiles::Tile.for_klass(klass)&.new(0)&.meeple_grant
+        return [] unless grant
+        [ Turn::Consequences::MeepleGranted.new(player: player_order, kind: grant["kind"], qty: grant["qty"]) ]
+      end
+
+      def immediate_score_for(klass, from, _game, gp, player_order)
+        score = Tiles::Tile.for_klass(klass)&.new(0)&.immediate_score
+        return [] unless score
+        prior = gp.bonus_scores&.dig(score["goal"]) || 0
+        [
+          Turn::Consequences::GoalScored.new(player: player_order, goal: score["goal"], points: score["points"], prior_score: prior),
+          Turn::Consequences::TileDiscarded.new(player: player_order, klass: klass, from: from.to_key, used: true)
+        ]
+      end
+
+      def nomad_expiry_for(klass, from, game, gp, player_order)
+        tile_obj = Tiles::Tile.for_klass(klass)&.new(0)
+        return [] unless tile_obj&.nomad_tile?
+        return [] if tile_obj.immediate_score
+
+        prior = Array(gp.tiles).find { |t| t["klass"] == klass && t["from"] == from.to_key }&.dig("expires_on_turn")
+        [
+          Turn::Consequences::NomadTileExpirySet.new(
+            player: player_order,
+            klass: klass,
+            from: from.to_key,
+            expires_on_turn: game.turn_number + game.game_players.count,
+            prior_expires_on_turn: prior
+          )
+        ]
+      end
+
+      def settlements_after_move(game, player_order, destination)
+        game.board_contents.settlements_for(player_order).map do |row, col|
+          row == source.row && col == source.col ? [ destination.row, destination.col ] : [ row, col ]
+        end
+      end
+
+      def player_for(game, player_order)
+        game.game_players.find { |gp| gp.order == player_order }
+      end
+
+      def tile
+        Tiles::Nomad::ResettlementTile.new(0)
+      end
+
+      def error(msg)
+        [ Turn::Consequences::Error.new(message: msg) ]
+      end
+    end
+  end
+end

--- a/app/models/turn/sub_phases/settlement_move_phase.rb
+++ b/app/models/turn/sub_phases/settlement_move_phase.rb
@@ -59,7 +59,8 @@ class Turn
         valid = klass.new(0).valid_destinations(
           from_row: source.row, from_col: source.col,
           board_contents: game.board_contents, board: game.board,
-          player_order: player_order
+          player_order: player_order,
+          hand: game.game_players.find { |gp| gp.order == player_order }&.hand&.first
         )
         return error("not a valid destination") unless valid.include?([ row, col ])
 

--- a/app/models/turn/sub_phases/settlement_move_phase.rb
+++ b/app/models/turn/sub_phases/settlement_move_phase.rb
@@ -43,8 +43,10 @@ class Turn
 
       def handle_select(game:, player_order:, row:, col:)
         return error("source already selected") if source
-        return error("hex (#{row}, #{col}) is empty") if game.board_contents.empty?(row, col)
-        return error("not your settlement") unless game.board_contents.player_at(row, col) == player_order
+
+        klass = tile_class
+        return error("unknown tile #{tile_klass}") unless klass
+        return error("not a selectable settlement") unless selectable_settlements(klass, game, player_order).include?([ row, col ])
 
         prior = to_h
         @source = Coordinate.new(row, col)
@@ -54,7 +56,7 @@ class Turn
       def handle_move(game:, player_order:, row:, col:)
         return error("no source selected") unless source
 
-        klass = Tiles::Tile.for_klass(tile_klass)
+        klass = tile_class
         return error("unknown tile #{tile_klass}") unless klass
         valid = klass.new(0).valid_destinations(
           from_row: source.row, from_col: source.col,
@@ -73,6 +75,23 @@ class Turn
 
       def error(msg)
         [ Turn::Consequences::Error.new(message: msg) ]
+      end
+
+      def tile_class
+        Tiles::Tile.for_klass(tile_klass)
+      end
+
+      def selectable_settlements(klass, game, player_order)
+        klass.new(0).selectable_settlements(
+          player_order: player_order,
+          board_contents: game.board_contents,
+          board: game.board,
+          hand: player_for(game, player_order)&.hand&.first
+        )
+      end
+
+      def player_for(game, player_order)
+        game.game_players.find { |gp| gp.order == player_order }
       end
     end
   end

--- a/app/models/turn/sub_phases/targeted_removal_phase.rb
+++ b/app/models/turn/sub_phases/targeted_removal_phase.rb
@@ -1,0 +1,92 @@
+class Turn
+  module SubPhases
+    class TargetedRemovalPhase < Turn::SubPhase
+      TYPE = "targeted_removal".freeze
+      TILE_KLASS = "SwordTile".freeze
+
+      attr_reader :pending_orders
+
+      def initialize(pending_orders:)
+        super()
+        @pending_orders = Array(pending_orders).map(&:to_i)
+        @complete = false
+      end
+
+      def to_h
+        { "pending_orders" => pending_orders }
+      end
+
+      def self.from_h(hash)
+        new(pending_orders: Array(hash["pending_orders"]))
+      end
+
+      def handle(action_name, game:, player_order:, **params)
+        case action_name
+        when :remove_settlement
+          handle_remove(game:, player_order:, row: params[:row], col: params[:col])
+        else
+          [ error("unsupported action: #{action_name}") ]
+        end
+      end
+
+      private
+
+      def handle_remove(game:, player_order:, row:, col:)
+        return error("cannot remove a City Hall hex") if game.board_contents.city_hall_at?(row, col)
+
+        owner_order = game.board_contents.player_at(row, col)
+        return error("not a valid target") unless owner_order && pending_orders.include?(owner_order)
+
+        at = Coordinate.new(row, col)
+        kind = game.board_contents.meeple_at(row, col)
+        consequences = [
+          Turn::Consequences::PieceRemoved.new(at: at, kind: kind, player: owner_order),
+          *tile_forfeits(game, owner_order, at)
+        ]
+
+        remaining = pending_orders - [ owner_order ]
+        if remaining.empty?
+          @complete = true
+          consequences << Turn::Consequences::TileConsumed.new(klass: TILE_KLASS, player: player_order)
+        else
+          prior = to_h
+          @pending_orders = remaining
+          consequences << Turn::Consequences::SubPhaseStateUpdated.new(prior_state: prior, new_state: to_h)
+        end
+
+        consequences
+      end
+
+      def tile_forfeits(game, owner_order, removed_at)
+        owner = game.game_players.find { |gp| gp.order == owner_order }
+        settlement_positions = game.board_contents.settlements_for(owner_order).reject do |row, col|
+          row == removed_at.row && col == removed_at.col
+        end
+
+        Array(owner&.tiles).filter_map do |held_tile|
+          next if Tiles::Tile.for_klass(held_tile["klass"])&.new(0)&.nomad_tile?
+          from_key = held_tile["from"]
+          next unless from_key
+          from = Coordinate.from_key(from_key)
+          next unless game.board_contents.tile_klass(from.row, from.col)
+
+          still_adjacent = settlement_positions.any? do |row, col|
+            game.board_contents.neighbors(row, col).any? { |nr, nc| Coordinate.new(nr, nc).to_key == from_key }
+          end
+          next if still_adjacent
+
+          Turn::Consequences::TileDiscarded.new(
+            player: owner_order,
+            klass: held_tile["klass"],
+            from: from_key,
+            used: held_tile["used"]
+          )
+        end
+      end
+
+      def error(message)
+        [ Turn::Consequences::Error.new(message: message) ]
+      end
+    end
+  end
+end

--- a/app/models/turn/sub_phases/wall_placement_phase.rb
+++ b/app/models/turn/sub_phases/wall_placement_phase.rb
@@ -1,0 +1,105 @@
+class Turn
+  module SubPhases
+    class WallPlacementPhase < Turn::SubPhase
+      TYPE = "wall_placement".freeze
+      TILE_KLASS = "QuarryTile".freeze
+      MAX_WALLS = 2
+
+      attr_reader :walls_placed, :chosen_terrain
+
+      def initialize(walls_placed: 0, chosen_terrain: nil)
+        super()
+        @walls_placed = walls_placed.to_i
+        @chosen_terrain = chosen_terrain
+        @complete = false
+      end
+
+      def to_h
+        { "walls_placed" => walls_placed, "chosen_terrain" => chosen_terrain }
+      end
+
+      def self.from_h(hash)
+        new(walls_placed: hash.fetch("walls_placed", 0), chosen_terrain: hash["chosen_terrain"])
+      end
+
+      def handle(action_name, game:, player_order:, **params)
+        case action_name
+        when :place_wall
+          handle_place_wall(game:, player_order:, row: params[:row], col: params[:col])
+        when :end_tile_action
+          handle_end_tile_action(player_order:)
+        else
+          [ error("unsupported action: #{action_name}") ]
+        end
+      end
+
+      private
+
+      def handle_place_wall(game:, player_order:, row:, col:)
+        return error("no stone walls left") if game.stone_walls <= 0
+
+        terrain = terrain_for(game, player_order, row, col)
+        return error("not a valid wall destination") unless terrain
+
+        consequences = [ Turn::Consequences::WallPlaced.new(at: Coordinate.new(row, col)) ]
+        next_walls_placed = walls_placed + 1
+        next_chosen_terrain = chosen_terrain || terrain
+
+        if next_walls_placed >= MAX_WALLS || remaining_destinations(game, player_order, terrain, excluding: [ row, col ]).empty?
+          @complete = true
+          consequences << Turn::Consequences::TileConsumed.new(klass: TILE_KLASS, player: player_order)
+        else
+          prior = to_h
+          @walls_placed = next_walls_placed
+          @chosen_terrain = next_chosen_terrain
+          consequences << Turn::Consequences::SubPhaseStateUpdated.new(prior_state: prior, new_state: to_h)
+        end
+
+        consequences
+      end
+
+      def handle_end_tile_action(player_order:)
+        return error("cannot end Quarry before placing a wall") if walls_placed <= 0
+
+        @complete = true
+        [ Turn::Consequences::TileConsumed.new(klass: TILE_KLASS, player: player_order) ]
+      end
+
+      def terrain_for(game, player_order, row, col)
+        player = player_for(game, player_order)
+        terrains = chosen_terrain ? [ chosen_terrain ] : Array(player&.hand)
+        terrains.find do |terrain|
+          tile.valid_destinations(
+            board_contents: game.board_contents,
+            board: game.board,
+            player_order: player_order,
+            hand: terrain
+          ).include?([ row, col ])
+        end
+      end
+
+      def remaining_destinations(game, player_order, terrain, excluding:)
+        board_contents = game.board_contents.dup
+        board_contents.place_wall(*excluding)
+        tile.valid_destinations(
+          board_contents: board_contents,
+          board: game.board,
+          player_order: player_order,
+          hand: terrain
+        )
+      end
+
+      def player_for(game, player_order)
+        game.game_players.find { |gp| gp.order == player_order }
+      end
+
+      def tile
+        Tiles::QuarryTile.new(0)
+      end
+
+      def error(message)
+        [ Turn::Consequences::Error.new(message: message) ]
+      end
+    end
+  end
+end

--- a/test/models/turn/consequences/city_hall_placed_test.rb
+++ b/test/models/turn/consequences/city_hall_placed_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class Turn::Consequences::CityHallPlacedTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+  end
+
+  test "apply places city hall hexes" do
+    cluster = [ Coordinate.new(4, 4), Coordinate.new(4, 5) ]
+
+    Turn::Consequences::CityHallPlaced.new(cluster: cluster, player: 0).apply!(@game)
+
+    assert @game.board_contents.city_hall_at?(4, 4)
+    assert @game.board_contents.city_hall_at?(4, 5)
+    assert_equal 0, @game.board_contents.player_at(4, 4)
+  end
+
+  test "unapply removes city hall hexes" do
+    @game.board_contents.place_city_hall_hex(4, 4, 0)
+    @game.board_contents.place_city_hall_hex(4, 5, 0)
+    cluster = [ Coordinate.new(4, 4), Coordinate.new(4, 5) ]
+
+    Turn::Consequences::CityHallPlaced.new(cluster: cluster, player: 0).unapply!(@game)
+
+    assert @game.board_contents.empty?(4, 4)
+    assert @game.board_contents.empty?(4, 5)
+  end
+
+  test "to_h round-trips through from_h" do
+    consequence = Turn::Consequences::CityHallPlaced.new(
+      cluster: [ Coordinate.new(4, 4), Coordinate.new(4, 5) ],
+      player: 0
+    )
+
+    assert_equal consequence, Turn::Consequences::CityHallPlaced.from_h(consequence.to_h)
+  end
+end

--- a/test/models/turn/consequences/city_hall_supply_decremented_test.rb
+++ b/test/models/turn/consequences/city_hall_supply_decremented_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Turn::Consequences::CityHallSupplyDecrementedTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @player = @game.game_players.find { |gp| gp.order == 0 }
+    @player.add_city_halls!(1)
+  end
+
+  test "apply decrements city hall supply" do
+    Turn::Consequences::CityHallSupplyDecremented.new(player: @player.order).apply!(@game)
+
+    assert_equal 0, @player.city_halls_remaining
+  end
+
+  test "unapply increments city hall supply" do
+    @player.decrement_city_hall_supply!
+
+    Turn::Consequences::CityHallSupplyDecremented.new(player: @player.order).unapply!(@game)
+
+    assert_equal 1, @player.city_halls_remaining
+  end
+
+  test "to_h round-trips through from_h" do
+    consequence = Turn::Consequences::CityHallSupplyDecremented.new(player: 0)
+
+    assert_equal consequence, Turn::Consequences::CityHallSupplyDecremented.from_h(consequence.to_h)
+  end
+end

--- a/test/models/turn/consequences/permanent_tile_consumed_test.rb
+++ b/test/models/turn/consequences/permanent_tile_consumed_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Turn::Consequences::PermanentTileConsumedTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @player = @game.game_players.find { |gp| gp.order == 0 }
+    @player.tiles = [ { "klass" => "CityHallTile", "from" => "[2, 5]", "used" => false } ]
+  end
+
+  test "apply marks tile used and permanent" do
+    Turn::Consequences::PermanentTileConsumed.new(klass: "CityHallTile", player: @player.order).apply!(@game)
+
+    tile = @player.tiles.first
+    assert tile["used"]
+    assert tile["permanent"]
+  end
+
+  test "unapply marks tile unused and non-permanent" do
+    @player.mark_tile_permanently_used!("CityHallTile")
+
+    Turn::Consequences::PermanentTileConsumed.new(klass: "CityHallTile", player: @player.order).unapply!(@game)
+
+    tile = @player.tiles.first
+    assert_equal false, tile["used"]
+    assert_nil tile["permanent"]
+  end
+
+  test "to_h round-trips through from_h" do
+    consequence = Turn::Consequences::PermanentTileConsumed.new(klass: "CityHallTile", player: 0)
+
+    assert_equal consequence, Turn::Consequences::PermanentTileConsumed.from_h(consequence.to_h)
+  end
+end

--- a/test/models/turn/consequences/piece_removed_test.rb
+++ b/test/models/turn/consequences/piece_removed_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class Turn::Consequences::PieceRemovedTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.game_players.find { |gp| gp.order == 1 }
+  end
+
+  test "apply removes settlement and returns it to supply" do
+    @game.board_contents.place_settlement(4, 4, @player.order)
+    before = @player.settlements_remaining
+
+    Turn::Consequences::PieceRemoved.new(at: Coordinate.new(4, 4), kind: nil, player: @player.order).apply!(@game)
+
+    assert_nil @game.board_contents.player_at(4, 4)
+    assert_equal before + 1, @player.settlements_remaining
+  end
+
+  test "unapply restores warrior and removes it from supply" do
+    @player.add_warriors!(1)
+    before = @player.warriors_remaining
+    consequence = Turn::Consequences::PieceRemoved.new(at: Coordinate.new(4, 4), kind: "warrior", player: @player.order)
+
+    consequence.unapply!(@game)
+
+    assert @game.board_contents.warrior_at?(4, 4)
+    assert_equal before - 1, @player.warriors_remaining
+  end
+
+  test "to_h round-trips through from_h" do
+    consequence = Turn::Consequences::PieceRemoved.new(at: Coordinate.new(4, 4), kind: "ship", player: 1)
+
+    assert_equal consequence, Turn::Consequences::PieceRemoved.from_h(consequence.to_h)
+  end
+end

--- a/test/models/turn/consequences/wall_placed_test.rb
+++ b/test/models/turn/consequences/wall_placed_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Turn::Consequences::WallPlacedTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+  end
+
+  test "apply places wall and decrements stone walls" do
+    before = @game.stone_walls
+
+    Turn::Consequences::WallPlaced.new(at: Coordinate.new(4, 4)).apply!(@game)
+
+    assert_equal "Wall", @game.board_contents.tile_klass(4, 4)
+    assert_equal before - 1, @game.stone_walls
+  end
+
+  test "unapply removes wall and increments stone walls" do
+    @game.board_contents.place_wall(4, 4)
+    @game.stone_walls = 20
+
+    Turn::Consequences::WallPlaced.new(at: Coordinate.new(4, 4)).unapply!(@game)
+
+    assert @game.board_contents.empty?(4, 4)
+    assert_equal 21, @game.stone_walls
+  end
+
+  test "to_h round-trips through from_h" do
+    consequence = Turn::Consequences::WallPlaced.new(at: Coordinate.new(4, 4))
+
+    assert_equal consequence, Turn::Consequences::WallPlaced.from_h(consequence.to_h)
+  end
+end

--- a/test/models/turn/sub_phases/city_hall_phase_test.rb
+++ b/test/models/turn/sub_phases/city_hall_phase_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class Turn::SubPhases::CityHallPhaseTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.boards = [ [ 1, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    @game.instantiate
+    @player = @game.current_player
+    @player.add_city_halls!(1)
+    @player.save!
+  end
+
+  test "to_h round-trips through from_h" do
+    rebuilt = Turn::SubPhases::CityHallPhase.from_h(Turn::SubPhases::CityHallPhase.new.to_h)
+
+    assert_instance_of Turn::SubPhases::CityHallPhase, rebuilt
+  end
+
+  test "place_city_hall emits placement supply permanent tile and completes" do
+    center = setup_city_hall_center
+    phase = Turn::SubPhases::CityHallPhase.new
+
+    cs = phase.handle(:place_city_hall, game: @game, player_order: @player.order, row: center[0], col: center[1])
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::CityHallPlaced) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::CityHallSupplyDecremented) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::PermanentTileConsumed) && c.klass == "CityHallTile" })
+    assert phase.complete?
+  end
+
+  test "place_city_hall rejects invalid center" do
+    setup_city_hall_center
+
+    cs = Turn::SubPhases::CityHallPhase.new.handle(:place_city_hall, game: @game, player_order: @player.order, row: 0, col: 0)
+
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "place_city_hall rejects when supply is empty" do
+    center = setup_city_hall_center
+    @player.decrement_city_hall_supply!
+    @player.save!
+
+    cs = Turn::SubPhases::CityHallPhase.new.handle(:place_city_hall, game: @game, player_order: @player.order, row: center[0], col: center[1])
+
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  private
+
+  def setup_city_hall_center
+    center = find_empty_cluster_center
+    cluster = Set.new([ center ] + @game.board_contents.neighbors(*center))
+    outer = @game.board_contents.neighbors(*center).lazy.flat_map { |row, col| @game.board_contents.neighbors(row, col) }
+      .find { |hex| !cluster.include?(hex) && @game.board_contents.empty?(*hex) }
+    raise "no outer settlement spot" unless outer
+
+    @game.board_contents.place_settlement(*outer, @player.order)
+    @game.save!
+    center
+  end
+
+  def find_empty_cluster_center
+    20.times do |row|
+      20.times do |col|
+        next unless Tiles::Tile::BUILDABLE_TERRAIN.include?(@game.board.terrain_at(row, col))
+        next unless @game.board_contents.empty?(row, col)
+        neighbors = @game.board_contents.neighbors(row, col)
+        next unless neighbors.size == 6
+        next unless neighbors.all? { |nr, nc|
+          @game.board_contents.empty?(nr, nc) && Tiles::Tile::BUILDABLE_TERRAIN.include?(@game.board.terrain_at(nr, nc))
+        }
+        return [ row, col ]
+      end
+    end
+    raise "no City Hall cluster center"
+  end
+end

--- a/test/models/turn/sub_phases/resettlement_phase_test.rb
+++ b/test/models/turn/sub_phases/resettlement_phase_test.rb
@@ -1,0 +1,110 @@
+require "test_helper"
+
+class Turn::SubPhases::ResettlementPhaseTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.boards = [ [ 10, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "to_h round-trips through from_h" do
+    phase = Turn::SubPhases::ResettlementPhase.new(
+      budget: 2,
+      vacated: [ "[0, 0]" ],
+      moves: 1,
+      source: Coordinate.new(0, 1)
+    )
+
+    rebuilt = Turn::SubPhases::ResettlementPhase.from_h(phase.to_h)
+
+    assert_equal 2, rebuilt.budget
+    assert_equal [ "[0, 0]" ], rebuilt.vacated
+    assert_equal 1, rebuilt.moves
+    assert_equal Coordinate.new(0, 1), rebuilt.source
+  end
+
+  test "select_settlement records selectable source" do
+    @game.board_contents.place_settlement(0, 0, @player.order)
+
+    cs = phase.handle(:select_settlement, game: @game, player_order: @player.order, row: 0, col: 0)
+
+    update = cs.find { |c| c.is_a?(Turn::Consequences::SubPhaseStateUpdated) }
+    refute_nil update
+    assert_equal "[0, 0]", update.new_state["source"]
+  end
+
+  test "select_settlement rejects city hall source" do
+    @game.board_contents.place_city_hall_hex(0, 0, @player.order)
+
+    cs = phase.handle(:select_settlement, game: @game, player_order: @player.order, row: 0, col: 0)
+
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "move_settlement deducts actual cost and keeps phase active when budget remains" do
+    @game.board_contents.place_settlement(0, 0, @player.order)
+    p = phase(source: Coordinate.new(0, 0))
+
+    cs = p.handle(:move_settlement, game: @game, player_order: @player.order, row: 0, col: 2)
+
+    moved = cs.find { |c| c.is_a?(Turn::Consequences::SettlementMoved) }
+    update = cs.find { |c| c.is_a?(Turn::Consequences::SubPhaseStateUpdated) }
+    refute_nil moved
+    refute_nil update
+    assert_equal 2, update.new_state["budget"]
+    assert_equal [ "[0, 0]" ], update.new_state["vacated"]
+    assert_equal 1, update.new_state["moves"]
+    assert_nil update.new_state["source"]
+    refute p.complete?
+  end
+
+  test "move_settlement consumes tile and completes when budget is exhausted" do
+    @game.board_contents.place_settlement(0, 0, @player.order)
+    p = phase(budget: 1, source: Coordinate.new(0, 0))
+
+    cs = p.handle(:move_settlement, game: @game, player_order: @player.order, row: 0, col: 1)
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::SettlementMoved) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) && c.klass == "ResettlementTile" })
+    assert p.complete?
+  end
+
+  test "move_settlement emits pickup and forfeit consequences" do
+    @player.update!(tiles: [
+      { "klass" => "FarmTile", "from" => "[1, 0]", "used" => false },
+      { "klass" => "ResettlementTile", "from" => "[0, 0]", "used" => false }
+    ])
+    @game.board_contents.place_settlement(0, 0, @player.order)
+    @game.board_contents.place_tile(1, 0, "FarmTile", 1)
+    @game.board_contents.place_tile(0, 3, "OracleTile", 1)
+    p = phase(source: Coordinate.new(0, 0))
+
+    cs = p.handle(:move_settlement, game: @game, player_order: @player.order, row: 0, col: 2)
+
+    discard = cs.find { |c| c.is_a?(Turn::Consequences::TileDiscarded) && c.klass == "FarmTile" }
+    pickup = cs.find { |c| c.is_a?(Turn::Consequences::TilePickedUp) && c.klass == "OracleTile" }
+    refute_nil discard
+    refute_nil pickup
+  end
+
+  test "end_tile_action consumes tile only after at least one move" do
+    cs = phase(moves: 0).handle(:end_tile_action, game: @game, player_order: @player.order)
+    assert_kind_of Turn::Consequences::Error, cs.first
+
+    p = phase(moves: 1)
+    cs = p.handle(:end_tile_action, game: @game, player_order: @player.order)
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) && c.klass == "ResettlementTile" })
+    assert p.complete?
+  end
+
+  private
+
+  def phase(budget: 4, vacated: [], moves: 0, source: nil)
+    Turn::SubPhases::ResettlementPhase.new(budget:, vacated:, moves:, source:)
+  end
+end

--- a/test/models/turn/sub_phases/settlement_move_phase_test.rb
+++ b/test/models/turn/sub_phases/settlement_move_phase_test.rb
@@ -31,24 +31,45 @@ class Turn::SubPhases::SettlementMovePhaseTest < ActiveSupport::TestCase
   end
 
   test "select_settlement on own settlement emits SubPhaseStateUpdated with source set" do
-    @game.board_contents.place_settlement(5, 5, 0)
+    src = first_paddock_movable_source
+    @game.board_contents.place_settlement(src[0], src[1], 0)
     p = phase
-    cs = p.handle(:select_settlement, game: @game, player_order: 0, row: 5, col: 5)
+    cs = p.handle(:select_settlement, game: @game, player_order: 0, row: src[0], col: src[1])
     update = cs.find { |c| c.is_a?(Turn::Consequences::SubPhaseStateUpdated) }
     refute_nil update
-    assert_equal "[5, 5]", update.new_state["source"]
+    assert_equal "[#{src[0]}, #{src[1]}]", update.new_state["source"]
   end
 
   test "select_settlement on opponent settlement errors" do
-    @game.board_contents.place_settlement(5, 5, 1)
+    src = first_paddock_movable_source
+    @game.board_contents.place_settlement(src[0], src[1], 1)
     p = phase
-    cs = p.handle(:select_settlement, game: @game, player_order: 0, row: 5, col: 5)
+    cs = p.handle(:select_settlement, game: @game, player_order: 0, row: src[0], col: src[1])
     assert_kind_of Turn::Consequences::Error, cs.first
   end
 
   test "select_settlement on empty hex errors" do
     p = phase
     cs = p.handle(:select_settlement, game: @game, player_order: 0, row: 5, col: 5)
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "select_settlement on own settlement without a valid tile destination errors" do
+    src = first_paddock_movable_source
+    @game.board_contents.place_settlement(src[0], src[1], 0)
+    @game.game_players.find { |gp| gp.order == 0 }.update!(hand: [])
+
+    cs = phase(tile_klass: "BarnTile").handle(:select_settlement, game: @game, player_order: 0, row: src[0], col: src[1])
+
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "select_settlement on a city hall settlement errors even when it has destinations" do
+    src = first_paddock_movable_source
+    @game.board_contents.place_city_hall_hex(src[0], src[1], 0)
+
+    cs = phase.handle(:select_settlement, game: @game, player_order: 0, row: src[0], col: src[1])
+
     assert_kind_of Turn::Consequences::Error, cs.first
   end
 
@@ -74,6 +95,25 @@ class Turn::SubPhases::SettlementMovePhaseTest < ActiveSupport::TestCase
     refute_nil consumed
     assert_equal "PaddockTile", consumed.klass
     assert p.complete?
+  end
+
+  test "Turn completion emits only SettlementMoved TileConsumed and SubPhasePopped" do
+    src = first_paddock_movable_source
+    dst = paddock_destination_for(src)
+    @game.board_contents.place_settlement(src[0], src[1], 0)
+    @game.current_action = {
+      "turn" => {
+        "sub_phase" => {
+          "type" => Turn::SubPhases::SettlementMovePhase::TYPE,
+          "state" => { "tile_klass" => "PaddockTile", "source" => "[#{src[0]}, #{src[1]}]" }
+        }
+      }
+    }
+    @game.save!
+
+    cs = Turn.from_game(@game.reload).handle(:move_settlement, game: @game, row: dst[0], col: dst[1])
+
+    assert_equal [ Turn::Consequences::SettlementMoved, Turn::Consequences::TileConsumed, Turn::Consequences::SubPhasePopped ], cs.map(&:class)
   end
 
   test "move_settlement to a non-valid destination errors" do

--- a/test/models/turn/sub_phases/targeted_removal_phase_test.rb
+++ b/test/models/turn/sub_phases/targeted_removal_phase_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class Turn::SubPhases::TargetedRemovalPhaseTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @actor = @game.current_player
+    @opponent = @game.game_players.find { |gp| gp.order != @actor.order }
+  end
+
+  test "to_h round-trips through from_h" do
+    phase = Turn::SubPhases::TargetedRemovalPhase.new(pending_orders: [ 1, 2 ])
+
+    rebuilt = Turn::SubPhases::TargetedRemovalPhase.from_h(phase.to_h)
+
+    assert_equal [ 1, 2 ], rebuilt.pending_orders
+  end
+
+  test "remove_settlement removes target owner from pending orders when more remain" do
+    @game.board_contents.place_settlement(4, 4, @opponent.order)
+    phase = Turn::SubPhases::TargetedRemovalPhase.new(pending_orders: [ @opponent.order, 2 ])
+
+    cs = phase.handle(:remove_settlement, game: @game, player_order: @actor.order, row: 4, col: 4)
+
+    removed = cs.find { |c| c.is_a?(Turn::Consequences::PieceRemoved) }
+    update = cs.find { |c| c.is_a?(Turn::Consequences::SubPhaseStateUpdated) }
+    refute_nil removed
+    assert_equal @opponent.order, removed.player
+    assert_equal [ 2 ], update.new_state["pending_orders"]
+    refute phase.complete?
+  end
+
+  test "remove_settlement consumes tile and completes after last pending owner" do
+    @game.board_contents.place_settlement(4, 4, @opponent.order)
+    phase = Turn::SubPhases::TargetedRemovalPhase.new(pending_orders: [ @opponent.order ])
+
+    cs = phase.handle(:remove_settlement, game: @game, player_order: @actor.order, row: 4, col: 4)
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::PieceRemoved) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) && c.klass == "SwordTile" && c.player == @actor.order })
+    assert phase.complete?
+  end
+
+  test "remove_settlement rejects city hall hex" do
+    @game.board_contents.place_city_hall_hex(4, 4, @opponent.order)
+    phase = Turn::SubPhases::TargetedRemovalPhase.new(pending_orders: [ @opponent.order ])
+
+    cs = phase.handle(:remove_settlement, game: @game, player_order: @actor.order, row: 4, col: 4)
+
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "remove_settlement rejects owner not pending" do
+    @game.board_contents.place_settlement(4, 4, @opponent.order)
+    phase = Turn::SubPhases::TargetedRemovalPhase.new(pending_orders: [ 2 ])
+
+    cs = phase.handle(:remove_settlement, game: @game, player_order: @actor.order, row: 4, col: 4)
+
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "remove_settlement emits tile forfeit for removed owner's unsupported location tile" do
+    @opponent.update!(tiles: [ { "klass" => "PaddockTile", "from" => "[4, 5]", "used" => false } ])
+    @game.board_contents.place_settlement(4, 4, @opponent.order)
+    @game.board_contents.place_tile(4, 5, "PaddockTile", 2)
+    phase = Turn::SubPhases::TargetedRemovalPhase.new(pending_orders: [ @opponent.order ])
+
+    cs = phase.handle(:remove_settlement, game: @game, player_order: @actor.order, row: 4, col: 4)
+
+    discard = cs.find { |c| c.is_a?(Turn::Consequences::TileDiscarded) && c.player == @opponent.order }
+    refute_nil discard
+    assert_equal "PaddockTile", discard.klass
+  end
+end

--- a/test/models/turn/sub_phases/wall_placement_phase_test.rb
+++ b/test/models/turn/sub_phases/wall_placement_phase_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+
+class Turn::SubPhases::WallPlacementPhaseTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "to_h round-trips through from_h" do
+    phase = Turn::SubPhases::WallPlacementPhase.new(walls_placed: 1, chosen_terrain: "G")
+
+    rebuilt = Turn::SubPhases::WallPlacementPhase.from_h(phase.to_h)
+
+    assert_equal 1, rebuilt.walls_placed
+    assert_equal "G", rebuilt.chosen_terrain
+  end
+
+  test "place_wall emits WallPlaced and persists chosen terrain when another wall remains" do
+    setup_quarry_target("G")
+    target = quarry_targets("G").first
+    phase = Turn::SubPhases::WallPlacementPhase.new
+
+    cs = phase.handle(:place_wall, game: @game, player_order: @player.order, row: target[0], col: target[1])
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::WallPlaced) })
+    update = cs.find { |c| c.is_a?(Turn::Consequences::SubPhaseStateUpdated) }
+    refute_nil update
+    assert_equal 1, update.new_state["walls_placed"]
+    assert_equal "G", update.new_state["chosen_terrain"]
+    refute phase.complete?
+  end
+
+  test "place_wall consumes tile and completes on second wall" do
+    setup_quarry_target("G")
+    first, second = quarry_targets("G").first(2)
+    @game.board_contents.place_wall(first[0], first[1])
+    phase = Turn::SubPhases::WallPlacementPhase.new(walls_placed: 1, chosen_terrain: "G")
+
+    cs = phase.handle(:place_wall, game: @game, player_order: @player.order, row: second[0], col: second[1])
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::WallPlaced) })
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) && c.klass == "QuarryTile" })
+    assert phase.complete?
+  end
+
+  test "place_wall rejects non-hand terrain" do
+    setup_quarry_target("G")
+    @player.update!(hand: [ "D" ])
+    target = quarry_targets("G").first
+
+    cs = Turn::SubPhases::WallPlacementPhase.new.handle(:place_wall, game: @game, player_order: @player.order, row: target[0], col: target[1])
+
+    assert_kind_of Turn::Consequences::Error, cs.first
+  end
+
+  test "end_tile_action consumes tile only after at least one wall" do
+    cs = Turn::SubPhases::WallPlacementPhase.new(walls_placed: 0).handle(:end_tile_action, game: @game, player_order: @player.order)
+    assert_kind_of Turn::Consequences::Error, cs.first
+
+    phase = Turn::SubPhases::WallPlacementPhase.new(walls_placed: 1)
+    cs = phase.handle(:end_tile_action, game: @game, player_order: @player.order)
+
+    assert(cs.any? { |c| c.is_a?(Turn::Consequences::TileConsumed) && c.klass == "QuarryTile" })
+    assert phase.complete?
+  end
+
+  private
+
+  def setup_quarry_target(terrain)
+    @player.update!(hand: [ terrain, "D" ].uniq)
+    source, = first_quarry_setup(terrain)
+    @game.board_contents.place_settlement(source[0], source[1], @player.order)
+    @game.save!
+  end
+
+  def quarry_targets(terrain)
+    Tiles::QuarryTile.new(0).valid_destinations(
+      board_contents: @game.board_contents,
+      board: @game.board,
+      player_order: @player.order,
+      hand: terrain
+    )
+  end
+
+  def first_quarry_setup(terrain)
+    20.times do |row|
+      20.times do |col|
+        next unless Tiles::Tile::BUILDABLE_TERRAIN.include?(@game.board.terrain_at(row, col))
+        next unless @game.board_contents.empty?(row, col)
+        targets = @game.board_contents.neighbors(row, col).select do |nr, nc|
+          @game.board_contents.empty?(nr, nc) && @game.board.terrain_at(nr, nc) == terrain
+        end
+        return [ [ row, col ], targets ] if targets.size >= 2
+      end
+    end
+    raise "no Quarry setup for #{terrain}"
+  end
+end

--- a/test/services/turn_barn_flow_test.rb
+++ b/test/services/turn_barn_flow_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class TurnBarnFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.boards = [ [ 6, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "activate Barn, select source, move to played terrain, full unwind across 3 clicks" do
+    src = [ 0, 0 ]
+    @player.update!(
+      hand: [ "F" ],
+      tiles: [ { "klass" => "BarnTile", "from" => "[2, 6]", "used" => false } ]
+    )
+    @game.board_contents.place_settlement(src[0], src[1], @player.order)
+    @game.save!
+    dst = barn_destination_for(src)
+
+    snapshot_before = snapshot
+
+    cs = Turn.from_game(@game.reload).handle(:select_action, game: @game, tile: "BarnTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_action to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "settlement_move", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_nil @game.current_action.dig("turn", "sub_phase", "state", "source")
+
+    @game.instantiate
+    cs = Turn.from_game(@game.reload).handle(:select_settlement, game: @game, row: src[0], col: src[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_settlement to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.instantiate
+    cs = Turn.from_game(@game.reload).handle(:move_settlement, game: @game, row: dst[0], col: dst[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected move_settlement to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(src[0], src[1])
+    assert_equal @player.order, @game.board_contents.player_at(dst[0], dst[1])
+    assert @game.current_player.tiles.find { |t| t["klass"] == "BarnTile" }["used"]
+
+    3.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.supply.deep_dup, hand: Array(g.hand), tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  def barn_destination_for(src)
+    Tiles::BarnTile.new(0).valid_destinations(
+      from_row: src[0], from_col: src[1],
+      board_contents: @game.board_contents,
+      board: @game.board,
+      player_order: @player.order,
+      hand: @player.hand.first
+    ).first || raise("no Barn destination")
+  end
+end

--- a/test/services/turn_caravan_flow_test.rb
+++ b/test/services/turn_caravan_flow_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+
+class TurnCaravanFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "activate Caravan, select source, move destination, full unwind across 3 clicks" do
+    src = first_caravan_movable_source
+    dst = caravan_destination_for(src)
+
+    @game.board_contents.place_settlement(src[0], src[1], @player.order)
+    @player.update!(tiles: [ { "klass" => "CaravanTile", "from" => "[2, 3]", "used" => false } ])
+    @game.save!
+
+    snapshot_before = snapshot
+
+    cs = Turn.from_game(@game.reload).handle(:select_action, game: @game, tile: "CaravanTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_action to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "settlement_move", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_nil @game.current_action.dig("turn", "sub_phase", "state", "source")
+
+    @game.instantiate
+    cs = Turn.from_game(@game.reload).handle(:select_settlement, game: @game, row: src[0], col: src[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_settlement to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.instantiate
+    cs = Turn.from_game(@game.reload).handle(:move_settlement, game: @game, row: dst[0], col: dst[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected move_settlement to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(src[0], src[1])
+    assert_equal @player.order, @game.board_contents.player_at(dst[0], dst[1])
+    assert @game.current_player.tiles.find { |t| t["klass"] == "CaravanTile" }["used"]
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+
+    3.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.supply.deep_dup, hand: Array(g.hand), tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  def first_caravan_movable_source
+    20.times do |r|
+      20.times do |c|
+        next if @game.board.terrain_at(r, c).nil?
+        next unless @game.board_contents.empty?(r, c)
+        next unless Tiles::CaravanTile.new(0).valid_destinations(from_row: r, from_col: c, board_contents: @game.board_contents, board: @game.board, player_order: @player.order).any?
+        return [ r, c ]
+      end
+    end
+    raise "no Caravan-movable source on this board"
+  end
+
+  def caravan_destination_for(src)
+    Tiles::CaravanTile.new(0).valid_destinations(
+      from_row: src[0], from_col: src[1],
+      board_contents: @game.board_contents,
+      board: @game.board,
+      player_order: @player.order
+    ).first || raise("no Caravan destination")
+  end
+end

--- a/test/services/turn_city_hall_flow_test.rb
+++ b/test/services/turn_city_hall_flow_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+class TurnCityHallFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.boards = [ [ 1, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "activate City Hall, place cluster, full unwind across 2 clicks" do
+    center = setup_city_hall
+    snapshot_before = snapshot
+
+    cs = Turn.from_game(@game.reload).handle(:select_action, game: @game, tile: "CityHallTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_action to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "city_hall", @game.current_action.dig("turn", "sub_phase", "type")
+
+    @game.instantiate
+    cs = Turn.from_game(@game.reload).handle(:place_city_hall, game: @game, row: center[0], col: center[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected place_city_hall to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    cluster = [ center ] + @game.board_contents.neighbors(*center)
+    cluster.each { |row, col| assert @game.board_contents.city_hall_at?(row, col), "expected City Hall at [#{row}, #{col}]" }
+    assert_equal 0, @game.current_player.city_halls_remaining
+    tile = @game.current_player.tiles.find { |t| t["klass"] == "CityHallTile" }
+    assert tile["used"]
+    assert tile["permanent"]
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+
+    2.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.supply.deep_dup, hand: Array(g.hand), tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  def setup_city_hall
+    @player.add_city_halls!(1)
+    @player.tiles = [ { "klass" => "CityHallTile", "from" => "[2, 5]", "used" => false } ]
+    center = find_empty_cluster_center
+    cluster = Set.new([ center ] + @game.board_contents.neighbors(*center))
+    outer = @game.board_contents.neighbors(*center).lazy.flat_map { |row, col| @game.board_contents.neighbors(row, col) }
+      .find { |hex| !cluster.include?(hex) && @game.board_contents.empty?(*hex) }
+    raise "no outer settlement spot" unless outer
+
+    @game.board_contents.place_settlement(*outer, @player.order)
+    @player.save!
+    @game.save!
+    center
+  end
+
+  def find_empty_cluster_center
+    20.times do |row|
+      20.times do |col|
+        next unless Tiles::Tile::BUILDABLE_TERRAIN.include?(@game.board.terrain_at(row, col))
+        next unless @game.board_contents.empty?(row, col)
+        neighbors = @game.board_contents.neighbors(row, col)
+        next unless neighbors.size == 6
+        next unless neighbors.all? { |nr, nc|
+          @game.board_contents.empty?(nr, nc) && Tiles::Tile::BUILDABLE_TERRAIN.include?(@game.board.terrain_at(nr, nc))
+        }
+        return [ row, col ]
+      end
+    end
+    raise "no City Hall cluster center"
+  end
+end

--- a/test/services/turn_harbor_flow_test.rb
+++ b/test/services/turn_harbor_flow_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class TurnHarborFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "activate Harbor, select source, move to water, full unwind across 3 clicks" do
+    src = first_harbor_source
+    @game.board_contents.place_settlement(src[0], src[1], @player.order)
+    @player.update!(tiles: [ { "klass" => "HarborTile", "from" => "[2, 3]", "used" => false } ])
+    @game.save!
+    dst = harbor_destination_for(src)
+
+    snapshot_before = snapshot
+
+    cs = Turn.from_game(@game.reload).handle(:select_action, game: @game, tile: "HarborTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_action to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "settlement_move", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_nil @game.current_action.dig("turn", "sub_phase", "state", "source")
+
+    @game.instantiate
+    cs = Turn.from_game(@game.reload).handle(:select_settlement, game: @game, row: src[0], col: src[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_settlement to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.instantiate
+    cs = Turn.from_game(@game.reload).handle(:move_settlement, game: @game, row: dst[0], col: dst[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected move_settlement to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(src[0], src[1])
+    assert_equal @player.order, @game.board_contents.player_at(dst[0], dst[1])
+    assert @game.current_player.tiles.find { |t| t["klass"] == "HarborTile" }["used"]
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+
+    3.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.supply.deep_dup, hand: Array(g.hand), tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  def first_harbor_source
+    20.times do |r|
+      20.times do |c|
+        next unless Tiles::Tile::BUILDABLE_TERRAIN.include?(@game.board.terrain_at(r, c))
+        next unless @game.board_contents.empty?(r, c)
+        return [ r, c ]
+      end
+    end
+    raise "no Harbor source on this board"
+  end
+
+  def harbor_destination_for(src)
+    Tiles::HarborTile.new(0).valid_destinations(
+      from_row: src[0], from_col: src[1],
+      board_contents: @game.board_contents,
+      board: @game.board,
+      player_order: @player.order
+    ).first || raise("no Harbor destination")
+  end
+end

--- a/test/services/turn_quarry_flow_test.rb
+++ b/test/services/turn_quarry_flow_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class TurnQuarryFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "activate Quarry, place one wall, end action, full unwind across 3 clicks" do
+    terrain = @player.hand.first
+    source, targets = first_quarry_setup(terrain)
+    target = targets.first
+    @game.board_contents.place_settlement(source[0], source[1], @player.order)
+    @player.update!(tiles: [ { "klass" => "QuarryTile", "from" => "[5, 5]", "used" => false } ])
+    @game.save!
+
+    snapshot_before = snapshot
+
+    cs = Turn.from_game(@game.reload).handle(:select_action, game: @game, tile: "QuarryTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_action to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "wall_placement", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_equal 0, @game.current_action.dig("turn", "sub_phase", "state", "walls_placed")
+
+    @game.instantiate
+    cs = Turn.from_game(@game.reload).handle(:place_wall, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected place_wall to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_equal "Wall", @game.board_contents.tile_klass(target[0], target[1])
+    assert_equal snapshot_before[:stone_walls] - 1, @game.stone_walls
+    assert_equal 1, @game.current_action.dig("turn", "sub_phase", "state", "walls_placed")
+    assert_equal terrain, @game.current_action.dig("turn", "sub_phase", "state", "chosen_terrain")
+
+    cs = Turn.from_game(@game.reload).handle(:end_tile_action, game: @game)
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected end_tile_action to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+    assert @game.current_player.tiles.find { |t| t["klass"] == "QuarryTile" }["used"]
+
+    3.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      stone_walls: @game.stone_walls,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.supply.deep_dup, hand: Array(g.hand), tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  def first_quarry_setup(terrain)
+    20.times do |row|
+      20.times do |col|
+        next unless Tiles::Tile::BUILDABLE_TERRAIN.include?(@game.board.terrain_at(row, col))
+        next unless @game.board_contents.empty?(row, col)
+        targets = @game.board_contents.neighbors(row, col).select do |nr, nc|
+          @game.board_contents.empty?(nr, nc) && @game.board.terrain_at(nr, nc) == terrain
+        end
+        return [ [ row, col ], targets ] if targets.size >= 2
+      end
+    end
+    raise "no Quarry setup for #{terrain}"
+  end
+end

--- a/test/services/turn_resettlement_flow_test.rb
+++ b/test/services/turn_resettlement_flow_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class TurnResettlementFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.boards = [ [ 10, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "activate Resettlement, select source, move, end action, full unwind across 4 clicks" do
+    src = [ 0, 0 ]
+    dst = [ 0, 2 ]
+    @game.board_contents.place_settlement(src[0], src[1], @player.order)
+    @player.update!(tiles: [ { "klass" => "ResettlementTile", "from" => "[5, 5]", "used" => false } ])
+    @game.save!
+
+    snapshot_before = snapshot
+
+    cs = Turn.from_game(@game.reload).handle(:select_action, game: @game, tile: "ResettlementTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_action to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "resettlement", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_equal 4, @game.current_action.dig("turn", "sub_phase", "state", "budget")
+    assert_equal [], @game.current_action.dig("turn", "sub_phase", "state", "vacated")
+    assert_equal 0, @game.current_action.dig("turn", "sub_phase", "state", "moves")
+
+    @game.instantiate
+    cs = Turn.from_game(@game.reload).handle(:select_settlement, game: @game, row: src[0], col: src[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_settlement to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "[#{src[0]}, #{src[1]}]", @game.current_action.dig("turn", "sub_phase", "state", "source")
+
+    @game.instantiate
+    cs = Turn.from_game(@game.reload).handle(:move_settlement, game: @game, row: dst[0], col: dst[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected move_settlement to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(src[0], src[1])
+    assert_equal @player.order, @game.board_contents.player_at(dst[0], dst[1])
+    assert_equal 2, @game.current_action.dig("turn", "sub_phase", "state", "budget")
+    assert_equal [ "[#{src[0]}, #{src[1]}]" ], @game.current_action.dig("turn", "sub_phase", "state", "vacated")
+    assert_equal 1, @game.current_action.dig("turn", "sub_phase", "state", "moves")
+    assert_nil @game.current_action.dig("turn", "sub_phase", "state", "source")
+
+    cs = Turn.from_game(@game.reload).handle(:end_tile_action, game: @game)
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected end_tile_action to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+    assert @game.current_player.tiles.find { |t| t["klass"] == "ResettlementTile" }["used"]
+
+    4.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.supply.deep_dup, hand: Array(g.hand), tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+end

--- a/test/services/turn_sword_flow_test.rb
+++ b/test/services/turn_sword_flow_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+class TurnSwordFlowTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @actor = @game.current_player
+    @opponent = @game.game_players.find { |gp| gp.order != @actor.order }
+  end
+
+  test "activate Sword, remove opponent settlement, full unwind across 2 clicks" do
+    target = first_buildable_hex
+    @actor.update!(tiles: [ { "klass" => "SwordTile", "from" => "[5, 5]", "used" => false } ])
+    @game.board_contents.place_settlement(target[0], target[1], @opponent.order)
+    @game.save!
+
+    snapshot_before = snapshot
+
+    cs = Turn.from_game(@game.reload).handle(:select_action, game: @game, tile: "SwordTile")
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected select_action to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    assert_equal "targeted_removal", @game.current_action.dig("turn", "sub_phase", "type")
+    assert_equal [ @opponent.order ], @game.current_action.dig("turn", "sub_phase", "state", "pending_orders")
+
+    @game.instantiate
+    before_supply = @opponent.reload.settlements_remaining
+    cs = Turn.from_game(@game.reload).handle(:remove_settlement, game: @game, row: target[0], col: target[1])
+    refute(cs.any? { |c| c.is_a?(Turn::Consequences::Error) }, "expected remove_settlement to succeed: #{cs.inspect}")
+    ConsequenceApplier.apply!(@game, cs)
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(target[0], target[1])
+    assert_equal before_supply + 1, @opponent.reload.settlements_remaining
+    assert @game.current_player.tiles.find { |t| t["klass"] == "SwordTile" }["used"]
+    assert_nil @game.current_action.dig("turn", "sub_phase")
+
+    2.times { ConsequenceApplier.unapply!(@game.reload) }
+    assert_equal snapshot_before, snapshot
+  end
+
+  test "remove_settlement on warrior restores warrior after unwind" do
+    target = first_buildable_hex
+    @actor.update!(tiles: [ { "klass" => "SwordTile", "from" => "[5, 5]", "used" => false } ])
+    @opponent.add_warriors!(1)
+    @game.board_contents.place_warrior(target[0], target[1], @opponent.order)
+    @game.save!
+
+    ConsequenceApplier.apply!(
+      @game,
+      Turn.from_game(@game.reload).handle(:select_action, game: @game, tile: "SwordTile")
+    )
+    @game.instantiate
+    ConsequenceApplier.apply!(
+      @game,
+      Turn.from_game(@game.reload).handle(:remove_settlement, game: @game, row: target[0], col: target[1])
+    )
+
+    @game.reload
+    @game.instantiate
+    assert_nil @game.board_contents.player_at(target[0], target[1])
+
+    ConsequenceApplier.unapply!(@game.reload)
+    @game.reload
+    @game.instantiate
+
+    assert @game.board_contents.warrior_at?(target[0], target[1])
+    assert_equal @opponent.order, @game.board_contents.player_at(target[0], target[1])
+  end
+
+  private
+
+  def snapshot
+    @game.reload
+    {
+      board_contents: BoardState.dump(@game.board_contents),
+      current_action: @game.current_action.deep_dup,
+      players: @game.game_players.map { |g|
+        g.reload
+        { order: g.order, supply: g.supply.deep_dup, hand: Array(g.hand), tiles: g.tiles&.deep_dup, taken_from: g.taken_from&.dup }
+      }
+    }
+  end
+
+  def first_buildable_hex
+    20.times do |row|
+      20.times do |col|
+        next unless Tiles::Tile::BUILDABLE_TERRAIN.include?(@game.board.terrain_at(row, col))
+        return [ row, col ] if @game.board_contents.empty?(row, col)
+      end
+    end
+    raise "no buildable hex"
+  end
+end


### PR DESCRIPTION
## Summary
- complete shared Turn settlement movement for Barn, Harbor, Caravan, and Paddock
- add Turn sub-phases for Resettlement, Sword targeted removal, Quarry wall placement, and City Hall
- add reversible consequences for piece removal, wall placement, City Hall placement/supply/permanent tile use, and Nomad tile expiry
- add focused phase/consequence tests and round-trip service flow tests for the new Turn stack slices

## Test commands
- bin/rails test
- RUBOCOP_CACHE_ROOT=/tmp/rubocop_cache bin/rubocop app/models/turn.rb app/models/turn/consequences.rb app/models/turn/consequences/city_hall_placed.rb app/models/turn/consequences/city_hall_supply_decremented.rb app/models/turn/consequences/permanent_tile_consumed.rb app/models/turn/sub_phases/city_hall_phase.rb test/models/turn/consequences/city_hall_placed_test.rb test/models/turn/consequences/city_hall_supply_decremented_test.rb test/models/turn/consequences/permanent_tile_consumed_test.rb test/models/turn/sub_phases/city_hall_phase_test.rb test/services/turn_city_hall_flow_test.rb