### PR TITLE
Add Turn view adapter

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -119,7 +119,7 @@ class Game < ApplicationRecord
 
   def turn_state
     return "Waiting for players" if waiting?
-    TurnEngine.new(self).turn_state
+    TurnViewAdapter.new(self).turn_state
   end
 
   def turn_phase
@@ -191,7 +191,7 @@ class Game < ApplicationRecord
   def broadcast_game_update
     @board = nil # reset the board so we can re-construct it from the game state
     instantiate
-    engine = TurnEngine.new(self)
+    engine = TurnViewAdapter.new(self)
     scores = live_scores
 
     # public stuff
@@ -214,7 +214,7 @@ class Game < ApplicationRecord
       "game_#{id}",
       target: "board",
       partial: "games/board",
-      locals: { game: self }
+      locals: { game: self, engine: engine }
     )
     # - game log
     broadcast_update_to(

--- a/app/services/turn_view_adapter.rb
+++ b/app/services/turn_view_adapter.rb
@@ -1,0 +1,372 @@
+class TurnViewAdapter
+  DEFAULT_MANDATORY = Turn::DEFAULT_MANDATORY
+
+  def initialize(game)
+    @game = game
+    @legacy = TurnEngine.new(game)
+  end
+
+  def turn_state
+    return @legacy.turn_state unless turn_backed?
+
+    if turn.sub_phase
+      tile = tile_for_sub_phase
+      return "#{player.player.handle} must act" unless tile
+
+      hand = tile.fort_tile? && turn.sub_phase.respond_to?(:fort_terrain) ? turn.sub_phase.fort_terrain : player.hand.first
+      tile.action_message(player_handle: player.player.handle, terrain_names: Boards::Board::TERRAIN_NAMES, hand: hand)
+    elsif turn.mandatory_remaining > 0 && player.settlements_remaining?
+      terrain_name = Boards::Board::TERRAIN_NAMES[player.hand.first]
+      "#{player.player.handle} must build " \
+        "#{ActionController::Base.helpers.pluralize(turn.mandatory_remaining, 'settlement')} on " \
+        "#{terrain_name}" \
+        "#{' or select a tile' if any_tile_activatable?}"
+    else
+      "#{player.player.handle} must end their turn" \
+        "#{' or select a tile' if any_tile_activatable?}"
+    end
+  end
+
+  def buildable_cells
+    return @legacy.buildable_cells unless turn_backed?
+    return [] unless @game.playing?
+
+    @game.instantiate
+    return mandatory_buildable_cells unless turn.sub_phase
+
+    case (phase = turn.sub_phase)
+    when Turn::SubPhases::TileBuildPhase
+      tile_build_cells(phase)
+    when Turn::SubPhases::FortPhase
+      empty_terrain_cells(phase.fort_terrain)
+    when Turn::SubPhases::SettlementMovePhase
+      settlement_move_cells(phase)
+    when Turn::SubPhases::ResettlementPhase
+      resettlement_cells(phase)
+    when Turn::SubPhases::TargetedRemovalPhase
+      phase.pending_orders.flat_map { |order| @game.board_contents.settlements_for(order) }
+        .reject { |row, col| @game.board_contents.city_hall_at?(row, col) }
+    when Turn::SubPhases::WallPlacementPhase
+      wall_cells(phase)
+    when Turn::SubPhases::CityHallPhase
+      city_hall_centers
+    when Turn::SubPhases::MeeplePlacementPhase
+      meeple_cells(phase)
+    else
+      []
+    end
+  end
+
+  def tile_activatable?(tile_hash)
+    return @legacy.tile_activatable?(tile_hash) unless turn_backed?
+    return false if tile_hash["used"]
+
+    tile_class = Tiles::Tile.for_klass(tile_hash["klass"])
+    return false unless tile_class
+    return false if turn.sub_phase
+    return false unless turn.mandatory_remaining == DEFAULT_MANDATORY || turn.mandatory_remaining <= 0 || !player.settlements_remaining?
+
+    @game.instantiate
+    tile = tile_class.new(0)
+    return false if tile.places_wall? && @game.stone_walls <= 0
+    return false if tile.builds_settlement? && !player.settlements_remaining?
+    return opponents_with_settlements.any? if tile.sword_tile?
+
+    tile.activatable?(
+      player_order: player.order,
+      board_contents: @game.board_contents,
+      board: @game.board,
+      hand: player.hand.first,
+      supply: player.supply_hash
+    )
+  end
+
+  def turn_endable?
+    return @legacy.turn_endable? unless turn_backed?
+
+    @game.playing? && !turn.sub_phase && (turn.mandatory_remaining <= 0 || !player.settlements_remaining?)
+  end
+
+  def tile_action_endable?
+    return @legacy.tile_action_endable? unless turn_backed?
+    return false unless @game.playing?
+
+    case turn.sub_phase
+    when Turn::SubPhases::ResettlementPhase
+      turn.sub_phase.moves.to_i >= 1
+    when Turn::SubPhases::WallPlacementPhase
+      turn.sub_phase.walls_placed.to_i >= 1
+    else
+      false
+    end
+  end
+
+  def undo_allowed?
+    return @legacy.undo_allowed? unless turn_click_backed?
+
+    click = TurnClick.most_recent_for(@game)
+    click&.reversible? || false
+  end
+
+  def city_hall_clusters
+    return @legacy.city_hall_clusters unless turn_backed?
+    return {} unless turn.sub_phase.is_a?(Turn::SubPhases::CityHallPhase)
+
+    city_hall_centers.to_h do |row, col|
+      [ "#{row},#{col}", city_hall_tile.cluster_hexes(row, col, @game.board_contents) ]
+    end
+  end
+
+  def tile_used?(tile_hash)
+    tile_hash["used"] || (tile_hash["klass"] == "MandatoryTile" && turn_endable?)
+  end
+
+  def mandatory_remaining
+    return @game.mandatory_count unless turn_backed?
+
+    turn.mandatory_remaining
+  end
+
+  def outpost_activatable?(tile_hash)
+    return @legacy.outpost_activatable?(tile_hash) unless turn_backed?
+    return false if tile_hash["used"]
+    return false if turn.outpost_active
+    return false if turn.sub_phase && !turn.sub_phase.is_a?(Turn::SubPhases::TileBuildPhase)
+
+    player.settlements_remaining?
+  end
+
+  def current_action_type
+    return @game.current_action&.dig("type") unless turn_backed?
+    return "mandatory" unless turn.sub_phase
+
+    active_tile_klass&.delete_suffix("Tile")&.downcase
+  end
+
+  def current_action_from
+    return @game.current_action&.dig("from") unless turn_backed?
+    return nil unless turn.sub_phase.respond_to?(:source)
+
+    turn.sub_phase.source&.to_key
+  end
+
+  def chosen_terrain
+    return @game.current_action&.dig("chosen_terrain") unless turn_backed?
+
+    case turn.sub_phase
+    when Turn::SubPhases::WallPlacementPhase
+      turn.sub_phase.chosen_terrain
+    when Turn::SubPhases::FortPhase
+      turn.sub_phase.fort_terrain
+    end
+  end
+
+  def outpost_active?
+    return @game.current_action&.dig("outpost_active") unless turn_backed?
+
+    turn.outpost_active
+  end
+
+  def active_tile?(tile_hash)
+    current_action_type == tile_hash["klass"].delete_suffix("Tile").downcase
+  end
+
+  def tile_progress(tile_hash)
+    return legacy_tile_progress(tile_hash) unless turn_backed?
+    return nil unless active_tile?(tile_hash)
+
+    case turn.sub_phase
+    when Turn::SubPhases::ResettlementPhase
+      "#{turn.sub_phase.budget} steps left"
+    end
+  end
+
+  def meeple_tile_active?
+    %w[BarracksTile LighthouseTile WagonTile].include?(active_tile_klass)
+  end
+
+  private
+
+  def turn_backed?
+    @game.current_action.is_a?(Hash) && @game.current_action["turn"].is_a?(Hash)
+  end
+
+  def turn_click_backed?
+    TurnClick.where(game_id: @game.id).exists?
+  end
+
+  def turn
+    @turn ||= Turn.from_game(@game)
+  end
+
+  def player
+    @game.current_player
+  end
+
+  def any_tile_activatable?
+    (player.tiles || []).any? { |tile| tile_activatable?(tile) }
+  end
+
+  def mandatory_buildable_cells
+    return [] unless player.settlements_remaining? && turn.mandatory_remaining > 0
+
+    if turn.outpost_active
+      empty_terrain_cells(player.hand.first)
+    else
+      mandatory_cells_for(player.hand.first)
+    end
+  end
+
+  def mandatory_cells_for(terrain)
+    list = TurnEngine.new(@game).available_list(player.order, terrain)
+    (0..19).flat_map { |row| (0..19).filter_map { |col| [ row, col ] if list[row][col] } }
+  end
+
+  def tile_build_cells(phase)
+    if phase.restricted_terrain
+      empty_terrain_cells(phase.restricted_terrain)
+    else
+      tile = Tiles::Tile.for_klass(phase.tile_klass)&.new(0)
+      return [] unless tile
+
+      tile.valid_destinations(board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: player.hand.first)
+    end
+  end
+
+  def settlement_move_cells(phase)
+    tile = Tiles::Tile.for_klass(phase.tile_klass)&.new(0)
+    return [] unless tile
+
+    if phase.source
+      tile.valid_destinations(
+        from_row: phase.source.row,
+        from_col: phase.source.col,
+        board_contents: @game.board_contents,
+        board: @game.board,
+        player_order: player.order,
+        hand: player.hand.first
+      )
+    else
+      tile.selectable_settlements(player_order: player.order, board_contents: @game.board_contents, board: @game.board, hand: player.hand.first)
+    end
+  end
+
+  def resettlement_cells(phase)
+    tile = Tiles::Nomad::ResettlementTile.new(0)
+    if phase.source
+      tile.valid_destinations(
+        from_row: phase.source.row,
+        from_col: phase.source.col,
+        board_contents: @game.board_contents,
+        board: @game.board,
+        player_order: player.order,
+        budget: phase.budget,
+        vacated: phase.vacated
+      )
+    else
+      tile.selectable_settlements(
+        player_order: player.order,
+        board_contents: @game.board_contents,
+        board: @game.board,
+        budget: phase.budget,
+        vacated: phase.vacated
+      )
+    end
+  end
+
+  def wall_cells(phase)
+    terrains = phase.chosen_terrain ? [ phase.chosen_terrain ] : Array(player.hand)
+    terrains.flat_map do |terrain|
+      Tiles::QuarryTile.new(0).valid_destinations(
+        board_contents: @game.board_contents,
+        board: @game.board,
+        player_order: player.order,
+        hand: terrain
+      )
+    end.uniq
+  end
+
+  def city_hall_centers
+    city_hall_tile.valid_destinations(
+      board_contents: @game.board_contents,
+      board: @game.board,
+      player_order: player.order,
+      supply: player.supply_hash
+    )
+  end
+
+  def meeple_cells(phase)
+    tile = Tiles::Tile.for_klass(phase.tile_klass)&.new(0)
+    return [] unless tile
+
+    if phase.source
+      tile.valid_destinations(
+        from_row: phase.source.row,
+        from_col: phase.source.col,
+        board_contents: @game.board_contents,
+        board: @game.board,
+        player_order: player.order,
+        supply: player.supply_hash
+      )
+    else
+      tile.valid_destinations(
+        board_contents: @game.board_contents,
+        board: @game.board,
+        player_order: player.order,
+        supply: player.supply_hash
+      )
+    end
+  end
+
+  def empty_terrain_cells(terrain)
+    return [] unless terrain
+
+    (0..19).flat_map do |row|
+      (0..19).filter_map do |col|
+        [ row, col ] if @game.board_contents.empty?(row, col) && @game.board.terrain_at(row, col) == terrain
+      end
+    end
+  end
+
+  def city_hall_tile
+    Tiles::CityHallTile.new(0)
+  end
+
+  def tile_for_sub_phase
+    klass = active_tile_klass
+    Tiles::Tile.for_klass(klass)&.new(0) if klass
+  end
+
+  def active_tile_klass
+    case (phase = turn.sub_phase)
+    when Turn::SubPhases::TileBuildPhase, Turn::SubPhases::SettlementMovePhase, Turn::SubPhases::MeeplePlacementPhase
+      phase.tile_klass
+    when Turn::SubPhases::ResettlementPhase
+      Turn::SubPhases::ResettlementPhase::TILE_KLASS
+    when Turn::SubPhases::TargetedRemovalPhase
+      Turn::SubPhases::TargetedRemovalPhase::TILE_KLASS
+    when Turn::SubPhases::WallPlacementPhase
+      Turn::SubPhases::WallPlacementPhase::TILE_KLASS
+    when Turn::SubPhases::CityHallPhase
+      Turn::SubPhases::CityHallPhase::TILE_KLASS
+    when Turn::SubPhases::FortPhase
+      "FortTile"
+    end
+  end
+
+  def opponents_with_settlements
+    @game.game_players
+      .reject { |game_player| game_player.order == player.order }
+      .select { |game_player| @game.board_contents.settlements_for(game_player.order).any? }
+  end
+
+  def legacy_tile_progress(tile_hash)
+    return nil unless active_tile?(tile_hash)
+
+    if @game.current_action["remaining"]
+      "#{@game.current_action['remaining']} left"
+    elsif @game.current_action["budget"]
+      "#{@game.current_action['budget']} steps left"
+    end
+  end
+end

--- a/app/views/games/_board.html.erb
+++ b/app/views/games/_board.html.erb
@@ -1,7 +1,6 @@
-<%= render partial: "games/quadrant", locals: { game: game, quadrant: game.board.map[0], index: 0 } %>
-<%= render partial: "games/quadrant", locals: { game: game, quadrant: game.board.map[1], index: 1 } %>
+<%= render partial: "games/quadrant", locals: { game: game, engine: engine, quadrant: game.board.map[0], index: 0 } %>
+<%= render partial: "games/quadrant", locals: { game: game, engine: engine, quadrant: game.board.map[1], index: 1 } %>
 <div> <!-- for Mayor markers --></div>
-<%= render partial: "games/quadrant", locals: { game: game, quadrant: game.board.map[2], index: 2 } %>
-<%= render partial: "games/quadrant", locals: { game: game, quadrant: game.board.map[3], index: 3 } %>
+<%= render partial: "games/quadrant", locals: { game: game, engine: engine, quadrant: game.board.map[2], index: 2 } %>
+<%= render partial: "games/quadrant", locals: { game: game, engine: engine, quadrant: game.board.map[3], index: 3 } %>
 <div> <!-- for Mayor markers --></div>
-

--- a/app/views/games/_board_contents.html.erb
+++ b/app/views/games/_board_contents.html.erb
@@ -1,4 +1,3 @@
 <div id="board-contents">
-  <%= render partial: "games/board", locals: { game: game } %>
+  <%= render partial: "games/board", locals: { game: game, engine: TurnViewAdapter.new(game) } %>
 </div>
-

--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -20,7 +20,7 @@
       <%= render partial: "games/scoring", locals: { game: } %>
       <div id="board-viewport">
         <div id="board">
-          <%= render partial: "games/board", locals: { game: } %>
+          <%= render partial: "games/board", locals: { game:, engine: } %>
         </div>
       </div>
     </main>

--- a/app/views/games/_game_player.html.erb
+++ b/app/views/games/_game_player.html.erb
@@ -38,7 +38,7 @@
   </div>
   <div class="player-stats">
     <% display_cards = (n == 0 || game.current_player_id == player.id) ? Array(player.hand) : Array(player.hand).map { "Z" } %>
-    <% chosen = (game.current_player_id == player.id) ? game.current_action["chosen_terrain"] : nil %>
+    <% chosen = (game.current_player_id == player.id) ? engine.chosen_terrain : nil %>
     <% display_cards.each do |card| %>
       <% shunned = chosen && card != chosen %>
       <%= content_tag :span, card, title: Boards::Board::TERRAIN_NAMES[card], class: "player-card card-#{card}#{" card-shunned" if shunned}" %>

--- a/app/views/games/_quadrant.html.erb
+++ b/app/views/games/_quadrant.html.erb
@@ -47,7 +47,7 @@
               <% end %>
               <div class="tile-tooltip"><%= content.description.html_safe %></div>
             <% when Settlement %>
-              <% meeple_tile_active = %w[BarracksTile LighthouseTile WagonTile].include?(game.current_action["klass"]) %>
+              <% meeple_tile_active = engine.meeple_tile_active? %>
               <% show_popup = meeple_tile_active && content.player == game.current_player.order %>
               <% if show_popup && (content.warrior? || content.ship? || content.wagon?) %>
                 <div data-controller="meeple-popup"

--- a/app/views/games/_tiles.html.erb
+++ b/app/views/games/_tiles.html.erb
@@ -7,7 +7,7 @@
     <% description = Tiles::Tile.for_klass(tile["klass"])&.new(0)&.description %>
     <% type = tile["klass"].delete_suffix("Tile").downcase %>
     <% used = engine.tile_used?(tile) %>
-    <% active = my_turn && !used && game.current_action["type"] == type && marked_active_type != type %>
+    <% active = my_turn && !used && engine.current_action_type == type && marked_active_type != type %>
     <% marked_active_type = type if active %>
     <% activatable = my_turn && engine.tile_activatable?(tile) %>
     <% state = active ? "tile-active" : used ? "tile-used" : activatable ? "tile-activatable" : "tile-inactive" %>
@@ -52,7 +52,7 @@
       <% used = engine.tile_used?(tile) %>
 
       <% if tile_obj.outpost_tile? %>
-        <% outpost_on = game.current_action["outpost_active"] %>
+        <% outpost_on = engine.outpost_active? %>
         <% selectable = my_turn && engine.outpost_activatable?(tile) %>
         <% state = outpost_on ? "tile-active" : used ? "tile-used" : selectable ? "tile-activatable" : "tile-inactive" %>
         <% if selectable %>
@@ -68,7 +68,7 @@
         <% end %>
 
       <% else %>
-        <% active = my_turn && !used && game.current_action["type"] == type %>
+        <% active = my_turn && !used && engine.current_action_type == type %>
         <% activatable = my_turn && engine.tile_activatable?(tile) %>
         <% state = active ? "tile-active" : used ? "tile-used" : activatable ? "tile-activatable" : "tile-inactive" %>
         <% if activatable %>
@@ -82,11 +82,8 @@
             <div class="tile-container <%= type %>"></div>
           </div>
         <% end %>
-        <% if active && game.current_action["remaining"] %>
-          <span class="tile-progress"><%= game.current_action["remaining"] %> left</span>
-        <% end %>
-        <% if active && game.current_action["budget"] %>
-          <span class="tile-progress"><%= game.current_action["budget"] %> steps left</span>
+        <% if active && (progress = engine.tile_progress(tile)) %>
+          <span class="tile-progress"><%= progress %></span>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/games/_turn_state.html.erb
+++ b/app/views/games/_turn_state.html.erb
@@ -1,9 +1,9 @@
 <span class="turn-state-text">
   <%= engine.turn_state %>
-  <span class="mandatory-count"><%= game.mandatory_count %></span>
+  <span class="mandatory-count"><%= engine.mandatory_remaining %></span>
   <span id="current-action"
-    data-type="<%= game.current_action&.dig('type') %>"
-    data-from="<%= game.current_action&.dig('from') %>"
+    data-type="<%= engine.current_action_type %>"
+    data-from="<%= engine.current_action_from %>"
     data-buildable="<%= engine.buildable_cells.to_json %>"
     data-clusters="<%= engine.city_hall_clusters.to_json %>">
   </span>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "KBC Game #{game.id}" %>
 <% content_for :body_class, "game-page" %>
 <%= turbo_stream_from "game_#{game.id}" %>
-<%= render partial: "games/game", locals: { game:, my_player:, engine: TurnEngine.new(game), scores: game.live_scores } %>
+<%= render partial: "games/game", locals: { game:, my_player:, engine: TurnViewAdapter.new(game), scores: game.live_scores } %>
 <% if game.state == "completed" %>
   <%= render "games/end_game_modal", game:, scores: game.scores %>
 <% end %>

--- a/app/views/games/show.turbo_stream.erb
+++ b/app/views/games/show.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= render partial: "games/game", locals: { game:, my_player:, engine: TurnEngine.new(game), scores: game.live_scores } %>
+<%= render partial: "games/game", locals: { game:, my_player:, engine: TurnViewAdapter.new(game), scores: game.live_scores } %>
 <%= javascript_include_tag "sound" %>
 <%= javascript_include_tag "gameboard" %>

--- a/test/services/turn_view_adapter_test.rb
+++ b/test/services/turn_view_adapter_test.rb
@@ -1,0 +1,158 @@
+require "test_helper"
+
+class TurnViewAdapterTest < ActiveSupport::TestCase
+  def setup
+    @game = Game.create!(state: "waiting")
+    @game.add_player(users(:chris))
+    @game.add_player(users(:paula))
+    @game.start
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+  end
+
+  test "turn_state falls back to TurnEngine for legacy current_action" do
+    @game.update!(current_action: { "type" => "mandatory" })
+
+    assert_equal TurnEngine.new(@game).turn_state, TurnViewAdapter.new(@game).turn_state
+  end
+
+  test "mandatory Turn state exposes remaining count turn_state and buildable cells" do
+    @player.update!(hand: [ "G" ])
+    @game.update!(current_action: { "turn" => { "mandatory_remaining" => 2 } })
+
+    adapter = TurnViewAdapter.new(@game)
+
+    assert_equal 2, adapter.mandatory_remaining
+    assert_match(/must build 2 settlements on Grass/, adapter.turn_state)
+    assert(adapter.buildable_cells.any?)
+  end
+
+  test "tile_activatable uses Turn mandatory gate" do
+    @game.update!(current_action: { "turn" => { "mandatory_remaining" => 1 } })
+    tile = { "klass" => "OasisTile", "from" => "[2, 7]", "used" => false }
+
+    assert_not TurnViewAdapter.new(@game).tile_activatable?(tile)
+
+    @game.update!(current_action: { "turn" => { "mandatory_remaining" => 0 } })
+    assert TurnViewAdapter.new(@game).tile_activatable?(tile)
+  end
+
+  test "settlement move phase exposes active tile type source and destinations" do
+    src = first_paddock_source
+    dst = Tiles::PaddockTile.new(0).valid_destinations(
+      from_row: src[0], from_col: src[1],
+      board_contents: @game.board_contents,
+      board: @game.board,
+      player_order: @player.order
+    ).first
+    @game.board_contents.place_settlement(src[0], src[1], @player.order)
+    @player.update!(tiles: [ { "klass" => "PaddockTile", "from" => "[2, 3]", "used" => false } ])
+    @game.update!(current_action: {
+      "turn" => {
+        "sub_phase" => {
+          "type" => Turn::SubPhases::SettlementMovePhase::TYPE,
+          "state" => { "tile_klass" => "PaddockTile", "source" => "[#{src[0]}, #{src[1]}]" }
+        }
+      }
+    })
+
+    adapter = TurnViewAdapter.new(@game)
+
+    assert_equal "paddock", adapter.current_action_type
+    assert_equal "[#{src[0]}, #{src[1]}]", adapter.current_action_from
+    assert_includes adapter.buildable_cells, dst
+  end
+
+  test "tile_action_endable is true for started wall placement phase" do
+    @game.update!(current_action: {
+      "turn" => {
+        "sub_phase" => {
+          "type" => Turn::SubPhases::WallPlacementPhase::TYPE,
+          "state" => { "walls_placed" => 1, "chosen_terrain" => "G" }
+        }
+      }
+    })
+
+    assert TurnViewAdapter.new(@game).tile_action_endable?
+  end
+
+  test "city_hall_clusters returns center keyed cluster for Turn City Hall phase" do
+    center = setup_city_hall
+    @game.update!(current_action: {
+      "turn" => {
+        "sub_phase" => {
+          "type" => Turn::SubPhases::CityHallPhase::TYPE,
+          "state" => {}
+        }
+      }
+    })
+
+    clusters = TurnViewAdapter.new(@game).city_hall_clusters
+
+    assert_includes clusters.keys, "#{center[0]},#{center[1]}"
+    assert_equal 7, clusters["#{center[0]},#{center[1]}"].size
+  end
+
+  test "undo_allowed reads TurnClick when present" do
+    TurnClick.create!(game: @game, order: 1, consequences: [], reversible: false)
+    TurnClick.create!(game: @game, order: 2, consequences: [], reversible: true)
+    @game.update!(current_action: { "turn" => { "mandatory_remaining" => 3 } })
+
+    assert TurnViewAdapter.new(@game).undo_allowed?
+  end
+
+  private
+
+  def first_paddock_source
+    20.times do |row|
+      20.times do |col|
+        next if @game.board.terrain_at(row, col).nil?
+        next unless @game.board_contents.empty?(row, col)
+        next unless Tiles::PaddockTile.new(0).valid_destinations(
+          from_row: row, from_col: col,
+          board_contents: @game.board_contents,
+          board: @game.board,
+          player_order: @player.order
+        ).any?
+        return [ row, col ]
+      end
+    end
+    raise "no Paddock source"
+  end
+
+  def setup_city_hall
+    @game.boards = [ [ 1, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    @game.board_contents = BoardState.new
+    @game.save!
+    @game.reload
+    @game.instantiate
+    @player = @game.current_player
+    @player.add_city_halls!(1)
+    @player.save!
+
+    center = find_city_hall_center
+    cluster = Set.new([ center ] + @game.board_contents.neighbors(*center))
+    outer = @game.board_contents.neighbors(*center).lazy.flat_map { |row, col| @game.board_contents.neighbors(row, col) }
+      .find { |hex| !cluster.include?(hex) && @game.board_contents.empty?(*hex) }
+    @game.board_contents.place_settlement(*outer, @player.order)
+    @game.save!
+    center
+  end
+
+  def find_city_hall_center
+    20.times do |row|
+      20.times do |col|
+        next unless Tiles::Tile::BUILDABLE_TERRAIN.include?(@game.board.terrain_at(row, col))
+        next unless @game.board_contents.empty?(row, col)
+        neighbors = @game.board_contents.neighbors(row, col)
+        next unless neighbors.size == 6
+        next unless neighbors.all? { |nr, nc|
+          @game.board_contents.empty?(nr, nc) && Tiles::Tile::BUILDABLE_TERRAIN.include?(@game.board.terrain_at(nr, nc))
+        }
+        return [ row, col ]
+      end
+    end
+    raise "no City Hall center"
+  end
+end


### PR DESCRIPTION
## Summary
- add TurnViewAdapter as the view/runtime bridge for Turn-backed state with TurnEngine fallback
- route game rendering and broadcasts through the adapter
- update board, tile, player, and turn-state partials to use adapter state instead of direct current_action reads
- add focused adapter service tests

## Tests
- bin/rails test test/services/turn_view_adapter_test.rb
- bin/rails test test/controllers/games_controller_test.rb test/models/game_test.rb test/services/turn_engine_test.rb test/services/turn_view_adapter_test.rb
- bin/rails test
- RUBOCOP_CACHE_ROOT=/tmp/rubocop_cache bin/rubocop app/services/turn_view_adapter.rb app/models/game.rb test/services/turn_view_adapter_test.rb

Note: an initial full-suite run hit the known flaky TurnMandatoryBuildTest adjacency setup, the isolated file passed, and the full-suite rerun passed.