### PR TITLE
Delete multi-hop movement; collapse to a single-step rule

### DIFF
--- a/app/models/tiles/lighthouse_tile.rb
+++ b/app/models/tiles/lighthouse_tile.rb
@@ -15,20 +15,16 @@ module Tiles
     end
 
     # No from_row/from_col: placement hexes + own ship hex (for popup triggering).
-    # With from_row/from_col: BFS move destinations through empty water up to 3 steps.
+    # With from_row/from_col: the single move step — adjacent empty water hexes.
     def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil, supply: Hash.new(0))
       if from_row && from_col
-        water_bfs(from_row, from_col, board_contents:, board:, max_depth: 3)
+        board_contents.neighbors_where(from_row, from_col) do |nr, nc|
+          board_contents.available_for_building?(nr, nc) && board.terrain_at(nr, nc) == "W"
+        end
       else
         ships = board_contents.ships_for(player_order)
         placement = supply["ship"] > 0 ? placement_hexes(board_contents:, board:, player_order:) : []
         (placement + ships).uniq
-      end
-    end
-
-    def selectable_ships(player_order:, board_contents:, board:)
-      board_contents.ships_for(player_order).select do |r, c|
-        water_bfs(r, c, board_contents:, board:, max_depth: 3).any?
       end
     end
 
@@ -45,25 +41,6 @@ module Tiles
       (0..19).flat_map do |r|
         (0..19).filter_map { |c| [ r, c ] if board_contents.empty?(r, c) && board.terrain_at(r, c) == "W" }
       end
-    end
-
-    def water_bfs(from_row, from_col, board_contents:, board:, max_depth:)
-      visited = { [ from_row, from_col ] => 0 }
-      queue = [ [ from_row, from_col, 0 ] ]
-      reachable = []
-      while queue.any?
-        r, c, depth = queue.shift
-        next if depth >= max_depth
-        board_contents.neighbors(r, c).each do |nr, nc|
-          next if visited.key?([ nr, nc ])
-          next unless board.terrain_at(nr, nc) == "W"
-          next unless board_contents.empty?(nr, nc)
-          visited[[ nr, nc ]] = depth + 1
-          reachable << [ nr, nc ]
-          queue << [ nr, nc, depth + 1 ]
-        end
-      end
-      reachable
     end
   end
 end

--- a/app/models/tiles/nomad/resettlement_tile.rb
+++ b/app/models/tiles/nomad/resettlement_tile.rb
@@ -6,83 +6,31 @@ module Tiles
 
       def moves_settlement? = true
 
-      # BFS up to `budget` steps from (from_row, from_col).
-      # Vacated hexes count as empty/passable.
+      # The single move step from (from_row, from_col): adjacent empty buildable
+      # hexes. `budget` gates whether any step remains this turn.
       def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil,
-                             budget: 4, vacated: [])
+                             budget: 4)
         return [] if from_row.nil? || from_col.nil? || budget <= 0
 
-        vacated_set = vacated.to_set
-        reachable = []
-        visited = {}
-        queue = [ [ from_row, from_col, 0 ] ]
-
-        until queue.empty?
-          r, c, dist = queue.shift
-          next if visited[[ r, c ]]
-          visited[[ r, c ]] = true
-
-          board_contents.neighbors(r, c).each do |nr, nc|
-            next if visited[[ nr, nc ]]
-            key = "[#{nr}, #{nc}]"
-            is_empty = (board_contents.empty?(nr, nc) || vacated_set.include?(key)) && !board_contents.warrior_blocked?(nr, nc)
-            next unless is_empty
-            next unless BUILDABLE_TERRAIN.include?(board.terrain_at(nr, nc))
-
-            new_dist = dist + 1
-            next if new_dist > budget
-
-            reachable << [ nr, nc ] unless reachable.include?([ nr, nc ])
-            queue << [ nr, nc, new_dist ]
-          end
+        board_contents.neighbors_where(from_row, from_col) do |nr, nc|
+          board_contents.available_for_building?(nr, nc) && BUILDABLE_TERRAIN.include?(board.terrain_at(nr, nc))
         end
-
-        reachable
       end
 
