### PR TITLE
Behavior-pinning test net: GameScenario DSL + Phase 2 tracers (+ forfeit fix #223)

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -142,6 +142,32 @@ class Game < ApplicationRecord
     Scoring.new(self).compute
   end
 
+  # Stable domain query: the hexes where game_player may legally build right
+  # now. Delegates to the engine's availability rule; returns coordinate pairs.
+  def legal_builds(game_player, terrain: nil)
+    terrain ||= Array(game_player.hand).first
+    instantiate
+    list = TurnEngine.new(self).available_list(game_player.order, terrain)
+    return [] unless list
+    list.each_with_index.flat_map do |row_cells, row|
+      row_cells.each_index.select { |col| row_cells[col] }.map { |col| [ row, col ] }
+    end
+  end
+
+  # Stable domain query: the held tiles game_player could activate right now
+  # (unused, recognized klass, and permitted in the current turn phase).
+  def available_tile_actions(game_player)
+    instantiate
+    engine = TurnEngine.new(self)
+    (game_player.tiles || []).select { |tile| engine.tile_activatable?(tile) }
+  end
+
+  # Stable domain query: game_player's current points for one goal or task.
+  # Raises KeyError if the goal is not part of this game.
+  def score_for(goal, game_player)
+    Scoring.new(self).score_for(game_player).fetch(goal.to_s)[:score]
+  end
+
   def complete!
     self.state = "completed"
     self.scores = Scoring.new(self).compute

--- a/app/models/game_player.rb
+++ b/app/models/game_player.rb
@@ -159,6 +159,16 @@ class GamePlayer < ApplicationRecord
     (tiles || []).map { |t| t["from"] }.to_set
   end
 
+  def holds_tile?(klass: nil, from: nil)
+    (tiles || []).any? do |t|
+      (klass.nil? || t["klass"] == klass) && (from.nil? || t["from"] == from)
+    end
+  end
+
+  def usable_tiles
+    (tiles || []).reject { |t| t["used"] }
+  end
+
   def mark_tile_used!(klass)
     idx = (tiles || []).find_index { |t| t["klass"] == klass && !t["used"] }
     return unless idx

--- a/app/services/move_applicator.rb
+++ b/app/services/move_applicator.rb
@@ -33,6 +33,11 @@ module MoveApplicator
         klass: move.payload["klass"],
         used: move.to == "true"
       )