-      def selectable_settlements(player_order:, board_contents:, board:, hand: nil,
-                                  budget: 4, vacated: [])
+      def selectable_settlements(player_order:, board_contents:, board:, hand: nil, budget: 4)
         return [] if budget <= 0
         board_contents.settlements_for(player_order).filter_map do |r, c|
           next if board_contents.city_hall_at?(r, c)
           [ r, c ] if valid_destinations(
             from_row: r, from_col: c,
             board_contents:, board:, player_order:,
-            budget:, vacated:
+            budget:
           ).any?
         end
       end
 
       def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
         selectable_settlements(player_order:, board_contents:, board:, hand:).any?
-      end
-
-      # BFS shortest-path cost (in steps) from (from_row, from_col) to (to_row, to_col).
-      # Returns nil if the destination is unreachable within the budget.
-      def move_cost(from_row:, from_col:, to_row:, to_col:, board_contents:, board:, player_order:, budget: 4, vacated: [])
-        vacated_set = vacated.to_set
-        visited = {}
-        queue = [ [ from_row, from_col, 0 ] ]
-
-        until queue.empty?
-          r, c, dist = queue.shift
-          return dist if r == to_row && c == to_col
-          next if visited[[ r, c ]]
-          visited[[ r, c ]] = true
-
-          board_contents.neighbors(r, c).each do |nr, nc|
-            next if visited[[ nr, nc ]]
-            key = "[#{nr}, #{nc}]"
-            is_empty = (board_contents.empty?(nr, nc) || vacated_set.include?(key)) && !board_contents.warrior_blocked?(nr, nc)
-            next unless is_empty
-            next unless BUILDABLE_TERRAIN.include?(board.terrain_at(nr, nc))
-            new_dist = dist + 1
-            next if new_dist > budget
-            queue << [ nr, nc, new_dist ]
-          end
-        end
-
-        nil
       end
     end
   end

--- a/app/models/tiles/wagon_tile.rb
+++ b/app/models/tiles/wagon_tile.rb
@@ -17,20 +17,16 @@ module Tiles
     end
 
     # No from_row/from_col: placement hexes + own wagon hexes (for popup triggering).
-    # With from_row/from_col: BFS move destinations through empty suitable terrain up to 3 steps.
+    # With from_row/from_col: the single move step — adjacent empty suitable-terrain hexes.
     def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil, supply: Hash.new(0))
       if from_row && from_col
-        terrain_bfs(from_row, from_col, board_contents:, board:, max_depth: 3)
+        board_contents.neighbors_where(from_row, from_col) do |nr, nc|
+          board_contents.available_for_building?(nr, nc) && SUITABLE_TERRAIN.include?(board.terrain_at(nr, nc))
+        end
       else
         wagons = board_contents.wagons_for(player_order)
         placement = supply["wagon"] > 0 ? placement_hexes(board_contents:, board:, player_order:) : []
         (placement + wagons).uniq
-      end
-    end
-
-    def selectable_wagons(player_order:, board_contents:, board:)
-      board_contents.wagons_for(player_order).select do |r, c|
-        terrain_bfs(r, c, board_contents:, board:, max_depth: 3).any?
       end
     end
 
@@ -49,25 +45,6 @@ module Tiles
           [ r, c ] if board_contents.empty?(r, c) && SUITABLE_TERRAIN.include?(board.terrain_at(r, c))
         end
       end
-    end
-
-    def terrain_bfs(from_row, from_col, board_contents:, board:, max_depth:)
-      visited = { [ from_row, from_col ] => 0 }
-      queue = [ [ from_row, from_col, 0 ] ]
-      reachable = []
-      while queue.any?
-        r, c, depth = queue.shift
-        next if depth >= max_depth
-        board_contents.neighbors(r, c).each do |nr, nc|
-          next if visited.key?([ nr, nc ])
-          next unless SUITABLE_TERRAIN.include?(board.terrain_at(nr, nc))
-          next unless board_contents.empty?(nr, nc)
-          visited[[ nr, nc ]] = depth + 1
-          reachable << [ nr, nc ]
-          queue << [ nr, nc, depth + 1 ]
-        end
-      end
-      reachable
     end
   end
 end

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -295,20 +295,18 @@ class TurnPhase::SettlementMovePhase < TurnPhase
 end
 
 class TurnPhase::ResettlementPhase < TurnPhase
-  attr_reader :budget_value, :vacated_value, :moves_value, :from_value
+  attr_reader :budget_value, :moves_value, :from_value
 
   def self.from_hash(hash)
     new(
       budget: hash.fetch("budget"),
-      vacated: Array(hash["vacated"]),
       moves: hash.fetch("moves"),
       from: hash["from"]
     )
   end
 
-  def initialize(budget:, vacated:, moves:, from: nil)
+  def initialize(budget:, moves:, from: nil)
     @budget_value = budget
-    @vacated_value = vacated
     @moves_value = moves
     @from_value = from
   end
@@ -325,10 +323,6 @@ class TurnPhase::ResettlementPhase < TurnPhase
     budget_value
   end
 
-  def vacated
-    vacated_value
-  end
-
   def moves
     moves_value
   end
@@ -343,7 +337,6 @@ class TurnPhase::ResettlementPhase < TurnPhase
       TurnPhase::TransitionResult.new(
         next_phase: self.class.new(
           budget: budget,
-          vacated: vacated,
           moves: moves,
           from: event.coordinate_key
         ),
@@ -365,7 +358,6 @@ class TurnPhase::ResettlementPhase < TurnPhase
       "type" => "resettlement",
       "klass" => "ResettlementTile",
       "budget" => budget,
-      "vacated" => vacated,
       "moves" => moves
     }
     hash["from"] = from if from
@@ -602,10 +594,6 @@ class TurnPhase::LegacyPhase < TurnPhase
 
   def budget
     data["budget"]
-  end
-
-  def vacated
-    Array(data["vacated"])
   end
 
   def moves

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -461,7 +461,6 @@ class TurnEngine
       elsif tile_obj&.is_a?(Tiles::Nomad::ResettlementTile)
         TurnPhase::ResettlementPhase.new(
           budget: 4,
-          vacated: [],
           moves: 0
         )
       elsif tile_obj&.places_meeple? && %w[ship wagon].include?(tile_obj.meeple_kind)
@@ -547,18 +546,14 @@ class TurnEngine
       lock_terrain!(@game.board.terrain_at(row, col), chosen_terrain_before)
     end
     if tile_obj&.is_a?(Tiles::Nomad::ResettlementTile)
-      route = [ [ row, col ] ]
-      return "Not available" unless valid_movement_path?(
-        route,
-        from_coord.row,
-        from_coord.col,
-        budget: current_phase.budget.to_i,
-        allowed_terrains: Tiles::Tile::BUILDABLE_TERRAIN,
-        vacated: current_phase.vacated || []
-      )
+      return "Not available" unless current_phase.budget.to_i > 0 &&
+        tile_obj.valid_destinations(
+          from_row: from_coord.row, from_col: from_coord.col,
+          board_contents: @game.board_contents, board: @game.board,
+          player_order: @game.current_player.order, budget: current_phase.budget.to_i
+        ).include?([ row, col ])
 
       budget = current_phase.budget.to_i - 1
-      vacated = (current_phase.vacated || []) + [ from ]
       moves = current_phase.moves.to_i + 1
       next_phase =
         if budget <= 0
@@ -566,7 +561,6 @@ class TurnEngine
         else
           TurnPhase::ResettlementPhase.new(
             budget: budget,
-            vacated: vacated,
             moves: moves
           )
         end
@@ -574,7 +568,7 @@ class TurnEngine
         action: "move_settlement",
         game_player: @game.current_player,
         from_row: from_coord.row, from_col: from_coord.col,
-        path: route,
+        path: [ [ row, col ] ],
         payload: { "tile_klass" => tile_klass_name },
         message_piece: "settlement"
       )
@@ -889,7 +883,11 @@ class TurnEngine
             if current_phase.from
               from = Coordinate.from_key(current_phase.from)
               if tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
-                resettlement_step_destinations(from, current_phase)
+                tile_obj.valid_destinations(
+                  from_row: from.row, from_col: from.col,
+                  board_contents: @game.board_contents, board: @game.board,
+                  player_order: player.order, budget: current_phase.budget.to_i
+                )
               else
                 extra_kwargs = {}
                 if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
@@ -908,8 +906,7 @@ class TurnEngine
               extra_kwargs = {}
               if tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
                 extra_kwargs = {
-                  budget: current_phase.respond_to?(:budget) ? current_phase.budget.to_i : 0,
-                  vacated: current_phase.respond_to?(:vacated) ? current_phase.vacated || [] : []
+                  budget: current_phase.respond_to?(:budget) ? current_phase.budget.to_i : 0
                 }
               end
               if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
@@ -1357,71 +1354,16 @@ class TurnEngine
     end
   end
 