+    when "redistribute_tile_used"
+      backend.apply_redistribute_tile_used(
+        player_order: player_order,
+        changes: move.payload["changes"]
+      )
     when "end_turn"
       backend.apply_end_turn(
         player_order: player_order,
@@ -213,6 +218,15 @@ class MoveApplicator::HashState
   def apply_forfeit_tile(player_order:, from:, klass:, used:)
     player = @players[player_order]
     player["tiles"] = (player["tiles"] || []).reject { |t| t["from"] == from }
+  end
+
+  # Forward replay: apply the prefer-used flag reassignment.
+  def apply_redistribute_tile_used(player_order:, changes:)
+    tiles = @players[player_order]["tiles"] || []
+    changes.each do |change|
+      tile = tiles.find { |t| t["from"] == change["from"] }
+      tile["used"] = change["after"] if tile
+    end
   end
 
   def apply_end_turn(player_order:, card_discarded:, card_drawn:, reshuffled:, deck_after:)
@@ -554,6 +568,20 @@ class MoveApplicator::LiveState
   def apply_forfeit_tile(player_order:, from:, klass:, used:)
     gp = player_for(player_order)
     gp.restore_tile!(klass, from: from, used: used)
+    gp.save
+  end
+
+  # Undo (reverse): restore every reassigned `used` flag to its prior value.
+  # Runs after the forfeit_tile reversal, so the just-restored forfeited tile is
+  # present and corrected here too.
+  def apply_redistribute_tile_used(player_order:, changes:)
+    gp = player_for(player_order)
+    tiles = gp.tiles || []
+    changes.each do |change|
+      tile = tiles.find { |t| t["from"] == change["from"] }
+      tile["used"] = change["before"] if tile
+    end
+    gp.tiles = tiles
     gp.save
   end
 

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -1088,17 +1088,13 @@ class TurnEngine
   def apply_tile_forfeit(game_player)
     return if (game_player.tiles || []).empty?
     active_tile_klass = @game.turn_phase.type == "mandatory" ? nil : current_action_tile_klass
+    changes = prefer_used_forfeit!(game_player, active_tile_klass)
+    record_used_redistribution(game_player, changes) if changes.any?
     game_player.tiles = game_player.tiles.reject do |tile|
-      next false if tile["klass"] == active_tile_klass
-      # Rule: Nomad tiles expire by turn, never by location
-      next false if Tiles::Tile.for_klass(tile["klass"])&.new(0)&.nomad_tile?
+      next false unless forfeit_eligible?(tile, active_tile_klass)
       loc = tile["from"]
-      next false unless loc
-      loc_coord = Coordinate.from_key(loc)
-      klass = @game.board_contents.tile_klass(*loc_coord) || tile["klass"]
-      should_forfeit = @game.board_contents.settlements_for(game_player.order).none? do |s_row, s_col|
-        @game.board_contents.neighbors(s_row, s_col).any? { |nr, nc| Coordinate.new(nr, nc).to_key == loc }
-      end
+      should_forfeit = !source_adjacent?(game_player, loc)
+      klass = @game.board_contents.tile_klass(*Coordinate.from_key(loc)) || tile["klass"]
       if should_forfeit
         @game.move_count += 1
         @game.moves.create(
@@ -1118,6 +1114,63 @@ class TurnEngine
       end
       should_forfeit
     end
+  end
+
+  # A tile is subject to location forfeit unless it is the currently-active
+  # tile, a Nomad tile (which expires by turn, never by location), or has no
+  # source location.
+  def forfeit_eligible?(tile, active_tile_klass)
+    return false if tile["klass"] == active_tile_klass
+    return false if Tiles::Tile.for_klass(tile["klass"])&.new(0)&.nomad_tile?
+    !tile["from"].nil?
+  end
+
+  def source_adjacent?(game_player, loc)
+    return false unless loc
+    @game.board_contents.settlements_for(game_player.order).any? do |s_row, s_col|
+      @game.board_contents.neighbors(s_row, s_col).any? { |nr, nc| Coordinate.new(nr, nc).to_key == loc }
+    end
+  end
+
+  # Prefer-used forfeit: copies of the same klass are interchangeable, so when
+  # some sources are still adjacent and some are not, reassign the `used` flags
+  # within the klass group to the still-adjacent copies first — i.e. the
+  # surviving copies become the unused ones, and the used copies are the ones
+  # that go on to be forfeited. Returns the list of flag changes so the
+  # redistribution can be replayed and undone.
+  def prefer_used_forfeit!(game_player, active_tile_klass)
+    changes = []
+    eligible = (game_player.tiles || []).select { |t| forfeit_eligible?(t, active_tile_klass) }
+    eligible.group_by { |t| t["klass"] }.each_value do |group|
+      adjacent, forfeiting = group.partition { |t| source_adjacent?(game_player, t["from"]) }
+      # Only a mixed group forces a forfeit choice; otherwise leave flags as-is.
+      next if adjacent.empty? || forfeiting.empty?
+      unused_first = group.map { |t| t["used"] }.sort_by { |used| used ? 1 : 0 }
+      (adjacent + forfeiting).each_with_index do |tile, i|
+        before, after = tile["used"], unused_first[i]
+        next if before == after
+        tile["used"] = after
+        changes << { "from" => tile["from"], "before" => before, "after" => after }
+      end
+    end
+    changes
+  end
+
+  # Records the prefer-used flag reassignment as a reversible move so that both
+  # replay (forward) and undo (reverse) reproduce it. Ordered before the
+  # forfeit_tile moves so undo restores forfeited tiles first, then corrects
+  # every affected flag back to its pre-forfeit value. No log message: this is
+  # internal bookkeeping, not a player-visible action.
+  def record_used_redistribution(game_player, changes)
+    @game.move_count += 1
+    @game.moves.create(
+      order: @game.move_count,
+      game_player: game_player,
+      deliberate: false,
+      action: "redistribute_tile_used",
+      reversible: true,
+      payload: { "changes" => changes }
+    )
   end
 
   def find_tile_pickup(game_player, row, col)

--- a/app/views/games/_log.html.erb
+++ b/app/views/games/_log.html.erb
@@ -1,5 +1,6 @@
 <h1>Game Log</h1>
 <% game.moves.order(created_at: :desc).each do |move| %>
+  <% next if move.message.blank? %>
   <div class="move <%= 'abcde'.chars[move.game_player.order] %>">
     <%= move.message %>
   </div>

--- a/test/scenarios/goals/ambassadors_test.rb
+++ b/test/scenarios/goals/ambassadors_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+# Tracer for a Tier-2 (callback-derived) goal. Ambassadors is scored inside the
+# turn engine as builds happen, not recomputed from the board, so it must be
+# driven end-to-end through a real build action and read back through the
+# Scoring seam. (Hand-setting bonus_scores would prove nothing.) The Tier-1
+# board-derived seam is covered by goals/hermits_test.rb.
+class AmbassadorsScenarioTest < ActiveSupport::TestCase
+  test "building adjacent to an opponent settlement scores an ambassadors point" do
+    scenario = GameScenario.new(goals: [ "ambassadors" ], hands: { 0 => "G", 1 => "D" })
+    build_spot = scenario.empty_hexes("G", 1).first
+    opponent_hex = scenario.neighbors(build_spot).find { |n| scenario.owner_at(n).nil? }
+    scenario.place_settlement(1, at: opponent_hex)
+
+    assert_equal 0, scenario.score_for("ambassadors", 0)
+    scenario.build_settlement(at: build_spot)
+    assert_equal 1, scenario.score_for("ambassadors", 0)
+  end
+
+  test "building away from any opponent scores no ambassadors point" do
+    scenario = GameScenario.new(goals: [ "ambassadors" ], hands: { 0 => "G", 1 => "D" })
+    build_spot = scenario.empty_hexes("G", 1).first
+
+    scenario.build_settlement(at: build_spot)
+
+    assert_equal 0, scenario.score_for("ambassadors", 0)
+  end
+end

--- a/test/scenarios/goals/hermits_test.rb
+++ b/test/scenarios/goals/hermits_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class HermitsScenarioTest < ActiveSupport::TestCase
+  test "hermits awards one point per separate settlement area" do
+    scenario = GameScenario.new(goals: [ "hermits" ], hands: { 0 => "G", 1 => "D" })
+    first = scenario.empty_hexes("G", 1).first
+    apart = scenario.empty_hexes("G", 50).find do |spot|
+      spot != first && !scenario.neighbors(first).include?(spot)
+    end
+    scenario.place_settlement(0, at: first)
+    scenario.place_settlement(0, at: apart)
+
+    assert_equal 2, scenario.score_for("hermits", 0)
+    assert_equal 0, scenario.score_for("hermits", 1)
+  end
+end

--- a/test/scenarios/rules/forfeit_test.rb
+++ b/test/scenarios/rules/forfeit_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class ForfeitScenarioTest < ActiveSupport::TestCase
+  # When a player holds two interchangeable copies of a location tile and a move
+  # leaves only one source hex adjacent to a settlement, exactly one copy is
+  # forfeited. The rule is prefer-used: keep the unused copy, forfeit the used
+  # one (confirmed with the game owner 2026-06-12), so the player retains a
+  # usable tile rather than losing it to the accident of which copy was spent.
+  test "forfeit drops the used copy and keeps the unused one when sources are interchangeable" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+
+    # Two grass hexes whose neighbourhoods don't overlap, so each settlement's
+    # adjacency is independent.
+    grass = scenario.empty_hexes("G", 200)
+    stationary = grass.first
+    mover = grass.find do |g|
+      g != stationary &&
+        (scenario.neighbors(g) & (scenario.neighbors(stationary) + [ stationary ])).empty? &&
+        scenario.neighbors(g).count { |n| scenario.terrain_at(n) == "G" && scenario.owner_at(n).nil? } >= 2
+    end
+    raise "fixed board should offer two independent grass settlements" unless mover
+
+    # Destination one grass step from the mover, plus a source hex Y adjacent to
+    # the mover but NOT to the destination (so the move breaks Y's adjacency).
+    movable_neighbors = scenario.neighbors(mover).select do |n|
+      scenario.terrain_at(n) == "G" && scenario.owner_at(n).nil?
+    end
+    dest = movable_neighbors.first
+    y_source = scenario.neighbors(mover).find do |n|
+      n != dest && !scenario.neighbors(dest).include?(n) &&
+        !scenario.neighbors(stationary).include?(n) && n != stationary
+    end
+    x_source = scenario.neighbors(stationary).first
+    raise "could not place independent tile sources" unless y_source && x_source
+
+    scenario.place_settlement(0, at: stationary)
+    scenario.place_settlement(0, at: mover)
+    scenario.give_tile(0, "FarmTile", from: x_source, used: true)   # source stays adjacent
+    scenario.give_tile(0, "FarmTile", from: y_source, used: false)  # source goes non-adjacent
+    scenario.give_tile(0, "ResettlementTile", from: [ 0, 0 ])
+
+    scenario.activate_tile(:resettlement)
+    scenario.select_settlement(at: mover)
+    scenario.move_step(to: dest)
+
+    farms = scenario.held_tiles(0, klass: "FarmTile")
+    assert_equal 1, farms.size, "exactly one FarmTile should be forfeited"
+    assert_not farms.first["used"], "the surviving FarmTile should be the unused copy (prefer-used)"
+  end
+end

--- a/test/scenarios/rules/legal_builds_test.rb
+++ b/test/scenarios/rules/legal_builds_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class LegalBuildsScenarioTest < ActiveSupport::TestCase
+  test "with no settlements on the board, every empty hex of the hand terrain is legal" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    all_grass = scenario.empty_hexes("G", 400)
+
+    assert_equal all_grass.sort, scenario.legal_builds(0).sort
+  end
+
+  test "builds are restricted to adjacent hand-terrain hexes if any exist" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    home = scenario.empty_hexes("G", 50).find do |spot|
+      scenario.neighbors(spot).any? { |n| scenario.terrain_at(n) == "G" }
+    end
+    raise "fixed board should contain adjacent grass hexes" unless home
+    scenario.place_settlement(0, at: home)
+
+    expected = scenario.neighbors(home).select do |n|
+      scenario.terrain_at(n) == "G" && scenario.owner_at(n).nil?
+    end
+
+    assert_equal expected.sort, scenario.legal_builds(0).sort
+  end
+end

--- a/test/scenarios/rules/mandatory_build_test.rb
+++ b/test/scenarios/rules/mandatory_build_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class MandatoryBuildScenarioTest < ActiveSupport::TestCase
+  test "building on the hand terrain places a settlement, spends supply, and counts toward the mandatory three" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    spot = scenario.empty_hexes("G", 1).first
+
+    scenario.build_settlement(at: spot)
+
+    assert_equal 0, scenario.owner_at(spot)
+    assert_equal 39, scenario.settlements_remaining(0)
+    assert_equal 2, scenario.mandatory_remaining
+  end
+
+  test "building on terrain not matching the hand card is rejected" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    desert_spot = scenario.empty_hexes("D", 1).first
+
+    assert_raises(GameScenario::IllegalMove) do
+      scenario.build_settlement(at: desert_spot)
+    end
+    assert_nil scenario.owner_at(desert_spot)
+    assert_equal 40, scenario.settlements_remaining(0)
+  end
+end

--- a/test/scenarios/rules/tile_pickup_test.rb
+++ b/test/scenarios/rules/tile_pickup_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class TilePickupScenarioTest < ActiveSupport::TestCase
+  test "building adjacent to a location hex with remaining tiles picks one up" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    spot = scenario.empty_hexes("G", 1).first
+    tile_spot = scenario.neighbors(spot).first
+    scenario.place_tile("OasisTile", at: tile_spot, qty: 2)
+
+    scenario.build_settlement(at: spot)
+
+    assert scenario.holds_tile?(0, klass: "OasisTile", from: tile_spot)
+    assert_equal 1, scenario.tile_qty(tile_spot)
+  end
+
+  test "building away from any location hex picks up nothing" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    spot = scenario.empty_hexes("G", 1).first
+
+    scenario.build_settlement(at: spot)
+
+    assert_not scenario.holds_tile?(0, klass: "OasisTile")
+  end
+end

--- a/test/scenarios/rules/tile_usability_test.rb
+++ b/test/scenarios/rules/tile_usability_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class TileUsabilityScenarioTest < ActiveSupport::TestCase
+  test "a tile held from a previous turn is usable" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    scenario.give_tile(0, "FarmTile", from: [ 2, 7 ])
+
+    assert_equal [ "FarmTile" ], scenario.usable_tiles(0)
+  end
+
+  test "tile actions are available before mandatory builds begin but not mid-build" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    scenario.give_tile(0, "OasisTile", from: [ 2, 7 ])
+
+    assert_equal [ "OasisTile" ], scenario.available_tile_actions(0)
+
+    scenario.build_settlement(at: scenario.empty_hexes("G", 1).first)
+
+    assert_empty scenario.available_tile_actions(0)
+  end
+
+  test "a tile picked up this turn arrives spent and is not usable until next turn" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    spot = scenario.empty_hexes("G", 1).first
+    scenario.place_tile("FarmTile", at: scenario.neighbors(spot).first, qty: 2)
+
+    scenario.build_settlement(at: spot)
+
+    assert scenario.holds_tile?(0, klass: "FarmTile")
+    assert_empty scenario.usable_tiles(0)
+  end
+end

--- a/test/scenarios/rules/undo_round_trip_test.rb
+++ b/test/scenarios/rules/undo_round_trip_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+# Tracer for the undo round-trip mode: assert_undo_round_trip runs an action,
+# undoes it, asserts the exact pre-action state is restored, then replays the
+# action and asserts the post-action state is reproduced. This is the mechanism
+# that lets the scenario suite prove undo preserves state across the refactor.
+class UndoRoundTripScenarioTest < ActiveSupport::TestCase
+  test "a mandatory build round-trips through undo" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    spot = scenario.empty_hexes("G", 1).first
+
+    assert_undo_round_trip(scenario) { scenario.build_settlement(at: spot) }
+  end
+
+  test "a resettlement step round-trips through undo" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    scenario.give_tile(0, "ResettlementTile", from: [ 0, 0 ])
+    start = scenario.empty_hexes("G", 1).first
+    scenario.place_settlement(0, at: start)
+    step = scenario.neighbors(start).find do |n|
+      scenario.terrain_at(n) == "G" && scenario.owner_at(n).nil?
+    end
+    scenario.activate_tile(:resettlement)
+    scenario.select_settlement(at: start)
+
+    assert_undo_round_trip(scenario) { scenario.move_step(to: step) }
+  end
+end

--- a/test/scenarios/rules/undo_test.rb
+++ b/test/scenarios/rules/undo_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class UndoScenarioTest < ActiveSupport::TestCase
+  test "undo after a build removes the settlement and restores supply and mandatory count" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    spot = scenario.empty_hexes("G", 1).first
+    scenario.build_settlement(at: spot)
+
+    scenario.undo
+
+    assert_nil scenario.owner_at(spot)
+    assert_equal 40, scenario.settlements_remaining(0)
+    assert_equal 3, scenario.mandatory_remaining
+  end
+end

--- a/test/scenarios/tiles/resettlement_movement_test.rb
+++ b/test/scenarios/tiles/resettlement_movement_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class ResettlementMovementScenarioTest < ActiveSupport::TestCase
+  # Tracer for the stepped-movement contract: a settlement mover relocates one
+  # hex per call, vacating its source. (The full "steps up to allowance / picks
+  # up en route / forfeits" contract is parameterized across movers in Phase 3.)
+  test "resettlement relocates a settlement one hex per step, vacating the source" do
+    scenario = GameScenario.new(hands: { 0 => "G", 1 => "D" })
+    scenario.give_tile(0, "ResettlementTile", from: [ 0, 0 ])
+    start = scenario.empty_hexes("G", 1).first
+    scenario.place_settlement(0, at: start)
+    step = scenario.neighbors(start).find do |n|
+      scenario.terrain_at(n) == "G" && scenario.owner_at(n).nil?
+    end
+    raise "fixed board should offer an adjacent grass hex" unless step
+
+    scenario.activate_tile(:resettlement)
+    scenario.select_settlement(at: start)
+    scenario.move_step(to: step)
+
+    assert_equal 0, scenario.owner_at(step)
+    assert_nil scenario.owner_at(start)
+  end
+end

--- a/test/support/game_scenario.rb
+++ b/test/support/game_scenario.rb
@@ -84,6 +84,12 @@ class GameScenario
     game_player(player).holds_tile?(klass: klass, from: from)
   end
 
+  # Raw held-tile hashes (klass/from/used), optionally filtered by klass.
+  def held_tiles(player, klass: nil)
+    tiles = game_player(player).tiles || []
+    klass ? tiles.select { |t| t["klass"] == klass } : tiles
+  end
+
   def tile_qty(at)
     @game.board_contents.tile_qty(*at)
   end

--- a/test/support/game_scenario.rb
+++ b/test/support/game_scenario.rb
@@ -42,6 +42,21 @@ class GameScenario
     perform { |engine| engine.undo_last_move }
   end
 
+  # Activate a held tile's action (e.g. :resettlement, :paddock). The player
+  # must already hold the corresponding tile.
+  def activate_tile(type)
+    perform { |engine| engine.select_action(type.to_s) }
+  end
+
+  def select_settlement(at:)
+    perform { |engine| engine.select_settlement(*at) }
+  end
+
+  # One step of a stepped settlement move (resettlement, paddock, etc.).
+  def move_step(to:)
+    perform { |engine| engine.move_settlement(*to) }
+  end
+
   # --- setup (direct state construction; no rules applied) ---
 
   def place_tile(klass, at:, qty: 2)

--- a/test/support/game_scenario.rb
+++ b/test/support/game_scenario.rb
@@ -142,6 +142,16 @@ class GameScenario
     @game.game_players.find_by!(order: order)
   end
 
+  # Canonical, order-normalized game state for round-trip comparison. Mirrors
+  # the fields game_replayer_test treats as the replayable state.
+  def snapshot
+    state = @game.capture_snapshot
+    state.merge(
+      "board_contents" => state["board_contents"].sort_by { |e| [ e["r"], e["c"] ] },
+      "players" => state["players"].sort_by { |p| p["order"] }
+    )
+  end
+
   private
 
   def create_player(order, hand)

--- a/test/support/game_scenario.rb
+++ b/test/support/game_scenario.rb
@@ -1,0 +1,169 @@
+# Test-owned DSL for driving games at the domain layer. Tests speak only to
+# this class (setup, actions, queries); it delegates to the real domain entry
+# points. When a refactor moves those internals, re-point this class and the
+# scenario suites stay unchanged.
+class GameScenario
+  class IllegalMove < StandardError; end
+
+  # Fixed board sections (same set as game_replayer_test's known state) so
+  # every scenario sees an identical map.
+  DEFAULT_BOARDS = [ [ 1, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ].freeze
+  DEFAULT_DECK = %w[T G C D F].freeze
+  DEFAULT_HAND = "G".freeze
+
+  attr_reader :game
+
+  def initialize(players: 2, boards: DEFAULT_BOARDS, deck: DEFAULT_DECK,
+                 goals: [], tasks: [], hands: {})
+    @game = Game.create!(
+      state: "playing",
+      boards: boards.map(&:dup),
+      board_contents: BoardState.new,
+      deck: deck.dup,
+      discard: [],
+      goals: goals,
+      tasks: tasks,
+      mandatory_count: Game::MANDATORY_COUNT,
+      move_count: 0,
+      current_action: { "type" => "mandatory" }
+    )
+    players.times { |order| create_player(order, hands.fetch(order, DEFAULT_HAND)) }
+    @game.update!(current_player: game_player(0))
+    @game.update!(base_snapshot: @game.capture_snapshot)
+  end
+
+  # --- actions (domain intent; raise IllegalMove when the rules forbid it) ---
+
+  def build_settlement(at:)
+    perform { |engine| engine.build_settlement(*at) }
+  end
+
+  def undo
+    perform { |engine| engine.undo_last_move }
+  end
+
+  # --- setup (direct state construction; no rules applied) ---
+
+  def place_tile(klass, at:, qty: 2)
+    mutate_board { |contents| contents.place_tile(*at, klass, qty) }
+  end
+
+  def place_settlement(player, at:)
+    mutate_board { |contents| contents.place_settlement(*at, player) }
+  end
+
+  def give_tile(player, klass, from:, used: false)
+    gp = game_player(player)
+    gp.restore_tile!(klass, from: Coordinate.new(*from).to_key, used: used)
+    gp.save!
+  end
+
+  # --- queries ---
+
+  def owner_at(at)
+    @game.board_contents.player_at(*at)
+  end
+
+  def holds_tile?(player, klass: nil, from: nil)
+    from = Coordinate.new(*from).to_key if from.is_a?(Array)
+    game_player(player).holds_tile?(klass: klass, from: from)
+  end
+
+  def tile_qty(at)
+    @game.board_contents.tile_qty(*at)
+  end
+
+  def neighbors(at)
+    @game.board_contents.neighbors(*at)
+  end
+
+  def terrain_at(at)
+    fresh_board.terrain_at(*at)
+  end
+
+  def legal_builds(player)
+    @game.legal_builds(game_player(player))
+  end
+
+  def score_for(goal, player)
+    fresh_board
+    @game.score_for(goal, game_player(player))
+  end
+
+  def usable_tiles(player)
+    game_player(player).usable_tiles.map { |t| t["klass"] }
+  end
+
+  def available_tile_actions(player)
+    fresh_board
+    @game.available_tile_actions(game_player(player)).map { |t| t["klass"] }
+  end
+
+  def settlements_remaining(player)
+    game_player(player).settlements_remaining
+  end
+
+  def mandatory_remaining
+    @game.mandatory_count
+  end
+
+  # Deterministic on a fixed board: scans row-major for empty hexes of the
+  # given terrain.
+  def empty_hexes(terrain, count)
+    board = fresh_board
+    spots = []
+    20.times do |row|
+      20.times do |col|
+        next unless board.terrain_at(row, col) == terrain
+        next unless @game.board_contents.empty?(row, col)
+        spots << [ row, col ]
+        return spots if spots.size >= count
+      end
+    end
+    spots
+  end
+
+  def game_player(order)
+    @game.game_players.find_by!(order: order)
+  end
+
+  private
+
+  def create_player(order, hand)
+    user = User.create!(
+      handle: "scenario-#{@game.id}-p#{order}",
+      email_address: "scenario-#{@game.id}-p#{order}@example.com",
+      password: "password",
+      approved: true
+    )
+    GamePlayer.create!(
+      game: @game,
+      player: user,
+      order: order,
+      hand: Array(hand),
+      supply: { "settlements" => Game::SETTLEMENTS_PER_PLAYER },
+      tiles: []
+    )
+  end
+
+  def mutate_board
+    @game.board_contents_will_change!
+    yield @game.board_contents
+    @game.board = nil
+    @game.save!
+  end
+
+  def perform
+    @game.board = nil
+    result = yield TurnEngine.new(@game)
+    raise IllegalMove, result if result.is_a?(String)
+    @game.reload
+    @game.board = nil
+    result
+  end
+
+  def fresh_board
+    @game.board = nil
+    @game.instantiate
+  end
+end

--- a/test/support/scenario_assertions.rb
+++ b/test/support/scenario_assertions.rb
@@ -1,0 +1,20 @@
+# Assertions for the scenario suite. assert_undo_round_trip is the opt-in undo
+# mode from the test-net plan: run an action, undo it, prove the exact
+# pre-action state is restored, then replay the action and prove the
+# post-action state is reproduced.
+module ScenarioAssertions
+  def assert_undo_round_trip(scenario)
+    before = scenario.snapshot
+    yield
+    after = scenario.snapshot
+    refute_equal before, after, "the action under test should change game state"
+    scenario.undo
+    assert_equal before, scenario.snapshot, "undo should restore the exact pre-action state"
+    yield
+    assert_equal after, scenario.snapshot, "replaying the action should reproduce the post-action state"
+  end
+end
+
+class ActiveSupport::TestCase
+  include ScenarioAssertions
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,8 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 
+Dir[Rails.root.join("test/support/**/*.rb")].sort.each { |f| require f }
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers


### PR DESCRIPTION
## What

Phase 1 and Phase 2 of the behavior-pinning test net (shimmering-muffin plan) — a rules-based regression suite that drives games through a test-owned DSL hiding `TurnEngine`, so it survives the planned turn-engine refactor. Plus one production bug fix surfaced by the work.

## Why

The May turn-engine refactor was reverted because its tests validated the new engine against itself, not the rulebook. This net asserts the rules at the domain layer through a stable DSL/query surface, so a future refactor can be verified against behavior that doesn't move.

## Phase 1 — DSL + stable query surface

- `test/support/game_scenario.rb` — `GameScenario`: deterministic setup (fixed boards/deck/hands, own users), actions that raise `IllegalMove` on rule violations, and queries. Tests never touch `TurnEngine`.
- New domain query methods that form the assertion contract a refactor must preserve: `GamePlayer#holds_tile?` / `#usable_tiles`, `Game#legal_builds` / `#score_for` / `#available_tile_actions`.

## Phase 2 — tracer bullets

- **Stepped movement** — `activate_tile` / `select_settlement` / `move_step`, validated via a Resettlement move.
- **Forfeit-prefers-used (#223)** — surfaced a real bug: tile forfeit was strictly provenance-based and could discard an unused copy while keeping a spent one. Now redistributes `used` flags within mixed klass groups so survivors stay usable, recorded as a reversible `redistribute_tile_used` move so **undo and replay both round-trip**. Red→green test.
- **Undo round-trip mode** — `assert_undo_round_trip` (act → undo → assert restored → replay → assert reproduced), backed by `GameScenario#snapshot`.
- **Ambassadors end-to-end** — a Tier-2 callback goal driven through a real build and read back through the Scoring seam (Tier-1 covered by the Hermits test).

## Review focus

The test files are low-risk and additive. The change that warrants scrutiny is the **forfeit fix**: `app/services/turn_engine.rb` (`prefer_used_forfeit!`, `apply_tile_forfeit`) and both `MoveApplicator` backends (`apply_redistribute_tile_used`), since it touches the undo/replay core. `app/views/games/_log.html.erb` now skips blank-message moves (the bookkeeping move has none).

## Verification

- Full suite green: 798 runs, 0 failures.
- New scenario suite: `test/scenarios/{rules,goals,tiles}/`.
- RuboCop clean on changed files.

Closes #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)