-  def valid_movement_path?(path, from_row, from_col, budget:, allowed_terrains:, vacated:)
-    return false if path.empty? || path.size > budget
-
-    vacated_set = vacated.to_set
-    current = [ from_row, from_col ]
-    path.all? do |row, col|
-      key = Coordinate.new(row, col).to_key
-      valid = @game.board_contents.neighbors(*current).include?([ row, col ]) &&
-        allowed_terrains.include?(@game.board.terrain_at(row, col)) &&
-        ((@game.board_contents.empty?(row, col) || vacated_set.include?(key)) && !@game.board_contents.warrior_blocked?(row, col))
-      current = [ row, col ]
-      valid
-    end
-  end
-
-  def shortest_movement_path(from_row, from_col, to_row, to_col, budget:, allowed_terrains:, vacated:)
-    vacated_set = vacated.to_set
-    queue = [ [ from_row, from_col, [] ] ]
-    visited = Set.new([ [ from_row, from_col ] ])
-
-    until queue.empty?
-      row, col, path = queue.shift
-      @game.board_contents.neighbors(row, col).each do |next_row, next_col|
-        next if visited.include?([ next_row, next_col ])
-        key = Coordinate.new(next_row, next_col).to_key
-        next unless allowed_terrains.include?(@game.board.terrain_at(next_row, next_col))
-        next unless (@game.board_contents.empty?(next_row, next_col) || vacated_set.include?(key)) && !@game.board_contents.warrior_blocked?(next_row, next_col)
-
-        next_path = path + [ [ next_row, next_col ] ]
-        return next_path if next_row == to_row && next_col == to_col
-        next if next_path.size >= budget
-
-        visited << [ next_row, next_col ]
-        queue << [ next_row, next_col, next_path ]
-      end
-    end
-    nil
-  end
-
+  # One move step is legal when a hop remains this turn and the destination is
+  # among the piece's adjacent single-step destinations (the tile owns the
+  # terrain rule via valid_destinations).
   def meeple_step_available?(from_coord, row, col, tile_obj)
     @game.turn_phase.budget.to_i > 0 &&
-      @game.board_contents.neighbors(from_coord.row, from_coord.col).include?([ row, col ]) &&
-      meeple_movement_terrain(tile_obj).include?(@game.board.terrain_at(row, col)) &&
-      @game.board_contents.empty?(row, col) &&
-      !@game.board_contents.warrior_blocked?(row, col)
-  end
-
-  def resettlement_step_destinations(from_coord, current_phase)
-    @game.board_contents.neighbors(from_coord.row, from_coord.col).select do |row, col|
-      valid_movement_path?(
-        [ [ row, col ] ],
-        from_coord.row, from_coord.col,
-        budget: current_phase.budget.to_i,
-        allowed_terrains: Tiles::Tile::BUILDABLE_TERRAIN,
-        vacated: current_phase.respond_to?(:vacated) ? current_phase.vacated || [] : []
-      )
-    end
-  end
-
-  def meeple_movement_terrain(tile_obj)
-    case tile_obj.meeple_kind
-    when "ship" then [ "W" ]
-    when "wagon" then Tiles::WagonTile::SUITABLE_TERRAIN
-    else []
-    end
+      tile_obj.valid_destinations(
+        from_row: from_coord.row, from_col: from_coord.col,
+        board_contents: @game.board_contents, board: @game.board,
+        player_order: @game.current_player.order
+      ).include?([ row, col ])
   end
 
   def place_warrior(row, col, game_player, tile_klass:)

--- a/test/models/tiles/lighthouse_tile_test.rb
+++ b/test/models/tiles/lighthouse_tile_test.rb
@@ -96,7 +96,7 @@ class Tiles::LighthouseTileTest < ActiveSupport::TestCase
     assert_equal [], destinations
   end
 
-  test "valid_destinations (move) returns reachable water hexes within 3 steps" do
+  test "valid_destinations (move) returns only adjacent empty water hexes (one step)" do
     state = BoardState.new
     state.place_ship(10, 10, 0)
     dests = tile.valid_destinations(
@@ -104,9 +104,8 @@ class Tiles::LighthouseTileTest < ActiveSupport::TestCase
       board_contents: state, board: all_water_board, player_order: 0
     )
     assert_includes dests, [ 10, 11 ]
-    assert_includes dests, [ 10, 12 ]
-    assert_includes dests, [ 10, 13 ]
-    assert_not_includes dests, [ 10, 14 ]
+    assert_not_includes dests, [ 10, 12 ]
+    assert_not_includes dests, [ 10, 13 ]
     assert_not_includes dests, [ 10, 10 ]
   end
 
@@ -133,22 +132,5 @@ class Tiles::LighthouseTileTest < ActiveSupport::TestCase
       board_contents: state, board: all_water_board, player_order: 0
     )
     assert_not_includes dests, [ 10, 11 ]
-  end
-
-  test "selectable_ships returns ship coords when ship can move" do
-    state = BoardState.new
-    state.place_ship(10, 10, 0)
-    result = tile.selectable_ships(player_order: 0, board_contents: state, board: all_water_board)
-    assert_includes result, [ 10, 10 ]
-  end
-
-  test "selectable_ships returns empty when ship has no move destinations" do
-    state = BoardState.new
-    state.place_ship(1, 1, 0)
-    all_land = {}
-    20.times { |r| 20.times { |c| all_land[[ r, c ]] = "G" } }
-    all_land[[ 1, 1 ]] = "W"
-    result = tile.selectable_ships(player_order: 0, board_contents: state, board: BoardStub.new(all_land))
-    assert_equal [], result
   end
 end

--- a/test/models/tiles/nomad/resettlement_tile_test.rb
+++ b/test/models/tiles/nomad/resettlement_tile_test.rb
@@ -67,52 +67,16 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
     end
   end
 
-  test "BFS reaches hexes 2 steps away with budget=2" do
-    # (0,0) -> (0,1) -> (0,2) is 2 steps, all G terrain
+  test "returns only adjacent hexes (one step), not 2 away, regardless of budget" do
+    # Movement is one hex per step; budget only gates whether a step remains.
     ctx = setup_board { |s| s.place_settlement(0, 0, @chris.order) }
     result = @tile.valid_destinations(
       from_row: 0, from_col: 0,
       board_contents: ctx[:board_contents], board: ctx[:board], player_order: @chris.order,
       budget: 2
     )
-    assert_includes result, [ 0, 2 ], "should reach 2 steps away"
-  end
-
-  test "BFS does not exceed budget" do
-    # With budget=1, should NOT include (0,2) which is 2 steps from (0,0)
-    ctx = setup_board { |s| s.place_settlement(0, 0, @chris.order) }
-    result = @tile.valid_destinations(
-      from_row: 0, from_col: 0,
-      board_contents: ctx[:board_contents], board: ctx[:board], player_order: @chris.order,
-      budget: 1
-    )
-    refute_includes result, [ 0, 2 ], "budget=1 should not reach 2 steps away"
-  end
-
-  test "vacated hexes are passable" do
-    # Settlement at (0,2) [G]. Place another settlement at (0,1) to block direct path.
-    # If (0,1) is vacated (treated as empty), BFS can pass through it.
-    ctx = setup_board do |s|
-      s.place_settlement(0, 2, @chris.order)
-      s.place_settlement(0, 1, @chris.order)  # blocks (0,1) normally
-    end
-
-    # Without vacated, (0,1) is occupied — should not appear as destination
-    result_no_vacated = @tile.valid_destinations(
-      from_row: 0, from_col: 2,
-      board_contents: ctx[:board_contents], board: ctx[:board], player_order: @chris.order,
-      budget: 2, vacated: []
-    )
-    refute_includes result_no_vacated, [ 0, 1 ], "occupied hex should not be a destination without vacated"
-
-    # With (0,1) in vacated, BFS can pass through it
-    result_with_vacated = @tile.valid_destinations(
-      from_row: 0, from_col: 2,
-      board_contents: ctx[:board_contents], board: ctx[:board], player_order: @chris.order,
-      budget: 2, vacated: [ "[0, 1]" ]
-    )
-    assert_includes result_with_vacated, [ 0, 1 ], "vacated hex should be reachable"
-    assert_includes result_with_vacated, [ 0, 0 ], "hex beyond vacated should be reachable with remaining budget"
+    assert_includes result, [ 0, 1 ], "adjacent hex is a destination"
+    refute_includes result, [ 0, 2 ], "a hex 2 steps away is never a single-step destination"
   end
 
   test "non-buildable terrain is excluded from destinations" do

--- a/test/models/tiles/wagon_tile_test.rb
+++ b/test/models/tiles/wagon_tile_test.rb
@@ -125,7 +125,7 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
     assert_equal [], destinations
   end
 
-  test "valid_destinations (move) reaches up to 3 steps through suitable terrain" do
+  test "valid_destinations (move) returns only adjacent suitable hexes (one step)" do
     state = BoardState.new
     state.place_wagon(10, 10, 0)
     dests = tile.valid_destinations(
@@ -133,9 +133,8 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
       board_contents: state, board: all_grass_board, player_order: 0
     )
     assert_includes dests, [ 10, 11 ]
-    assert_includes dests, [ 10, 12 ]
-    assert_includes dests, [ 10, 13 ]
-    assert_not_includes dests, [ 10, 14 ]
+    assert_not_includes dests, [ 10, 12 ]
+    assert_not_includes dests, [ 10, 13 ]
     assert_not_includes dests, [ 10, 10 ]
   end
 
@@ -163,7 +162,7 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
     assert_not_includes dests, [ 10, 11 ]
   end
 
-  test "valid_destinations (move) can traverse mountain hexes" do
+  test "valid_destinations (move) includes adjacent mountain hexes" do
     terrain = {}
     20.times { |r| 20.times { |c| terrain[[ r, c ]] = "M" } }
     state = BoardState.new
@@ -173,23 +172,6 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
       board_contents: state, board: BoardStub.new(terrain), player_order: 0
     )
     assert_includes dests, [ 10, 11 ]
-    assert_includes dests, [ 10, 12 ]
-    assert_includes dests, [ 10, 13 ]
-  end
-
-  # --- selectable_wagons ---
-
-  test "selectable_wagons returns wagon coords when wagon can move" do
-    state = BoardState.new
-    state.place_wagon(10, 10, 0)
-    result = tile.selectable_wagons(player_order: 0, board_contents: state, board: all_grass_board)
-    assert_includes result, [ 10, 10 ]
-  end
-
-  test "selectable_wagons returns empty when wagon surrounded by water" do
-    state = BoardState.new
-    state.place_wagon(5, 5, 0)
-    result = tile.selectable_wagons(player_order: 0, board_contents: state, board: all_water_board)
-    assert_equal [], result
+    assert_not_includes dests, [ 10, 12 ]
   end
 end

--- a/test/models/turn_phase_test.rb
+++ b/test/models/turn_phase_test.rb
@@ -83,7 +83,6 @@ class TurnPhaseTest < ActiveSupport::TestCase
       "type" => "resettlement",
       "klass" => "ResettlementTile",
       "budget" => 4,
-      "vacated" => [],
       "moves" => 0
     })
 
@@ -95,7 +94,6 @@ class TurnPhaseTest < ActiveSupport::TestCase
     assert_instance_of TurnPhase::ResettlementPhase, result.next_phase
     assert_equal "[1, 2]", result.next_phase.from
     assert_equal 4, result.next_phase.budget
-    assert_equal [], result.next_phase.vacated
     assert_equal 0, result.next_phase.moves
   end
 
@@ -104,14 +102,12 @@ class TurnPhaseTest < ActiveSupport::TestCase
       "type" => "resettlement",
       "klass" => "ResettlementTile",
       "budget" => 3,
-      "vacated" => ["[2, 3]"],
       "moves" => 1,
       "from" => "[5, 5]"
     })
 
     assert_instance_of TurnPhase::ResettlementPhase, phase
     assert_equal 3, phase.budget
-    assert_equal ["[2, 3]"], phase.vacated
     assert_equal 1, phase.moves
     assert_equal "[5, 5]", phase.from
   end

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -380,7 +380,6 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_equal "resettlement", @game.current_action["type"]
     assert_equal "ResettlementTile", @game.current_action["klass"]
     assert_equal 4, @game.current_action["budget"]
-    assert_equal [], @game.current_action["vacated"]
     assert_equal 0, @game.current_action["moves"]
   end
 
@@ -422,21 +421,7 @@ class TurnEngineTest < ActiveSupport::TestCase
 
   test "resettlement move deducts one step from budget" do
     @game.boards = [ [ 2, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
-    # Find two Grass hexes at least 2 apart so cost > 1
-    grass_hexes = empty_hexes_of("G", 10)
-    # Find a source and a destination that are 2+ steps apart
-    from_hex = grass_hexes[0]
-    dest_hex = grass_hexes.find do |h|
-      @game.instantiate
-      dist = Tiles::Nomad::ResettlementTile.new(0).move_cost(
-        from_row: from_hex[0], from_col: from_hex[1],
-        to_row: h[0], to_col: h[1],
-        board_contents: @game.board_contents, board: @game.board,
-        player_order: @game.current_player.order
-      )
-      dist && dist >= 2
-    end
-    raise "No suitable hex pair found" unless dest_hex
+    from_hex = empty_hexes_of("G", 10).first
 
     player = @game.current_player
     player.update!(tiles: [ { "klass" => "ResettlementTile", "from" => "[0, 0]", "used" => false } ])
@@ -445,47 +430,48 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.save
     @game.update!(current_action: {
       "type" => "resettlement", "klass" => "ResettlementTile",
-      "budget" => 4, "vacated" => [], "moves" => 0
+      "budget" => 4, "moves" => 0
     })
     @game.instantiate
-    path = @engine.send(
-      :shortest_movement_path,
-      from_hex[0], from_hex[1], dest_hex[0], dest_hex[1],
-      budget: 4,
-      allowed_terrains: Tiles::Tile::BUILDABLE_TERRAIN,
-      vacated: []
-    )
+    dest = Tiles::Nomad::ResettlementTile.new(0).valid_destinations(
+      from_row: from_hex[0], from_col: from_hex[1],
+      board_contents: @game.board_contents, board: @game.board,
+      player_order: player.order, budget: 4
+    ).first
+    raise "No adjacent step available" unless dest
+
     @engine.select_settlement(*from_hex)
     @game.reload
-    @engine.move_settlement(*path.first)
+    @engine.move_settlement(*dest)
     @game.reload
 
     assert_equal 3, @game.current_action["budget"]
   end
 
-  test "undo of resettlement move restores budget, vacated, moves, and from in current_action" do
+  test "undo of resettlement move restores budget, moves, and from in current_action" do
     @game.boards = [ [ 6, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
-    spots = empty_hexes_of("G", 2)
+    from_hex = empty_hexes_of("G", 2).first
     player = @game.current_player
     player.update!(tiles: [ { "klass" => "ResettlementTile", "from" => "[0, 0]", "used" => false } ])
     # Place a settlement so there's something to move
     @game.board_contents_will_change!
-    @game.board_contents.place_settlement(*spots[0], player.order)
+    @game.board_contents.place_settlement(*from_hex, player.order)
     @game.save
-    from_key = "[#{spots[0][0]}, #{spots[0][1]}]"
+    from_key = "[#{from_hex[0]}, #{from_hex[1]}]"
     @game.update!(current_action: {
       "type" => "resettlement", "klass" => "ResettlementTile",
-      "budget" => 4, "vacated" => [], "moves" => 0
+      "budget" => 4, "moves" => 0
     })
-    @engine.select_settlement(*spots[0])
-    @game.reload
-    step = @engine.send(
-      :shortest_movement_path,
-      spots[0][0], spots[0][1], spots[1][0], spots[1][1],
-      budget: 4,
-      allowed_terrains: Tiles::Tile::BUILDABLE_TERRAIN,
-      vacated: []
+    @game.instantiate
+    step = Tiles::Nomad::ResettlementTile.new(0).valid_destinations(
+      from_row: from_hex[0], from_col: from_hex[1],
+      board_contents: @game.board_contents, board: @game.board,
+      player_order: player.order, budget: 4
     ).first
+    raise "No adjacent step available" unless step
+
+    @engine.select_settlement(*from_hex)
+    @game.reload
     @engine.move_settlement(*step)
     @game.reload
     assert_equal 3, @game.current_action["budget"]
@@ -496,7 +482,6 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_equal "resettlement",     @game.current_action["type"]
     assert_equal "ResettlementTile", @game.current_action["klass"]
     assert_equal 4,                  @game.current_action["budget"]
-    assert_equal [],                 @game.current_action["vacated"]
     assert_equal 0,                  @game.current_action["moves"]
     assert_equal from_key,           @game.current_action["from"]
   end
@@ -510,7 +495,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.save
     @game.update!(current_action: {
       "type" => "resettlement", "klass" => "ResettlementTile",
-      "budget" => 4, "vacated" => [], "moves" => 0
+      "budget" => 4, "moves" => 0
     })
     @engine.select_settlement(*spots[0])
     @game.reload
@@ -521,7 +506,6 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_equal "resettlement",     @game.current_action["type"]
     assert_equal "ResettlementTile", @game.current_action["klass"]
     assert_equal 4,                  @game.current_action["budget"]
-    assert_equal [],                 @game.current_action["vacated"]
     assert_equal 0,                  @game.current_action["moves"]
     assert_nil                       @game.current_action["from"]
   end
@@ -816,7 +800,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     player.update!(tiles: [ { "klass" => "ResettlementTile", "from" => "[3, 4]", "used" => false } ])
     @game.update!(current_action: {
       "type" => "resettlement", "klass" => "ResettlementTile",
-      "budget" => 4, "vacated" => [], "moves" => 0, "from" => "[4, 3]"
+      "budget" => 4, "moves" => 0, "from" => "[4, 3]"
     })
 
     cells = @engine.buildable_cells
@@ -1904,7 +1888,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     player.update!(tiles: [ { "klass" => "ResettlementTile", "from" => "[3, 4]", "used" => false } ])
     @game.update!(current_action: {
       "type" => "resettlement", "klass" => "ResettlementTile",
-      "budget" => 4, "vacated" => [], "moves" => 0
+      "budget" => 4, "moves" => 0
     })
     @game.instantiate
 
@@ -1913,15 +1897,13 @@ class TurnEngineTest < ActiveSupport::TestCase
       from_row: 4, from_col: 3,
       board_contents: @game.board_contents, board: @game.board,
       player_order: player.order,
-      budget: 4,
-      vacated: []
+      budget: 4
     ).first
     second_step = source_tile.valid_destinations(
       from_row: 2, from_col: 7,
       board_contents: @game.board_contents, board: @game.board,
       player_order: player.order,
-      budget: 4,
-      vacated: []
+      budget: 4
     ).first
     assert first_step
     assert second_step


### PR DESCRIPTION
## Context

Piece movement (ship, wagon, resettlement) is taken **one hex per click**; `budget` on the phase counts the hops left this turn. The codebase still carried machinery from an earlier design where one click could move a piece N hexes at once — **five BFS searches and a path-validator** computing "hexes reachable within N steps."

Tracing every call site proved **no consumer ever uses a distance > 1 result as a destination**: highlighting and move-validation were already single-step, and the only production use of the BFS was a boolean `.any?` guard ("can this piece move at all?"), which is provably equal to "has ≥1 empty passable neighbour." Two of the searches (`shortest_movement_path`, `move_cost`) and two helpers (`selectable_ships`, `selectable_wagons`) were already dead — referenced only by tests.

The `vacated` set was part of the same relic, and — because it is **never pruned** — a latent bug: move A out of `h1`, move B *into* `h1`, then a move toward `h1` still passed the guard via `vacated.include?(h1)` and `move_settlement` overwrote B.

## Change

- Each mover tile's `valid_destinations(from:)` collapses from a BFS to one `neighbors_where { available_for_building? && <terrain> }` call (reusing existing `BoardState` methods); the engine delegates to it (`meeple_step_available?` becomes a thin delegator).
- **Deleted**: `shortest_movement_path`, `valid_movement_path?`, `resettlement_step_destinations`, `meeple_movement_terrain` (engine); `water_bfs`/`selectable_ships` (Lighthouse); `terrain_bfs`/`selectable_wagons` (Wagon); `move_cost` (Resettlement); the `vacated` field across `ResettlementPhase` + `LegacyPhase` and every call threading it.
- **Bug fixed**: the un-pruned `vacated` overwrite hazard is gone.
- `budget` stays — purely as the per-turn hop counter.

**No production behaviour change other than the bug fix.** Net **~260 lines deleted** (79 insertions, 341 deletions).

This is the predicate cleanup ADR-0001 named as the first move, and candidate 02 of the architecture review (order 02 → 04 → 01 → 03).

## Tests

- `test/scenarios/` movement net (ship/wagon/resettlement) stays green **untouched** — the safety harness.
- Orphan-method unit tests deleted; multi-hop unit tests rewritten to the single-step contract; `vacated` assertions dropped.
- Full suite: **875 runs, 0 failures, 0 errors**. RuboCop: no new offenses.
- Manually smoke-tested: ship/wagon/resettlement moves highlight only adjacent legal hexes, decrement budget, undo correctly, and the vacated overwrite case can no longer occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)