### PR TITLE
Give BoardState terrain_at; drop the board: param

### DIFF
--- a/app/models/board_state.rb
+++ b/app/models/board_state.rb
@@ -1,10 +1,22 @@
 class BoardState
+  # Terrain is static board config (from game.boards), not occupancy, so it is
+  # never serialized. A terrain source (anything answering terrain_at(row, col)
+  # — the Boards::Board in production, a stub in tests) is attached at
+  # game.instantiate so BoardState can answer both occupancy and terrain.
+  attr_writer :terrain_source
+
   def initialize
     @cells = {}
   end
 
   def initialize_copy(original)
     @cells = original.instance_variable_get(:@cells).transform_values(&:dup)
+    @terrain_source = original.instance_variable_get(:@terrain_source)
+  end
+
+  def terrain_at(row, col)
+    raise "no terrain source attached (call game.instantiate first)" unless @terrain_source
+    @terrain_source.terrain_at(row, col)
   end
 
   def place_settlement(row, col, player)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -196,6 +196,8 @@ class Game < ApplicationRecord
 
   def instantiate_board
     @board ||= Boards::Board.new(self)
+    board_contents.terrain_source = @board
+    @board
   end
 
   def broadcast_dashboard_update

--- a/app/models/scoring/goals/merchants.rb
+++ b/app/models/scoring/goals/merchants.rb
@@ -18,7 +18,7 @@ class Scoring
 
       def special_hexes
         (0..19).flat_map do |r|
-          (0..19).filter_map { |c| [ r, c ] if %w[L S].include?(board.terrain_at(r, c)) }
+          (0..19).filter_map { |c| [ r, c ] if %w[L S].include?(board_contents.terrain_at(r, c)) }
         end
       end
     end

--- a/app/models/scoring/goals/workers.rb
+++ b/app/models/scoring/goals/workers.rb
@@ -4,7 +4,7 @@ class Scoring
       DESCRIPTION = "1 point for each settlement next to a castle or location space"
       def score_for(game_player)
         count = settlements_for(game_player.order).count do |r, c|
-          neighbors(r, c).any? { |nr, nc| %w[S L].include?(board.terrain_at(nr, nc)) }
+          neighbors(r, c).any? { |nr, nc| %w[S L].include?(board_contents.terrain_at(nr, nc)) }
         end
         { score: count }
       end

--- a/app/models/scoring/scorer.rb
+++ b/app/models/scoring/scorer.rb
@@ -19,8 +19,8 @@ class Scoring
 
     def count_adjacent_to(order, terrain)
       settlements_for(order).count do |r, c|
-        board.terrain_at(r, c) != terrain &&
-          neighbors(r, c).any? { |nr, nc| board.terrain_at(nr, nc) == terrain }
+        board_contents.terrain_at(r, c) != terrain &&
+          neighbors(r, c).any? { |nr, nc| board_contents.terrain_at(nr, nc) == terrain }
       end
     end
 
@@ -82,7 +82,7 @@ class Scoring
     def terrain_hexes(terrain)
       @terrain_hexes ||= {}
       @terrain_hexes[terrain] ||= 20.times.flat_map do |r|
-        20.times.filter_map { |c| [ r, c ] if board.terrain_at(r, c) == terrain }
+        20.times.filter_map { |c| [ r, c ] if board_contents.terrain_at(r, c) == terrain }
       end
     end
   end

--- a/app/models/scoring/tasks/place_of_refuge.rb
+++ b/app/models/scoring/tasks/place_of_refuge.rb
@@ -18,7 +18,7 @@ class Scoring
 
       def special_hexes
         20.times.flat_map do |r|
-          20.times.filter_map { |c| [ r, c ] if SPECIAL_TERRAINS.include?(board.terrain_at(r, c)) }
+          20.times.filter_map { |c| [ r, c ] if SPECIAL_TERRAINS.include?(board_contents.terrain_at(r, c)) }
         end
       end
     end

--- a/app/models/tiles/barracks_tile.rb
+++ b/app/models/tiles/barracks_tile.rb
@@ -10,22 +10,22 @@ module Tiles
       game_player.add_warriors!(2)
     end
 
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
       supply["warrior"] > 0 || board_contents.warriors_for(player_order).any?
     end
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil, supply: Hash.new(0))
-      placement = supply["warrior"] > 0 ? placement_hexes(board_contents:, board:, player_order:) : []
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil, supply: Hash.new(0))
+      placement = supply["warrior"] > 0 ? placement_hexes(board_contents:, player_order:) : []
       removal = board_contents.warriors_for(player_order)
       (placement + removal).uniq
     end
 
     private
 
-    def placement_hexes(board_contents:, board:, player_order:)
+    def placement_hexes(board_contents:, player_order:)
       all_valid = (0..19).flat_map do |r|
         (0..19).filter_map do |c|
-          [ r, c ] if BUILDABLE_TERRAIN.include?(board.terrain_at(r, c)) && board_contents.available_for_building?(r, c)
+          [ r, c ] if BUILDABLE_TERRAIN.include?(board_contents.terrain_at(r, c)) && board_contents.available_for_building?(r, c)
         end
       end
 

--- a/app/models/tiles/caravan_tile.rb
+++ b/app/models/tiles/caravan_tile.rb
@@ -7,7 +7,7 @@ module Tiles
 
     def moves_settlement? = true
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order: nil, hand: nil)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order: nil, hand: nil)
       return [] if from_row.nil? || from_col.nil?
       STRAIGHT_LINES.filter_map do |steps|
         last = nil
@@ -17,7 +17,7 @@ module Tiles
           nr, nc = r + dr, c + dc
           break unless (0..19).cover?(nr) && (0..19).cover?(nc) &&
                        board_contents.available_for_building?(nr, nc) &&
-                       BUILDABLE_TERRAIN.include?(board.terrain_at(nr, nc))
+                       BUILDABLE_TERRAIN.include?(board_contents.terrain_at(nr, nc))
           last = [ nr, nc ]
           r, c = nr, nc
         end
@@ -25,15 +25,15 @@ module Tiles
       end
     end
 
-    def selectable_settlements(player_order:, board_contents:, board:, hand: nil)
+    def selectable_settlements(player_order:, board_contents:, hand: nil)
       board_contents.settlements_for(player_order).filter_map do |r, c|
         next if board_contents.city_hall_at?(r, c)
-        [ r, c ] if valid_destinations(from_row: r, from_col: c, board_contents:, board:).any?
+        [ r, c ] if valid_destinations(from_row: r, from_col: c, board_contents:).any?
       end
     end
 
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
-      selectable_settlements(player_order:, board_contents:, board:, hand:).any?
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
+      selectable_settlements(player_order:, board_contents:, hand:).any?
     end
   end
 end

--- a/app/models/tiles/city_hall_tile.rb
+++ b/app/models/tiles/city_hall_tile.rb
@@ -9,16 +9,16 @@ module Tiles
       game_player.add_city_halls!(1)
     end
 
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
-      supply["city_hall"].to_i > 0 && valid_destinations(board_contents:, board:, player_order:, supply:).any?
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
+      supply["city_hall"].to_i > 0 && valid_destinations(board_contents:, player_order:, supply:).any?
     end
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil, supply: Hash.new(0))
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil, supply: Hash.new(0))
       return [] if supply["city_hall"].to_i < 1
 
       (0..19).flat_map do |r|
         (0..19).filter_map do |c|
-          [ r, c ] if valid_center?(r, c, board_contents:, board:, player_order:)
+          [ r, c ] if valid_center?(r, c, board_contents:, player_order:)
         end
       end
     end
@@ -34,12 +34,12 @@ module Tiles
 
     private
 
-    def valid_center?(row, col, board_contents:, board:, player_order:)
-      return false unless buildable_and_empty?(row, col, board_contents:, board:)
+    def valid_center?(row, col, board_contents:, player_order:)
+      return false unless buildable_and_empty?(row, col, board_contents:)
 
       neighbors = board_contents.neighbors(row, col)
       return false unless neighbors.size == 6
-      return false unless neighbors.all? { |nr, nc| buildable_and_empty?(nr, nc, board_contents:, board:) }
+      return false unless neighbors.all? { |nr, nc| buildable_and_empty?(nr, nc, board_contents:) }
 
       cluster = Set.new([ [ row, col ] ] + neighbors)
       neighbors.any? do |nr, nc|
@@ -49,8 +49,8 @@ module Tiles
       end
     end
 
-    def buildable_and_empty?(row, col, board_contents:, board:)
-      board_contents.empty?(row, col) && BUILDABLE_TERRAIN.include?(board.terrain_at(row, col))
+    def buildable_and_empty?(row, col, board_contents:)
+      board_contents.empty?(row, col) && BUILDABLE_TERRAIN.include?(board_contents.terrain_at(row, col))
     end
   end
 end

--- a/app/models/tiles/fort_tile.rb
+++ b/app/models/tiles/fort_tile.rb
@@ -6,7 +6,7 @@ module Tiles
     def builds_settlement? = true
     def fort_tile? = true
 
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
       true
     end
   end

--- a/app/models/tiles/harbor_tile.rb
+++ b/app/models/tiles/harbor_tile.rb
@@ -6,12 +6,12 @@ module Tiles
     def moves_settlement? = true
     def move_terrain(hand:) = "W"
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil)
       other_settlements = board_contents.settlements_for(player_order).reject { |r, c| r == from_row && c == from_col }
 
       adjacent = other_settlements.flat_map do |r, c|
         board_contents.neighbors_where(r, c) do |nr, nc|
-          board_contents.available_for_building?(nr, nc) && board.terrain_at(nr, nc) == "W"
+          board_contents.available_for_building?(nr, nc) && board_contents.terrain_at(nr, nc) == "W"
         end
       end.uniq
 
@@ -19,7 +19,7 @@ module Tiles
 
       (0..19).flat_map do |r|
         (0..19).filter_map do |c|
-          [ r, c ] if board_contents.available_for_building?(r, c) && board.terrain_at(r, c) == "W"
+          [ r, c ] if board_contents.available_for_building?(r, c) && board_contents.terrain_at(r, c) == "W"
         end
       end
     end

--- a/app/models/tiles/lighthouse_tile.rb
+++ b/app/models/tiles/lighthouse_tile.rb
@@ -10,36 +10,36 @@ module Tiles
       game_player.add_ships!(1)
     end
 
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
       supply["ship"] > 0 || board_contents.ships_for(player_order).any?
     end
 
     # No from_row/from_col: placement hexes + own ship hex (for popup triggering).
     # With from_row/from_col: the single move step — adjacent empty water hexes.
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil, supply: Hash.new(0))
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil, supply: Hash.new(0))
       if from_row && from_col
         board_contents.neighbors_where(from_row, from_col) do |nr, nc|
-          board_contents.available_for_building?(nr, nc) && board.terrain_at(nr, nc) == "W"
+          board_contents.available_for_building?(nr, nc) && board_contents.terrain_at(nr, nc) == "W"
         end
       else
         ships = board_contents.ships_for(player_order)
-        placement = supply["ship"] > 0 ? placement_hexes(board_contents:, board:, player_order:) : []
+        placement = supply["ship"] > 0 ? placement_hexes(board_contents:, player_order:) : []
         (placement + ships).uniq
       end
     end
 
     private
 
-    def placement_hexes(board_contents:, board:, player_order:)
+    def placement_hexes(board_contents:, player_order:)
       own = board_contents.settlements_for(player_order)
       adjacent = own.flat_map do |r, c|
         board_contents.neighbors_where(r, c) do |nr, nc|
-          board_contents.empty?(nr, nc) && board.terrain_at(nr, nc) == "W"
+          board_contents.empty?(nr, nc) && board_contents.terrain_at(nr, nc) == "W"
         end
       end.uniq
       return adjacent unless adjacent.empty?
       (0..19).flat_map do |r|
-        (0..19).filter_map { |c| [ r, c ] if board_contents.empty?(r, c) && board.terrain_at(r, c) == "W" }
+        (0..19).filter_map { |c| [ r, c ] if board_contents.empty?(r, c) && board_contents.terrain_at(r, c) == "W" }
       end
     end
   end

--- a/app/models/tiles/mandatory_tile.rb
+++ b/app/models/tiles/mandatory_tile.rb
@@ -4,6 +4,6 @@ module Tiles
 
     # Mandatory placement is handled by clicking the board directly,
     # not by selecting this tile as an action.
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0)) = false
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0)) = false
   end
 end

--- a/app/models/tiles/nomad/donation_tile.rb
+++ b/app/models/tiles/nomad/donation_tile.rb
@@ -16,7 +16,7 @@ module Tiles
         raise NotImplementedError, "#{self.class} must define build_terrain"
       end
 
-      def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
+      def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil)
         terrain = build_terrain
         settlements = board_contents.settlements_for(player_order)
 
@@ -24,7 +24,7 @@ module Tiles
         # Note: Donation tiles can build on W and M (unlike normal builds)
         adjacent = settlements.flat_map do |r, c|
           board_contents.neighbors_where(r, c) do |nr, nc|
-            board_contents.available_for_building?(nr, nc) && board.terrain_at(nr, nc) == terrain
+            board_contents.available_for_building?(nr, nc) && board_contents.terrain_at(nr, nc) == terrain
           end
         end.uniq
 
@@ -33,13 +33,13 @@ module Tiles
         # Fallback: all empty hexes of that terrain anywhere on board
         (0..19).flat_map do |r|
           (0..19).filter_map do |c|
-            [ r, c ] if board_contents.available_for_building?(r, c) && board.terrain_at(r, c) == terrain
+            [ r, c ] if board_contents.available_for_building?(r, c) && board_contents.terrain_at(r, c) == terrain
           end
         end
       end
 
-      def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
-        valid_destinations(board_contents:, board:, player_order:, hand:).any?
+      def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
+        valid_destinations(board_contents:, player_order:, hand:).any?
       end
     end
   end

--- a/app/models/tiles/nomad/outpost_tile.rb
+++ b/app/models/tiles/nomad/outpost_tile.rb
@@ -6,7 +6,7 @@ module Tiles
 
       def outpost_tile? = true
 
-      def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
+      def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
         false # activated via separate route, not the normal tile action flow
       end
     end

--- a/app/models/tiles/nomad/resettlement_tile.rb
+++ b/app/models/tiles/nomad/resettlement_tile.rb
@@ -8,29 +8,29 @@ module Tiles
 
       # The single move step from (from_row, from_col): adjacent empty buildable
       # hexes. `budget` gates whether any step remains this turn.
-      def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil,
+      def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil,
                              budget: 4)
         return [] if from_row.nil? || from_col.nil? || budget <= 0
 
         board_contents.neighbors_where(from_row, from_col) do |nr, nc|
-          board_contents.available_for_building?(nr, nc) && BUILDABLE_TERRAIN.include?(board.terrain_at(nr, nc))
+          board_contents.available_for_building?(nr, nc) && BUILDABLE_TERRAIN.include?(board_contents.terrain_at(nr, nc))
         end
       end
 
-      def selectable_settlements(player_order:, board_contents:, board:, hand: nil, budget: 4)
+      def selectable_settlements(player_order:, board_contents:, hand: nil, budget: 4)
         return [] if budget <= 0
         board_contents.settlements_for(player_order).filter_map do |r, c|
           next if board_contents.city_hall_at?(r, c)
           [ r, c ] if valid_destinations(
             from_row: r, from_col: c,
-            board_contents:, board:, player_order:,
+            board_contents:, player_order:,
             budget:
           ).any?
         end
       end
 
-      def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
-        selectable_settlements(player_order:, board_contents:, board:, hand:).any?
+      def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
+        selectable_settlements(player_order:, board_contents:, hand:).any?
       end
     end
   end

--- a/app/models/tiles/nomad/sword_tile.rb
+++ b/app/models/tiles/nomad/sword_tile.rb
@@ -10,7 +10,7 @@ module Tiles
         "#{player_handle} must select a settlement to remove"
       end
 
-      def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
+      def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
         # Activatable if any opponent has settlements; full validation done in select_action
         true
       end

--- a/app/models/tiles/paddock_tile.rb
+++ b/app/models/tiles/paddock_tile.rb
@@ -17,7 +17,7 @@ module Tiles
 
     def moves_settlement? = true
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order: nil, hand: nil)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order: nil, hand: nil)
       return [] if from_row.nil? || from_col.nil?
       STRAIGHT_LINES.filter_map do |steps|
         dr1, dc1 = steps[from_row % 2]
@@ -29,19 +29,19 @@ module Tiles
         c2 = c1 + dc2
         next unless (0..19).cover?(r2) && (0..19).cover?(c2)
         next unless board_contents.available_for_building?(r2, c2)
-        next unless BUILDABLE_TERRAIN.include?(board.terrain_at(r2, c2))
+        next unless BUILDABLE_TERRAIN.include?(board_contents.terrain_at(r2, c2))
         [ r2, c2 ]
       end
     end
 
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
-      selectable_settlements(player_order:, board_contents:, board:, hand:).any?
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
+      selectable_settlements(player_order:, board_contents:, hand:).any?
     end
 
-    def selectable_settlements(player_order:, board_contents:, board:, hand: nil)
+    def selectable_settlements(player_order:, board_contents:, hand: nil)
       board_contents.settlements_for(player_order).filter_map do |r, c|
         next if board_contents.city_hall_at?(r, c)
-        [ r, c ] if valid_destinations(from_row: r, from_col: c, board_contents:, board:).any?
+        [ r, c ] if valid_destinations(from_row: r, from_col: c, board_contents:).any?
       end
     end
   end

--- a/app/models/tiles/quarry_tile.rb
+++ b/app/models/tiles/quarry_tile.rb
@@ -6,20 +6,20 @@ module Tiles
     def places_wall? = true
     def uses_played_terrain? = true
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil)
       terrain = hand
       return [] unless terrain
 
       settlements = board_contents.settlements_for(player_order)
       settlements.flat_map do |r, c|
         board_contents.neighbors_where(r, c) do |nr, nc|
-          board_contents.available_for_building?(nr, nc) && board.terrain_at(nr, nc) == terrain
+          board_contents.available_for_building?(nr, nc) && board_contents.terrain_at(nr, nc) == terrain
         end
       end.uniq
     end
 
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
-      valid_destinations(board_contents:, board:, player_order:, hand:).any?
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
+      valid_destinations(board_contents:, player_order:, hand:).any?
     end
 
     def action_message(player_handle:, terrain_names:, hand: nil)

--- a/app/models/tiles/tavern_tile.rb
+++ b/app/models/tiles/tavern_tile.rb
@@ -19,7 +19,7 @@ module Tiles
       [ [ [ -1, 0 ], [ -1, 1 ] ], [ [ 1, -1 ], [ 1, 0 ] ] ]    # NE / SW
     ].freeze
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil)
       settlements = board_contents.settlements_for(player_order).to_set
       candidates = []
 
@@ -41,16 +41,16 @@ module Tiles
 
           next if run_length < 3
 
-          candidates << [ nr, nc ] if valid_build?(nr, nc, board_contents, board)
-          candidates << [ br, bc ] if valid_build?(br, bc, board_contents, board)
+          candidates << [ nr, nc ] if valid_build?(nr, nc, board_contents)
+          candidates << [ br, bc ] if valid_build?(br, bc, board_contents)
         end
       end
 
       candidates.uniq
     end
 
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
-      valid_destinations(board_contents:, board:, player_order:).any?
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
+      valid_destinations(board_contents:, player_order:).any?
     end
 
     private
@@ -60,10 +60,10 @@ module Tiles
       [ r + dr, c + dc ]
     end
 
-    def valid_build?(r, c, board_contents, board)
+    def valid_build?(r, c, board_contents)
       (0..19).cover?(r) && (0..19).cover?(c) &&
         board_contents.available_for_building?(r, c) &&
-        BUILDABLE_TERRAIN.include?(board.terrain_at(r, c))
+        BUILDABLE_TERRAIN.include?(board_contents.terrain_at(r, c))
     end
   end
 end

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -18,7 +18,7 @@ module Tiles
 
     def build_terrain = nil
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil, supply: Hash.new(0))
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil, supply: Hash.new(0))
       terrain = build_terrain || hand
       return [] unless terrain
 
@@ -27,7 +27,7 @@ module Tiles
 
       adjacent = settlements.flat_map do |r, c|
         board_contents.neighbors_where(r, c) do |nr, nc|
-          board_contents.available_for_building?(nr, nc) && board.terrain_at(nr, nc) == terrain
+          board_contents.available_for_building?(nr, nc) && board_contents.terrain_at(nr, nc) == terrain
         end
       end.uniq
 
@@ -35,19 +35,19 @@ module Tiles
 
       (0..19).flat_map do |r|
         (0..19).filter_map do |c|
-          [ r, c ] if board_contents.available_for_building?(r, c) && board.terrain_at(r, c) == terrain
+          [ r, c ] if board_contents.available_for_building?(r, c) && board_contents.terrain_at(r, c) == terrain
         end
       end
     end
 
-    def selectable_settlements(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
+    def selectable_settlements(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
       return [] unless moves_settlement?
-      return [] unless valid_destinations(board_contents:, board:, player_order:, hand:).any?
+      return [] unless valid_destinations(board_contents:, player_order:, hand:).any?
       board_contents.settlements_for(player_order).reject { |r, c| board_contents.city_hall_at?(r, c) }
     end
 
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
-      valid_destinations(board_contents:, board:, player_order:, hand:).any?
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
+      valid_destinations(board_contents:, player_order:, hand:).any?
     end
 
     def builds_settlement?

--- a/app/models/tiles/tower_tile.rb
+++ b/app/models/tiles/tower_tile.rb
@@ -10,9 +10,9 @@ module Tiles
       "#{player_handle} must build at the edge of the board"
     end
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil)
       border = ->(r, c) { r == 0 || r == 19 || c == 0 || c == 19 }
-      buildable = ->(r, c) { BUILDABLE_TERRAIN.include?(board.terrain_at(r, c)) }
+      buildable = ->(r, c) { BUILDABLE_TERRAIN.include?(board_contents.terrain_at(r, c)) }
 
       adjacent = board_contents.settlements_for(player_order).flat_map do |r, c|
         board_contents.neighbors_where(r, c) do |nr, nc|

--- a/app/models/tiles/village_tile.rb
+++ b/app/models/tiles/village_tile.rb
@@ -5,12 +5,12 @@ module Tiles
 
     def builds_settlement? = true
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil)
       settlements = board_contents.settlements_for(player_order).to_set
       (0..19).flat_map do |r|
         (0..19).filter_map do |c|
           next unless board_contents.available_for_building?(r, c)
-          next unless BUILDABLE_TERRAIN.include?(board.terrain_at(r, c))
+          next unless BUILDABLE_TERRAIN.include?(board_contents.terrain_at(r, c))
           adj_count = board_contents.neighbors(r, c).count { |nr, nc| settlements.include?([ nr, nc ]) }
           [ r, c ] if adj_count >= 3
         end

--- a/app/models/tiles/wagon_tile.rb
+++ b/app/models/tiles/wagon_tile.rb
@@ -12,37 +12,37 @@ module Tiles
       game_player.add_wagons!(1)
     end
 
-    def activatable?(player_order:, board_contents:, board:, hand: nil, supply: Hash.new(0))
+    def activatable?(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
       supply["wagon"] > 0 || board_contents.wagons_for(player_order).any?
     end
 
     # No from_row/from_col: placement hexes + own wagon hexes (for popup triggering).
     # With from_row/from_col: the single move step — adjacent empty suitable-terrain hexes.
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, board:, player_order:, hand: nil, supply: Hash.new(0))
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil, supply: Hash.new(0))
       if from_row && from_col
         board_contents.neighbors_where(from_row, from_col) do |nr, nc|
-          board_contents.available_for_building?(nr, nc) && SUITABLE_TERRAIN.include?(board.terrain_at(nr, nc))
+          board_contents.available_for_building?(nr, nc) && SUITABLE_TERRAIN.include?(board_contents.terrain_at(nr, nc))
         end
       else
         wagons = board_contents.wagons_for(player_order)
-        placement = supply["wagon"] > 0 ? placement_hexes(board_contents:, board:, player_order:) : []
+        placement = supply["wagon"] > 0 ? placement_hexes(board_contents:, player_order:) : []
         (placement + wagons).uniq
       end
     end
 
     private
 
-    def placement_hexes(board_contents:, board:, player_order:)
+    def placement_hexes(board_contents:, player_order:)
       own = board_contents.settlements_for(player_order)
       adjacent = own.flat_map do |r, c|
         board_contents.neighbors_where(r, c) do |nr, nc|
-          board_contents.empty?(nr, nc) && SUITABLE_TERRAIN.include?(board.terrain_at(nr, nc))
+          board_contents.empty?(nr, nc) && SUITABLE_TERRAIN.include?(board_contents.terrain_at(nr, nc))
         end
       end.uniq
       return adjacent unless adjacent.empty?
       (0..19).flat_map do |r|
         (0..19).filter_map do |c|
-          [ r, c ] if board_contents.empty?(r, c) && SUITABLE_TERRAIN.include?(board.terrain_at(r, c))
+          [ r, c ] if board_contents.empty?(r, c) && SUITABLE_TERRAIN.include?(board_contents.terrain_at(r, c))
         end
       end
     end

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -10,9 +10,9 @@ class TurnEngine
     any = false
     20.times do |row|
       20.times do |col|
-        if @game.board.content_at(row, col).try(:player) == active_player
+        if @game.board_contents.player_at(row, col) == active_player
           @game.board_contents.neighbors(row, col).each do |nr, nc|
-            if @game.board.content_at(nr, nc) == nil && @game.board.terrain_at(nr, nc) == terrain &&
+            if @game.board_contents.empty?(nr, nc) && @game.board_contents.terrain_at(nr, nc) == terrain &&
                !@game.board_contents.warrior_blocked?(nr, nc)
               any = available[nr][nc] = true
             end
@@ -24,8 +24,8 @@ class TurnEngine
 
     20.times do |row|
       20.times do |col|
-        if @game.board.terrain_at(row, col) == terrain && !@game.board_contents.warrior_blocked?(row, col)
-          available[row][col] = true unless @game.board.content_at(row, col)
+        if @game.board_contents.terrain_at(row, col) == terrain && !@game.board_contents.warrior_blocked?(row, col)
+          available[row][col] = true if @game.board_contents.empty?(row, col)
         end
       end
     end
@@ -49,9 +49,9 @@ class TurnEngine
     card_terrain = effective_terrain(game_player)
 
     if current_phase.is_a?(TurnPhase::MandatoryBuildPhase) && current_phase.outpost_active?
-      card_terrain ||= game_player.hand.find { |t| @game.board.terrain_at(row, col) == t }
+      card_terrain ||= game_player.hand.find { |t| @game.board_contents.terrain_at(row, col) == t }
       # Skip adjacency: just check it's empty and correct terrain
-      return "Not available" unless @game.board_contents.available_for_building?(row, col) && @game.board.terrain_at(row, col) == card_terrain
+      return "Not available" unless @game.board_contents.available_for_building?(row, col) && @game.board_contents.terrain_at(row, col) == card_terrain
       lock_terrain!(card_terrain, chosen_terrain_before) unless chosen_terrain_before
       build_on_terrain(card_terrain, row, col, game_player)
       @game.mandatory_count -= 1
@@ -252,7 +252,7 @@ class TurnEngine
       return "Not available"  # handled by popup: remove_meeple_action
     else
       destinations = tile_obj.valid_destinations(
-        board_contents: @game.board_contents, board: @game.board,
+        board_contents: @game.board_contents,
         player_order: game_player.order, supply: game_player.supply_hash
       )
       return "Not available" unless destinations.include?([ row, col ])
@@ -317,7 +317,7 @@ class TurnEngine
 
     destinations = tile_obj.valid_destinations(
       from_row: row, from_col: col,
-      board_contents: @game.board_contents, board: @game.board,
+      board_contents: @game.board_contents,
       player_order: game_player.order
     )
     return "Not available" unless destinations.any?
@@ -354,7 +354,7 @@ class TurnEngine
     return "No City Hall tile" unless tile
     tile_obj = Tiles::CityHallTile.new(0)
     valid = tile_obj.valid_destinations(
-      board_contents: @game.board_contents, board: @game.board,
+      board_contents: @game.board_contents,
       player_order: game_player.order, supply: game_player.supply_hash
     )
     return "Not available" unless valid.include?([ row, col ])
@@ -393,31 +393,31 @@ class TurnEngine
     if current_phase.respond_to?(:outpost_active?) && current_phase.outpost_active?
       outpost_terrains = outpost_build_terrains(tile_obj, current_phase, game_player)
       return "Not available" unless @game.board_contents.available_for_building?(row, col) &&
-        outpost_terrains.include?(@game.board.terrain_at(row, col))
+        outpost_terrains.include?(@game.board_contents.terrain_at(row, col))
     else
       if tile_obj.fort_tile?
         hand = current_phase.respond_to?(:fort_terrain) ? current_phase.fort_terrain : nil
         destinations = tile_obj.valid_destinations(
-          board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: hand
+          board_contents: @game.board_contents, player_order: game_player.order, hand: hand
         )
       elsif tile_obj.uses_played_terrain? && effective_terrain(game_player).nil?
         destinations = game_player.hand.flat_map { |t|
           tile_obj.valid_destinations(
-            board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: t
+            board_contents: @game.board_contents, player_order: game_player.order, hand: t
           )
         }.uniq
       else
         hand = effective_terrain(game_player) || game_player.hand.first
         destinations = tile_obj.valid_destinations(
-          board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: hand
+          board_contents: @game.board_contents, player_order: game_player.order, hand: hand
         )
       end
       return "Not available" unless destinations.include?([ row, col ])
     end
     if tile_obj.uses_played_terrain? && chosen_terrain_before.nil? && game_player.hand.size > 1
-      lock_terrain!(@game.board.terrain_at(row, col), chosen_terrain_before)
+      lock_terrain!(@game.board_contents.terrain_at(row, col), chosen_terrain_before)
     end
-    build_on_terrain(@game.board.terrain_at(row, col), row, col, game_player, tile_klass: tile_klass)
+    build_on_terrain(@game.board_contents.terrain_at(row, col), row, col, game_player, tile_klass: tile_klass)
     if tile_obj.is_a?(Tiles::Nomad::DonationTile)
       remaining = current_phase.remaining.to_i - 1
       if remaining > 0
@@ -543,13 +543,13 @@ class TurnEngine
     tile_obj = Tiles::Tile.for_klass(tile_klass_name)&.new(0)
     chosen_terrain_before = current_phase.chosen_terrain
     if tile_obj&.uses_played_terrain? && chosen_terrain_before.nil? && @game.current_player.hand.size > 1
-      lock_terrain!(@game.board.terrain_at(row, col), chosen_terrain_before)
+      lock_terrain!(@game.board_contents.terrain_at(row, col), chosen_terrain_before)
     end
     if tile_obj&.is_a?(Tiles::Nomad::ResettlementTile)
       return "Not available" unless current_phase.budget.to_i > 0 &&
         tile_obj.valid_destinations(
           from_row: from_coord.row, from_col: from_coord.col,
-          board_contents: @game.board_contents, board: @game.board,
+          board_contents: @game.board_contents,
           player_order: @game.current_player.order, budget: current_phase.budget.to_i
         ).include?([ row, col ])
 
@@ -634,16 +634,16 @@ class TurnEngine
     wall_terrain = effective_terrain(game_player)
     if wall_terrain.nil?
       destinations = game_player.hand.flat_map { |t|
-        tile_obj.valid_destinations(board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: t)
+        tile_obj.valid_destinations(board_contents: @game.board_contents, player_order: game_player.order, hand: t)
       }.uniq
     else
-      destinations = tile_obj.valid_destinations(board_contents: @game.board_contents, board: @game.board, player_order: game_player.order, hand: wall_terrain)
+      destinations = tile_obj.valid_destinations(board_contents: @game.board_contents, player_order: game_player.order, hand: wall_terrain)
     end
     return "Not available" unless destinations.include?([ row, col ])
     return "No stone walls left" if @game.stone_walls <= 0
 
     if chosen_terrain_before.nil? && game_player.hand.size > 1
-      hex_terrain = @game.board.terrain_at(row, col)
+      hex_terrain = @game.board_contents.terrain_at(row, col)
       lock_terrain!(hex_terrain, chosen_terrain_before)
       current_phase = @game.turn_phase
     end
@@ -665,7 +665,7 @@ class TurnEngine
     @game.stone_walls -= 1
 
     remaining = tile_obj.valid_destinations(
-      board_contents: @game.board_contents, board: @game.board,
+      board_contents: @game.board_contents,
       player_order: game_player.order, hand: wall_terrain || game_player.hand.first
     )
     if walls_placed >= 2 || remaining.empty?
@@ -688,7 +688,7 @@ class TurnEngine
     tile_obj = Tiles::Tile.from_hash(tile)
     return false if tile_obj.places_wall? && @game.stone_walls <= 0
     return false if tile_obj.builds_settlement? && !@game.current_player.settlements_remaining?
-    ctx = { player_order: @game.current_player.order, board_contents: @game.board_contents, board: @game.board, hand: @game.current_player.hand.first, supply: @game.current_player.supply_hash }
+    ctx = { player_order: @game.current_player.order, board_contents: @game.board_contents, hand: @game.current_player.hand.first, supply: @game.current_player.supply_hash }
     tile_obj.activatable?(**ctx)
   end
 
@@ -829,7 +829,7 @@ class TurnEngine
             (0..19).flat_map do |r|
               (0..19).filter_map do |c|
                 [ r, c ] if @game.board_contents.available_for_building?(r, c) &&
-                  terrains.include?(@game.board.terrain_at(r, c))
+                  terrains.include?(@game.board_contents.terrain_at(r, c))
               end
             end
           else
@@ -862,7 +862,7 @@ class TurnEngine
               end
             else
               tile_obj.valid_destinations(
-                board_contents: @game.board_contents, board: @game.board,
+                board_contents: @game.board_contents,
                 player_order: player.order,
                 supply: player.supply_hash
               )
@@ -870,11 +870,11 @@ class TurnEngine
           elsif tile_obj.places_wall?
             if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
               player.hand.flat_map { |t|
-                tile_obj.valid_destinations(board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: t)
+                tile_obj.valid_destinations(board_contents: @game.board_contents, player_order: player.order, hand: t)
               }.uniq
             else
               tile_obj.valid_destinations(
-                board_contents: @game.board_contents, board: @game.board,
+                board_contents: @game.board_contents,
                 player_order: player.order, hand: effective_terrain(player) || player.hand.first
               )
             end
@@ -885,19 +885,19 @@ class TurnEngine
               if tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
                 tile_obj.valid_destinations(
                   from_row: from.row, from_col: from.col,
-                  board_contents: @game.board_contents, board: @game.board,
+                  board_contents: @game.board_contents,
                   player_order: player.order, budget: current_phase.budget.to_i
                 )
               else
                 extra_kwargs = {}
                 if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
                   player.hand.flat_map { |t|
-                    tile_obj.valid_destinations(from_row: from.row, from_col: from.col, board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: t, **extra_kwargs)
+                    tile_obj.valid_destinations(from_row: from.row, from_col: from.col, board_contents: @game.board_contents, player_order: player.order, hand: t, **extra_kwargs)
                   }.uniq
                 else
                   tile_obj.valid_destinations(
                     from_row: from.row, from_col: from.col,
-                    board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: hand_arg,
+                    board_contents: @game.board_contents, player_order: player.order, hand: hand_arg,
                     **extra_kwargs
                   )
                 end
@@ -911,18 +911,18 @@ class TurnEngine
               end
               if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
                 player.hand.flat_map { |t|
-                  tile_obj.selectable_settlements(player_order: player.order, board_contents: @game.board_contents, board: @game.board, hand: t, **extra_kwargs)
+                  tile_obj.selectable_settlements(player_order: player.order, board_contents: @game.board_contents, hand: t, **extra_kwargs)
                 }.uniq
               else
                 tile_obj.selectable_settlements(
-                  player_order: player.order, board_contents: @game.board_contents, board: @game.board, hand: hand_arg,
+                  player_order: player.order, board_contents: @game.board_contents, hand: hand_arg,
                   **extra_kwargs
                 )
               end
             end
           elsif tile_obj.places_city_hall?
             tile_obj.valid_destinations(
-              board_contents: @game.board_contents, board: @game.board, player_order: player.order, supply: player.supply_hash
+              board_contents: @game.board_contents, player_order: player.order, supply: player.supply_hash
             )
           else
             if tile_obj.builds_settlement? && current_phase.respond_to?(:outpost_active?) && current_phase.outpost_active?
@@ -930,24 +930,24 @@ class TurnEngine
               (0..19).flat_map do |r|
                 (0..19).filter_map do |c|
                   [ r, c ] if @game.board_contents.available_for_building?(r, c) &&
-                    terrains.include?(@game.board.terrain_at(r, c))
+                    terrains.include?(@game.board_contents.terrain_at(r, c))
                 end
               end
             elsif tile_obj.fort_tile?
               hand = current_phase.respond_to?(:fort_terrain) ? current_phase.fort_terrain : nil
               tile_obj.valid_destinations(
-                board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: hand
+                board_contents: @game.board_contents, player_order: player.order, hand: hand
               )
             elsif tile_obj.uses_played_terrain? && effective_terrain(player).nil?
               player.hand.flat_map { |t|
                 tile_obj.valid_destinations(
-                  board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: t
+                  board_contents: @game.board_contents, player_order: player.order, hand: t
                 )
               }.uniq
             else
               hand = effective_terrain(player) || player.hand.first
               tile_obj.valid_destinations(
-                board_contents: @game.board_contents, board: @game.board, player_order: player.order, hand: hand
+                board_contents: @game.board_contents, player_order: player.order, hand: hand
               )
             end
           end
@@ -964,7 +964,7 @@ class TurnEngine
     player = @game.current_player
     tile_obj = Tiles::CityHallTile.new(0)
     centers = tile_obj.valid_destinations(
-      board_contents: @game.board_contents, board: @game.board,
+      board_contents: @game.board_contents,
       player_order: player.order, supply: player.supply_hash
     )
     centers.to_h do |r, c|
@@ -1234,7 +1234,7 @@ class TurnEngine
   def check_shepherds_goal(game_player, row, col, terrain)
     return unless Array(@game.goals).include?("shepherds")
     no_adjacent_empty = @game.board_contents.neighbors(row, col).none? do |nr, nc|
-      @game.board_contents.empty?(nr, nc) && @game.board.terrain_at(nr, nc) == terrain
+      @game.board_contents.empty?(nr, nc) && @game.board_contents.terrain_at(nr, nc) == terrain
     end
     return unless no_adjacent_empty
     score_goal(game_player, "shepherds", 2,
@@ -1361,7 +1361,7 @@ class TurnEngine
     @game.turn_phase.budget.to_i > 0 &&
       tile_obj.valid_destinations(
         from_row: from_coord.row, from_col: from_coord.col,
-        board_contents: @game.board_contents, board: @game.board,
+        board_contents: @game.board_contents,
         player_order: @game.current_player.order
       ).include?([ row, col ])
   end

--- a/test/models/board_state_test.rb
+++ b/test/models/board_state_test.rb
@@ -267,4 +267,26 @@ class BoardStateTest < ActiveSupport::TestCase
     state.place_ship(3, 4, 0)
     assert_includes state.settlements_for(0), [ 3, 4 ]
   end
+
+  test "terrain_at delegates to the attached terrain source" do
+    source = Struct.new(:m) do
+      def terrain_at(row, col) = m.fetch([ row, col ], "G")
+    end.new({ [ 1, 2 ] => "W" })
+    state = BoardState.new
+    state.terrain_source = source
+
+    assert_equal "W", state.terrain_at(1, 2)
+    assert_equal "G", state.terrain_at(0, 0)
+  end
+
+  test "terrain_at raises when no terrain source is attached" do
+    assert_raises(RuntimeError) { BoardState.new.terrain_at(0, 0) }
+  end
+
+  test "dup carries the terrain source" do
+    source = Struct.new(:x) { def terrain_at(_r, _c) = "T" }.new(nil)
+    state = BoardState.new
+    state.terrain_source = source
+    assert_equal "T", state.dup.terrain_at(5, 5)
+  end
 end

--- a/test/models/tiles/barn_tile_test.rb
+++ b/test/models/tiles/barn_tile_test.rb
@@ -15,7 +15,7 @@ class Tiles::BarnTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    @ctx = { board_contents: game.board_contents, board: game.board }
+    @ctx = { board_contents: with_terrain(game.board_contents, game.board) }
   end
 
   test "selectable_settlements returns settlements when valid destinations exist" do

--- a/test/models/tiles/barracks_tile_test.rb
+++ b/test/models/tiles/barracks_tile_test.rb
@@ -30,13 +30,13 @@ class Tiles::BarracksTileTest < ActiveSupport::TestCase
   # valid_destinations: placement candidates
   test "valid_destinations returns empty array when warrior supply is 0 and no warriors on board" do
     state = BoardState.new
-    destinations = tile.valid_destinations(board_contents: state, board: grass_board, player_order: 0, supply: { "warrior" => 0 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, grass_board), player_order: 0, supply: { "warrior" => 0 })
     assert_equal [], destinations
   end
 
   test "valid_destinations includes all buildable hexes when warrior in supply and no own settlements" do
     state = BoardState.new
-    destinations = tile.valid_destinations(board_contents: state, board: grass_board, player_order: 0, supply: { "warrior" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, grass_board), player_order: 0, supply: { "warrior" => 1 })
     assert_includes destinations, [ 0, 0 ]
     assert_includes destinations, [ 5, 5 ]
   end
@@ -44,14 +44,14 @@ class Tiles::BarracksTileTest < ActiveSupport::TestCase
   test "valid_destinations excludes occupied hexes when placing" do
     state = BoardState.new
     state.place_settlement(5, 5, 1)
-    destinations = tile.valid_destinations(board_contents: state, board: grass_board, player_order: 0, supply: { "warrior" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, grass_board), player_order: 0, supply: { "warrior" => 1 })
     assert_not_includes destinations, [ 5, 5 ]
   end
 
   test "valid_destinations excludes warrior-blocked hexes when placing" do
     state = BoardState.new
     state.place_warrior(10, 10, 1)
-    destinations = tile.valid_destinations(board_contents: state, board: grass_board, player_order: 0, supply: { "warrior" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, grass_board), player_order: 0, supply: { "warrior" => 1 })
     # [10,10] even row; neighbors are [10,9],[10,11],[9,9],[9,10],[11,9],[11,10]
     assert_not_includes destinations, [ 10, 9 ]
     assert_not_includes destinations, [ 9, 10 ]
@@ -61,7 +61,7 @@ class Tiles::BarracksTileTest < ActiveSupport::TestCase
     state = BoardState.new
     state.place_settlement(5, 5, 0)
     # [5,5] is odd row; neighbors are [[5,4],[5,6],[4,5],[4,6],[6,5],[6,6]]
-    destinations = tile.valid_destinations(board_contents: state, board: grass_board, player_order: 0, supply: { "warrior" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, grass_board), player_order: 0, supply: { "warrior" => 1 })
     expected_neighbors = state.neighbors(5, 5).select { |r, c| state.empty?(r, c) }
     assert_equal expected_neighbors.sort, destinations.select { |d| expected_neighbors.include?(d) }.sort
     # Should not include non-adjacent hexes when adjacent ones exist
@@ -76,7 +76,7 @@ class Tiles::BarracksTileTest < ActiveSupport::TestCase
     state.place_settlement(1, 0, 1)
     # [0,0] even row neighbors: [0,-1],[0,1],[-1,-1],[-1,0],[1,-1],[1,0]
     # in-bounds: [0,1] and [1,0] — both occupied
-    destinations = tile.valid_destinations(board_contents: state, board: grass_board, player_order: 0, supply: { "warrior" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, grass_board), player_order: 0, supply: { "warrior" => 1 })
     assert_includes destinations, [ 5, 5 ]
   end
 
@@ -84,31 +84,31 @@ class Tiles::BarracksTileTest < ActiveSupport::TestCase
   test "valid_destinations includes own warrior hexes for removal" do
     state = BoardState.new
     state.place_warrior(3, 4, 0)
-    destinations = tile.valid_destinations(board_contents: state, board: grass_board, player_order: 0, supply: { "warrior" => 0 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, grass_board), player_order: 0, supply: { "warrior" => 0 })
     assert_includes destinations, [ 3, 4 ]
   end
 
   test "valid_destinations does not include opponent warriors" do
     state = BoardState.new
     state.place_warrior(3, 4, 1)
-    destinations = tile.valid_destinations(board_contents: state, board: grass_board, player_order: 0, supply: { "warrior" => 0 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, grass_board), player_order: 0, supply: { "warrior" => 0 })
     assert_not_includes destinations, [ 3, 4 ]
   end
 
   # activatable?
   test "activatable? is true when warrior in supply" do
     state = BoardState.new
-    assert tile.activatable?(player_order: 0, board_contents: state, board: grass_board, supply: { "warrior" => 1 })
+    assert tile.activatable?(player_order: 0, board_contents: with_terrain(state, grass_board), supply: { "warrior" => 1 })
   end
 
   test "activatable? is true when warrior on board" do
     state = BoardState.new
     state.place_warrior(5, 5, 0)
-    assert tile.activatable?(player_order: 0, board_contents: state, board: grass_board, supply: { "warrior" => 0 })
+    assert tile.activatable?(player_order: 0, board_contents: with_terrain(state, grass_board), supply: { "warrior" => 0 })
   end
 
   test "activatable? is false when no warriors in supply or on board" do
     state = BoardState.new
-    assert_not tile.activatable?(player_order: 0, board_contents: state, board: grass_board, supply: { "warrior" => 0 })
+    assert_not tile.activatable?(player_order: 0, board_contents: with_terrain(state, grass_board), supply: { "warrior" => 0 })
   end
 end

--- a/test/models/tiles/caravan_tile_test.rb
+++ b/test/models/tiles/caravan_tile_test.rb
@@ -22,7 +22,7 @@ class Tiles::CaravanTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    @ctx = { board_contents: game.board_contents, board: game.board }
+    @ctx = { board_contents: with_terrain(game.board_contents, game.board) }
   end
 
   test "valid_destinations slides east until blocked" do
@@ -99,7 +99,7 @@ class Tiles::CaravanTileTest < ActiveSupport::TestCase
     state.place_settlement(10, 10, 0)
     state.place_city_hall_hex(10, 14, 0)
     tile = Tiles::CaravanTile.new(0)
-    result = tile.selectable_settlements(player_order: 0, board_contents: state, board: all_grass)
+    result = tile.selectable_settlements(player_order: 0, board_contents: with_terrain(state, all_grass))
     assert_includes result, [ 10, 10 ]
     assert_not_includes result, [ 10, 14 ]
   end

--- a/test/models/tiles/city_hall_tile_test.rb
+++ b/test/models/tiles/city_hall_tile_test.rb
@@ -34,26 +34,26 @@ class Tiles::CityHallTileTest < ActiveSupport::TestCase
   test "activatable? returns false when city_hall supply is 0" do
     state = BoardState.new
     state.place_settlement(10, 8, 0)
-    assert_not tile.activatable?(player_order: 0, board_contents: state, board: all_grass_board, supply: { "city_hall" => 0 })
+    assert_not tile.activatable?(player_order: 0, board_contents: with_terrain(state, all_grass_board), supply: { "city_hall" => 0 })
   end
 
   test "activatable? returns false when no valid center exists" do
     state = BoardState.new
     # No settlements adjacent to any cluster
-    assert_not tile.activatable?(player_order: 0, board_contents: state, board: all_grass_board, supply: { "city_hall" => 1 })
+    assert_not tile.activatable?(player_order: 0, board_contents: with_terrain(state, all_grass_board), supply: { "city_hall" => 1 })
   end
 
   test "activatable? returns true when supply available and valid center exists" do
     state = BoardState.new
     # settlement at [10,8] is adjacent to cluster centered at [10,10] via outer hex [10,9]
     state.place_settlement(10, 8, 0)
-    assert tile.activatable?(player_order: 0, board_contents: state, board: all_grass_board, supply: { "city_hall" => 1 })
+    assert tile.activatable?(player_order: 0, board_contents: with_terrain(state, all_grass_board), supply: { "city_hall" => 1 })
   end
 
   test "valid_destinations returns valid center hexes" do
     state = BoardState.new
     state.place_settlement(10, 8, 0)
-    result = tile.valid_destinations(board_contents: state, board: all_grass_board, player_order: 0, supply: { "city_hall" => 1 })
+    result = tile.valid_destinations(board_contents: with_terrain(state, all_grass_board), player_order: 0, supply: { "city_hall" => 1 })
     assert_includes result, [ 10, 10 ]
   end
 
@@ -61,7 +61,7 @@ class Tiles::CityHallTileTest < ActiveSupport::TestCase
     state = BoardState.new
     state.place_settlement(10, 8, 0)
     state.place_settlement(10, 9, 1)  # occupies one cluster hex
-    result = tile.valid_destinations(board_contents: state, board: all_grass_board, player_order: 0, supply: { "city_hall" => 1 })
+    result = tile.valid_destinations(board_contents: with_terrain(state, all_grass_board), player_order: 0, supply: { "city_hall" => 1 })
     assert_not_includes result, [ 10, 10 ]
   end
 
@@ -71,14 +71,14 @@ class Tiles::CityHallTileTest < ActiveSupport::TestCase
     terrain[[ 10, 9 ]] = "M"  # one cluster hex is mountain
     state = BoardState.new
     state.place_settlement(10, 8, 0)
-    result = tile.valid_destinations(board_contents: state, board: BoardStub.new(terrain), player_order: 0, supply: { "city_hall" => 1 })
+    result = tile.valid_destinations(board_contents: with_terrain(state, BoardStub.new(terrain)), player_order: 0, supply: { "city_hall" => 1 })
     assert_not_includes result, [ 10, 10 ]
   end
 
   test "valid_destinations excludes centers not adjacent to any player settlement" do
     state = BoardState.new
     # No settlements anywhere — cluster at [10,10] has no adjacent player settlement
-    result = tile.valid_destinations(board_contents: state, board: all_grass_board, player_order: 0, supply: { "city_hall" => 1 })
+    result = tile.valid_destinations(board_contents: with_terrain(state, all_grass_board), player_order: 0, supply: { "city_hall" => 1 })
     assert_not_includes result, [ 10, 10 ]
   end
 
@@ -86,7 +86,7 @@ class Tiles::CityHallTileTest < ActiveSupport::TestCase
     state = BoardState.new
     state.place_settlement(10, 8, 0)
     state.place_city_hall_hex(10, 9, 1)  # opponent's city hall hex in the cluster
-    result = tile.valid_destinations(board_contents: state, board: all_grass_board, player_order: 0, supply: { "city_hall" => 1 })
+    result = tile.valid_destinations(board_contents: with_terrain(state, all_grass_board), player_order: 0, supply: { "city_hall" => 1 })
     assert_not_includes result, [ 10, 10 ]
   end
 
@@ -94,14 +94,14 @@ class Tiles::CityHallTileTest < ActiveSupport::TestCase
     state = BoardState.new
     # [10,8] is adjacent to [10,9] which is an outer cluster hex of center [10,10]
     state.place_settlement(10, 8, 0)
-    result = tile.valid_destinations(board_contents: state, board: all_grass_board, player_order: 0, supply: { "city_hall" => 1 })
+    result = tile.valid_destinations(board_contents: with_terrain(state, all_grass_board), player_order: 0, supply: { "city_hall" => 1 })
     assert_includes result, [ 10, 10 ]
   end
 
   test "valid_destinations: opponent settlement does not satisfy adjacency" do
     state = BoardState.new
     state.place_settlement(10, 8, 1)  # opponent player, order 1
-    result = tile.valid_destinations(board_contents: state, board: all_grass_board, player_order: 0, supply: { "city_hall" => 1 })
+    result = tile.valid_destinations(board_contents: with_terrain(state, all_grass_board), player_order: 0, supply: { "city_hall" => 1 })
     assert_not_includes result, [ 10, 10 ]
   end
 

--- a/test/models/tiles/crossroads_tile_test.rb
+++ b/test/models/tiles/crossroads_tile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class CrossroadsTileTest < ActiveSupport::TestCase
   test "CrossroadsTile is not activatable" do
-    assert_not Tiles::CrossroadsTile.new(1).activatable?(player_order: 0, board_contents: nil, board: nil)
+    assert_not Tiles::CrossroadsTile.new(1).activatable?(player_order: 0, board_contents: with_terrain(nil, nil))
   end
 
   test "CrossroadsTile has crossroads_tile? true" do

--- a/test/models/tiles/farm_tile_test.rb
+++ b/test/models/tiles/farm_tile_test.rb
@@ -15,19 +15,19 @@ class Tiles::FarmTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    { board_contents: game.board_contents, board: game.board, chris: chris }
+    { board_contents: with_terrain(game.board_contents, game.board), chris: chris }
   end
 
   test "valid_destinations returns adjacent Grass hexes when available" do
     ctx = setup_board
     tile = Tiles::FarmTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_includes result, [ 14, 1 ], "Grass hex adjacent to settlement must be included"
     assert_includes result, [ 15, 0 ], "Grass hex adjacent to settlement must be included"
     result.each do |r, c|
-      assert_equal "G", ctx[:board].terrain_at(r, c), "every destination must be Grass"
+      assert_equal "G", ctx[:board_contents].terrain_at(r, c), "every destination must be Grass"
     end
   end
 
@@ -35,7 +35,7 @@ class Tiles::FarmTileTest < ActiveSupport::TestCase
     ctx = setup_board { |s| s.place_settlement(14, 1, 1) }
     tile = Tiles::FarmTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_not_includes result, [ 14, 1 ], "occupied Grass hex must be excluded"
   end
@@ -50,7 +50,7 @@ class Tiles::FarmTileTest < ActiveSupport::TestCase
     game.instantiate
     tile = Tiles::FarmTile.new(0)
 
-    result = tile.valid_destinations(board_contents: game.board_contents, board: game.board, player_order: chris.order)
+    result = tile.valid_destinations(board_contents: with_terrain(game.board_contents, game.board), player_order: chris.order)
 
     assert_includes result, [ 14, 1 ], "fallback must include non-adjacent Grass hex"
     assert_includes result, [ 16, 0 ], "fallback must include distant Grass hex"
@@ -84,7 +84,7 @@ class Tiles::FarmTileTest < ActiveSupport::TestCase
     game.instantiate
     tile = Tiles::FarmTile.new(0)
 
-    result = tile.valid_destinations(board_contents: game.board_contents, board: game.board, player_order: chris.order)
+    result = tile.valid_destinations(board_contents: with_terrain(game.board_contents, game.board), player_order: chris.order)
 
     assert_empty result
   end
@@ -106,7 +106,7 @@ class Tiles::FarmTileTest < ActiveSupport::TestCase
   test "activatable? is true when Grass hexes are reachable" do
     ctx = setup_board
     tile = Tiles::FarmTile.new(0)
-    assert tile.activatable?(player_order: ctx[:chris].order, board_contents: ctx[:board_contents], board: ctx[:board])
+    assert tile.activatable?(player_order: ctx[:chris].order, board_contents: with_terrain(ctx[:board_contents], ctx[:board]))
   end
 
   test "activatable? is false when all Grass hexes are occupied" do
@@ -128,7 +128,7 @@ class Tiles::FarmTileTest < ActiveSupport::TestCase
     game.save
     game.instantiate
     tile = Tiles::FarmTile.new(0)
-    assert_not tile.activatable?(player_order: chris.order, board_contents: game.board_contents, board: game.board)
+    assert_not tile.activatable?(player_order: chris.order, board_contents: with_terrain(game.board_contents, game.board))
   end
 
   test "builds_settlement? returns true" do

--- a/test/models/tiles/foresters_lodge_tile_test.rb
+++ b/test/models/tiles/foresters_lodge_tile_test.rb
@@ -15,18 +15,18 @@ class Tiles::ForestersLodgeTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    { board_contents: game.board_contents, board: game.board, chris: chris }
+    { board_contents: with_terrain(game.board_contents, game.board), chris: chris }
   end
 
   test "valid_destinations returns adjacent Timberland hexes when available" do
     ctx = setup_board
     tile = Tiles::ForestersLodgeTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_includes result, [ 2, 5 ], "Timberland hex adjacent to settlement must be included"
     result.each do |r, c|
-      assert_equal "T", ctx[:board].terrain_at(r, c), "every destination must be Timberland"
+      assert_equal "T", ctx[:board_contents].terrain_at(r, c), "every destination must be Timberland"
     end
   end
 
@@ -34,7 +34,7 @@ class Tiles::ForestersLodgeTileTest < ActiveSupport::TestCase
     ctx = setup_board { |s| s.place_settlement(2, 5, 1) }
     tile = Tiles::ForestersLodgeTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_not_includes result, [ 2, 5 ], "occupied Timberland hex must be excluded"
   end
@@ -49,7 +49,7 @@ class Tiles::ForestersLodgeTileTest < ActiveSupport::TestCase
     game.instantiate
     tile = Tiles::ForestersLodgeTile.new(0)
 
-    result = tile.valid_destinations(board_contents: game.board_contents, board: game.board, player_order: chris.order)
+    result = tile.valid_destinations(board_contents: with_terrain(game.board_contents, game.board), player_order: chris.order)
 
     assert_includes result, [ 0, 5 ], "fallback must include non-adjacent Timberland hex"
     assert_includes result, [ 6, 1 ], "fallback must include distant Timberland hex"
@@ -85,7 +85,7 @@ class Tiles::ForestersLodgeTileTest < ActiveSupport::TestCase
     game.instantiate
     tile = Tiles::ForestersLodgeTile.new(0)
 
-    result = tile.valid_destinations(board_contents: game.board_contents, board: game.board, player_order: chris.order)
+    result = tile.valid_destinations(board_contents: with_terrain(game.board_contents, game.board), player_order: chris.order)
 
     assert_empty result
   end
@@ -107,7 +107,7 @@ class Tiles::ForestersLodgeTileTest < ActiveSupport::TestCase
   test "activatable? is true when Timberland hexes are reachable" do
     ctx = setup_board
     tile = Tiles::ForestersLodgeTile.new(0)
-    assert tile.activatable?(player_order: ctx[:chris].order, board_contents: ctx[:board_contents], board: ctx[:board])
+    assert tile.activatable?(player_order: ctx[:chris].order, board_contents: with_terrain(ctx[:board_contents], ctx[:board]))
   end
 
   test "activatable? is false when all Timberland hexes are occupied" do
@@ -131,7 +131,7 @@ class Tiles::ForestersLodgeTileTest < ActiveSupport::TestCase
     game.save
     game.instantiate
     tile = Tiles::ForestersLodgeTile.new(0)
-    assert_not tile.activatable?(player_order: chris.order, board_contents: game.board_contents, board: game.board)
+    assert_not tile.activatable?(player_order: chris.order, board_contents: with_terrain(game.board_contents, game.board))
   end
 
   test "builds_settlement? returns true" do

--- a/test/models/tiles/fort_tile_test.rb
+++ b/test/models/tiles/fort_tile_test.rb
@@ -14,13 +14,13 @@ class Tiles::FortTileTest < ActiveSupport::TestCase
   test "activatable? returns true regardless of board state" do
     state = BoardState.new
     board = Struct.new(:terrain).new({})
-    assert tile.activatable?(player_order: 0, board_contents: state, board: board)
+    assert tile.activatable?(player_order: 0, board_contents: with_terrain(state, board))
   end
 
   test "activatable? returns true even with no valid destinations for hand terrain" do
     # Fort doesn't check hand — it draws a new card
     state = BoardState.new
     board = Struct.new(:terrain).new({})
-    assert tile.activatable?(player_order: 0, board_contents: state, board: board, hand: "G")
+    assert tile.activatable?(player_order: 0, board_contents: with_terrain(state, board), hand: "G")
   end
 end

--- a/test/models/tiles/garden_tile_test.rb
+++ b/test/models/tiles/garden_tile_test.rb
@@ -18,7 +18,7 @@ class Tiles::GardenTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    @ctx = { board_contents: game.board_contents, board: game.board }
+    @ctx = { board_contents: with_terrain(game.board_contents, game.board) }
   end
 
   test "builds_settlement? returns true" do
@@ -33,7 +33,7 @@ class Tiles::GardenTileTest < ActiveSupport::TestCase
     result = tile.valid_destinations(**@ctx, player_order: @chris.order)
 
     assert result.any?
-    result.each { |r, c| assert_equal "F", @ctx[:board].terrain_at(r, c) }
+    result.each { |r, c| assert_equal "F", @ctx[:board_contents].terrain_at(r, c) }
   end
 
   test "valid_destinations includes only empty flower hexes" do
@@ -43,7 +43,7 @@ class Tiles::GardenTileTest < ActiveSupport::TestCase
     result = tile.valid_destinations(**@ctx, player_order: @chris.order)
 
     assert_not_includes result, [ 3, 6 ]
-    result.each { |r, c| assert_equal "F", @ctx[:board].terrain_at(r, c) }
+    result.each { |r, c| assert_equal "F", @ctx[:board_contents].terrain_at(r, c) }
   end
 
   test "valid_destinations falls back to all flower hexes when none adjacent" do
@@ -54,7 +54,7 @@ class Tiles::GardenTileTest < ActiveSupport::TestCase
     result = tile.valid_destinations(**@ctx, player_order: @chris.order)
 
     assert result.any?
-    result.each { |r, c| assert_equal "F", @ctx[:board].terrain_at(r, c) }
+    result.each { |r, c| assert_equal "F", @ctx[:board_contents].terrain_at(r, c) }
   end
 
   test "from_hash returns a GardenTile" do

--- a/test/models/tiles/harbor_tile_test.rb
+++ b/test/models/tiles/harbor_tile_test.rb
@@ -19,7 +19,7 @@ class Tiles::HarborTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    @ctx = { board_contents: game.board_contents, board: game.board }
+    @ctx = { board_contents: with_terrain(game.board_contents, game.board) }
   end
 
   test "moves_settlement? returns true" do
@@ -46,13 +46,13 @@ class Tiles::HarborTileTest < ActiveSupport::TestCase
     game.board_contents = BoardState.new.tap { |s| s.place_settlement(2, 0, chris.order) }
     game.save
     game.instantiate
-    ctx = { board_contents: game.board_contents, board: game.board }
+    ctx = { board_contents: with_terrain(game.board_contents, game.board) }
     tile = Tiles::HarborTile.new(0)
 
     result = tile.valid_destinations(from_row: 2, from_col: 0, **ctx, player_order: chris.order)
 
     assert result.any?
-    result.each { |r, c| assert_equal "W", ctx[:board].terrain_at(r, c) }
+    result.each { |r, c| assert_equal "W", ctx[:board_contents].terrain_at(r, c) }
   end
 
   test "selectable_settlements returns all settlements when empty water exists" do

--- a/test/models/tiles/lighthouse_tile_test.rb
+++ b/test/models/tiles/lighthouse_tile_test.rb
@@ -27,30 +27,30 @@ class Tiles::LighthouseTileTest < ActiveSupport::TestCase
 
   test "activatable? is true when ship in supply" do
     state = BoardState.new
-    assert tile.activatable?(player_order: 0, board_contents: state, board: all_water_board, supply: { "ship" => 1 })
+    assert tile.activatable?(player_order: 0, board_contents: with_terrain(state, all_water_board), supply: { "ship" => 1 })
   end
 
   test "activatable? is true when ship already on board" do
     state = BoardState.new
     state.place_ship(5, 5, 0)
-    assert tile.activatable?(player_order: 0, board_contents: state, board: all_water_board, supply: { "ship" => 0 })
+    assert tile.activatable?(player_order: 0, board_contents: with_terrain(state, all_water_board), supply: { "ship" => 0 })
   end
 
   test "activatable? is false when no supply and no ship on board" do
     state = BoardState.new
-    assert_not tile.activatable?(player_order: 0, board_contents: state, board: all_water_board, supply: { "ship" => 0 })
+    assert_not tile.activatable?(player_order: 0, board_contents: with_terrain(state, all_water_board), supply: { "ship" => 0 })
   end
 
   test "valid_destinations (placement) returns empty when ship supply 0 and no ship on board" do
     state = BoardState.new
-    assert_equal [], tile.valid_destinations(board_contents: state, board: all_water_board, player_order: 0, supply: { "ship" => 0 })
+    assert_equal [], tile.valid_destinations(board_contents: with_terrain(state, all_water_board), player_order: 0, supply: { "ship" => 0 })
   end
 
   test "valid_destinations (placement) returns adjacent water hexes when own settlements present" do
     state = BoardState.new
     state.place_settlement(5, 5, 0)
     neighbors = state.neighbors(5, 5)
-    destinations = tile.valid_destinations(board_contents: state, board: all_water_board, player_order: 0, supply: { "ship" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, all_water_board), player_order: 0, supply: { "ship" => 1 })
     neighbors.each { |r, c| assert_includes destinations, [ r, c ] }
     assert_not_includes destinations, [ 0, 0 ]
   end
@@ -62,7 +62,7 @@ class Tiles::LighthouseTileTest < ActiveSupport::TestCase
     land_neighbors.each { |(r, c)| terrain[[ r, c ]] = "G" }
     state = BoardState.new
     state.place_settlement(5, 5, 0)
-    destinations = tile.valid_destinations(board_contents: state, board: BoardStub.new(terrain), player_order: 0, supply: { "ship" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, BoardStub.new(terrain)), player_order: 0, supply: { "ship" => 1 })
     assert_includes destinations, [ 0, 0 ]
   end
 
@@ -70,14 +70,14 @@ class Tiles::LighthouseTileTest < ActiveSupport::TestCase
     state = BoardState.new
     state.place_settlement(5, 5, 0)
     state.place_settlement(5, 4, 1)
-    destinations = tile.valid_destinations(board_contents: state, board: all_water_board, player_order: 0, supply: { "ship" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, all_water_board), player_order: 0, supply: { "ship" => 1 })
     assert_not_includes destinations, [ 5, 4 ]
   end
 
   test "valid_destinations includes own ship hex when ship is on board" do
     state = BoardState.new
     state.place_ship(3, 3, 0)
-    destinations = tile.valid_destinations(board_contents: state, board: all_water_board, player_order: 0, supply: { "ship" => 0 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, all_water_board), player_order: 0, supply: { "ship" => 0 })
     assert_includes destinations, [ 3, 3 ]
   end
 
@@ -91,7 +91,7 @@ class Tiles::LighthouseTileTest < ActiveSupport::TestCase
     all_land[[ 1, 1 ]] = "W"
     destinations = tile.valid_destinations(
       from_row: 1, from_col: 1,
-      board_contents: state, board: BoardStub.new(all_land), player_order: 0
+      board_contents: with_terrain(state, BoardStub.new(all_land)), player_order: 0
     )
     assert_equal [], destinations
   end
@@ -101,7 +101,7 @@ class Tiles::LighthouseTileTest < ActiveSupport::TestCase
     state.place_ship(10, 10, 0)
     dests = tile.valid_destinations(
       from_row: 10, from_col: 10,
-      board_contents: state, board: all_water_board, player_order: 0
+      board_contents: with_terrain(state, all_water_board), player_order: 0
     )
     assert_includes dests, [ 10, 11 ]
     assert_not_includes dests, [ 10, 12 ]
@@ -118,7 +118,7 @@ class Tiles::LighthouseTileTest < ActiveSupport::TestCase
     state.place_ship(10, 10, 0)
     dests = tile.valid_destinations(
       from_row: 10, from_col: 10,
-      board_contents: state, board: BoardStub.new(terrain), player_order: 0
+      board_contents: with_terrain(state, BoardStub.new(terrain)), player_order: 0
     )
     assert_not_includes dests, [ 10, 15 ]
   end
@@ -129,7 +129,7 @@ class Tiles::LighthouseTileTest < ActiveSupport::TestCase
     state.place_settlement(10, 11, 1)
     dests = tile.valid_destinations(
       from_row: 10, from_col: 10,
-      board_contents: state, board: all_water_board, player_order: 0
+      board_contents: with_terrain(state, all_water_board), player_order: 0
     )
     assert_not_includes dests, [ 10, 11 ]
   end

--- a/test/models/tiles/monastery_tile_test.rb
+++ b/test/models/tiles/monastery_tile_test.rb
@@ -15,18 +15,18 @@ class Tiles::MonasteryTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    { board_contents: game.board_contents, board: game.board, chris: chris }
+    { board_contents: with_terrain(game.board_contents, game.board), chris: chris }
   end
 
   test "valid_destinations returns adjacent Canyon hexes when available" do
     ctx = setup_board
     tile = Tiles::MonasteryTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_includes result, [ 5, 6 ], "Canyon hex adjacent to settlement must be included"
     result.each do |r, c|
-      assert_equal "C", ctx[:board].terrain_at(r, c), "every destination must be Canyon"
+      assert_equal "C", ctx[:board_contents].terrain_at(r, c), "every destination must be Canyon"
     end
   end
 
@@ -34,7 +34,7 @@ class Tiles::MonasteryTileTest < ActiveSupport::TestCase
     ctx = setup_board { |s| s.place_settlement(5, 6, 1) }
     tile = Tiles::MonasteryTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_not_includes result, [ 5, 6 ], "occupied Canyon hex must be excluded"
   end
@@ -49,7 +49,7 @@ class Tiles::MonasteryTileTest < ActiveSupport::TestCase
     game.instantiate
     tile = Tiles::MonasteryTile.new(0)
 
-    result = tile.valid_destinations(board_contents: game.board_contents, board: game.board, player_order: chris.order)
+    result = tile.valid_destinations(board_contents: with_terrain(game.board_contents, game.board), player_order: chris.order)
 
     assert_includes result, [ 0, 2 ], "fallback must include non-adjacent Canyon hex"
     assert_includes result, [ 5, 6 ], "fallback must include distant Canyon hex"
@@ -85,7 +85,7 @@ class Tiles::MonasteryTileTest < ActiveSupport::TestCase
     game.instantiate
     tile = Tiles::MonasteryTile.new(0)
 
-    result = tile.valid_destinations(board_contents: game.board_contents, board: game.board, player_order: chris.order)
+    result = tile.valid_destinations(board_contents: with_terrain(game.board_contents, game.board), player_order: chris.order)
 
     assert_empty result
   end
@@ -107,7 +107,7 @@ class Tiles::MonasteryTileTest < ActiveSupport::TestCase
   test "activatable? is true when Canyon hexes are reachable" do
     ctx = setup_board
     tile = Tiles::MonasteryTile.new(0)
-    assert tile.activatable?(player_order: ctx[:chris].order, board_contents: ctx[:board_contents], board: ctx[:board])
+    assert tile.activatable?(player_order: ctx[:chris].order, board_contents: with_terrain(ctx[:board_contents], ctx[:board]))
   end
 
   test "activatable? is false when all Canyon hexes are occupied" do
@@ -131,7 +131,7 @@ class Tiles::MonasteryTileTest < ActiveSupport::TestCase
     game.save
     game.instantiate
     tile = Tiles::MonasteryTile.new(0)
-    assert_not tile.activatable?(player_order: chris.order, board_contents: game.board_contents, board: game.board)
+    assert_not tile.activatable?(player_order: chris.order, board_contents: with_terrain(game.board_contents, game.board))
   end
 
   test "builds_settlement? returns true" do

--- a/test/models/tiles/nomad/donation_tile_test.rb
+++ b/test/models/tiles/nomad/donation_tile_test.rb
@@ -23,7 +23,7 @@ class Tiles::Nomad::DonationTileTest < ActiveSupport::TestCase
     @game.board_contents = state
     @game.save
     @game.instantiate
-    { board_contents: @game.board_contents, board: @game.board, chris: @chris }
+    { board_contents: with_terrain(@game.board_contents, @game.board), chris: @chris }
   end
 
   # --- DonationCanyonTile (terrain "C") ---
@@ -34,12 +34,12 @@ class Tiles::Nomad::DonationTileTest < ActiveSupport::TestCase
     ctx = setup_board_with_settlement(0, 8)
     tile = Tiles::Nomad::DonationCanyonTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_includes result, [ 0, 7 ], "adjacent Canyon hex must be included"
     assert_includes result, [ 0, 9 ], "adjacent Canyon hex must be included"
     result.each do |r, c|
-      assert_equal "C", ctx[:board].terrain_at(r, c), "every destination must be Canyon"
+      assert_equal "C", ctx[:board_contents].terrain_at(r, c), "every destination must be Canyon"
     end
   end
 
@@ -49,11 +49,11 @@ class Tiles::Nomad::DonationTileTest < ActiveSupport::TestCase
     ctx = setup_board_with_settlement(2, 0)
     tile = Tiles::Nomad::DonationCanyonTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_not_empty result, "fallback should find Canyon hexes on the board"
     result.each do |r, c|
-      assert_equal "C", ctx[:board].terrain_at(r, c), "every fallback destination must be Canyon"
+      assert_equal "C", ctx[:board_contents].terrain_at(r, c), "every fallback destination must be Canyon"
     end
     # (0,7) is Canyon and not adjacent to (2,0), must appear in fallback
     assert_includes result, [ 0, 7 ]
@@ -67,11 +67,11 @@ class Tiles::Nomad::DonationTileTest < ActiveSupport::TestCase
     ctx = setup_board_with_settlement(0, 2)
     tile = Tiles::Nomad::DonationWaterTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_includes result, [ 0, 3 ], "adjacent Water hex must be included"
     result.each do |r, c|
-      assert_equal "W", ctx[:board].terrain_at(r, c), "every destination must be Water"
+      assert_equal "W", ctx[:board_contents].terrain_at(r, c), "every destination must be Water"
     end
   end
 
@@ -80,11 +80,11 @@ class Tiles::Nomad::DonationTileTest < ActiveSupport::TestCase
     ctx = setup_board_with_settlement(0, 8)
     tile = Tiles::Nomad::DonationWaterTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_not_empty result, "fallback should find Water hexes on the board"
     result.each do |r, c|
-      assert_equal "W", ctx[:board].terrain_at(r, c), "every fallback destination must be Water"
+      assert_equal "W", ctx[:board_contents].terrain_at(r, c), "every fallback destination must be Water"
     end
   end
 
@@ -101,11 +101,11 @@ class Tiles::Nomad::DonationTileTest < ActiveSupport::TestCase
     ctx = setup_board_with_settlement(0, 5)
     tile = Tiles::Nomad::DonationMountainTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_includes result, [ 0, 6 ], "adjacent Mountain hex must be included"
     result.each do |r, c|
-      assert_equal "M", ctx[:board].terrain_at(r, c), "every destination must be Mountain"
+      assert_equal "M", ctx[:board_contents].terrain_at(r, c), "every destination must be Mountain"
     end
   end
 
@@ -114,11 +114,11 @@ class Tiles::Nomad::DonationTileTest < ActiveSupport::TestCase
     ctx = setup_board_with_settlement(0, 8)
     tile = Tiles::Nomad::DonationMountainTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_not_empty result, "fallback should find Mountain hexes on the board"
     result.each do |r, c|
-      assert_equal "M", ctx[:board].terrain_at(r, c), "every fallback destination must be Mountain"
+      assert_equal "M", ctx[:board_contents].terrain_at(r, c), "every fallback destination must be Mountain"
     end
   end
 

--- a/test/models/tiles/nomad/outpost_tile_test.rb
+++ b/test/models/tiles/nomad/outpost_tile_test.rb
@@ -10,7 +10,7 @@ class Tiles::Nomad::OutpostTileTest < ActiveSupport::TestCase
   end
 
   test "activatable? returns false" do
-    refute @tile.activatable?(player_order: 0, board_contents: BoardState.new, board: nil)
+    refute @tile.activatable?(player_order: 0, board_contents: with_terrain(BoardState.new, nil))
   end
 
   test "nomad_tile? returns true" do

--- a/test/models/tiles/nomad/resettlement_tile_test.rb
+++ b/test/models/tiles/nomad/resettlement_tile_test.rb
@@ -21,7 +21,7 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
     @game.board_contents = state
     @game.save
     @game.instantiate
-    { board_contents: @game.board_contents, board: @game.board }
+    { board_contents: with_terrain(@game.board_contents, @game.board) }
   end
 
   # --- moves_settlement? ---
@@ -34,7 +34,7 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
 
   test "returns [] when from_row/from_col is nil" do
     ctx = setup_board { |s| s.place_settlement(0, 0, @chris.order) }
-    result = @tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: @chris.order)
+    result = @tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: @chris.order)
     assert_equal [], result
   end
 
@@ -42,7 +42,7 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
     ctx = setup_board { |s| s.place_settlement(0, 0, @chris.order) }
     result = @tile.valid_destinations(
       from_row: 0, from_col: 0,
-      board_contents: ctx[:board_contents], board: ctx[:board], player_order: @chris.order,
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: @chris.order,
       budget: 0
     )
     assert_equal [], result
@@ -55,15 +55,15 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
     ctx = setup_board { |s| s.place_settlement(0, 0, @chris.order) }
     result = @tile.valid_destinations(
       from_row: 0, from_col: 0,
-      board_contents: ctx[:board_contents], board: ctx[:board], player_order: @chris.order,
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: @chris.order,
       budget: 1
     )
     assert_includes result, [ 0, 1 ]
     assert_includes result, [ 1, 0 ]
     # Water (W) at (0,3) is not buildable; Mountain (M) is not buildable
     result.each do |r, c|
-      assert_includes Tiles::Tile::BUILDABLE_TERRAIN, ctx[:board].terrain_at(r, c),
-        "all destinations must be buildable terrain, but [#{r},#{c}] is #{ctx[:board].terrain_at(r, c)}"
+      assert_includes Tiles::Tile::BUILDABLE_TERRAIN, ctx[:board_contents].terrain_at(r, c),
+        "all destinations must be buildable terrain, but [#{r},#{c}] is #{ctx[:board_contents].terrain_at(r, c)}"
     end
   end
 
@@ -72,7 +72,7 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
     ctx = setup_board { |s| s.place_settlement(0, 0, @chris.order) }
     result = @tile.valid_destinations(
       from_row: 0, from_col: 0,
-      board_contents: ctx[:board_contents], board: ctx[:board], player_order: @chris.order,
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: @chris.order,
       budget: 2
     )
     assert_includes result, [ 0, 1 ], "adjacent hex is a destination"
@@ -85,7 +85,7 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
     ctx = setup_board { |s| s.place_settlement(0, 2, @chris.order) }
     result = @tile.valid_destinations(
       from_row: 0, from_col: 2,
-      board_contents: ctx[:board_contents], board: ctx[:board], player_order: @chris.order,
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: @chris.order,
       budget: 1
     )
     refute_includes result, [ 0, 3 ], "Water terrain should not be a valid destination"
@@ -96,7 +96,7 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
   test "selectable_settlements returns [] when budget is 0" do
     ctx = setup_board { |s| s.place_settlement(0, 0, @chris.order) }
     result = @tile.selectable_settlements(
-      player_order: @chris.order, board_contents: ctx[:board_contents], board: ctx[:board],
+      player_order: @chris.order, board_contents: with_terrain(ctx[:board_contents], ctx[:board]),
       budget: 0
     )
     assert_equal [], result
@@ -106,7 +106,7 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
     # Settlement at (0,0) [G] has buildable neighbors
     ctx = setup_board { |s| s.place_settlement(0, 0, @chris.order) }
     result = @tile.selectable_settlements(
-      player_order: @chris.order, board_contents: ctx[:board_contents], board: ctx[:board],
+      player_order: @chris.order, board_contents: with_terrain(ctx[:board_contents], ctx[:board]),
       budget: 4
     )
     assert_includes result, [ 0, 0 ]
@@ -128,7 +128,7 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
       s.place_settlement(2, 2, @chris.order)
     end
     result = @tile.selectable_settlements(
-      player_order: @chris.order, board_contents: ctx[:board_contents], board: ctx[:board],
+      player_order: @chris.order, board_contents: with_terrain(ctx[:board_contents], ctx[:board]),
       budget: 1
     )
     refute_includes result, [ 1, 1 ], "trapped settlement should not be selectable"
@@ -139,7 +139,7 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
     state = BoardState.new
     state.place_settlement(10, 10, @chris.order)
     state.place_city_hall_hex(10, 14, @chris.order)
-    result = @tile.selectable_settlements(player_order: @chris.order, board_contents: state, board: all_grass)
+    result = @tile.selectable_settlements(player_order: @chris.order, board_contents: with_terrain(state, all_grass))
     assert_includes result, [ 10, 10 ]
     refute_includes result, [ 10, 14 ]
   end
@@ -149,14 +149,14 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
   test "activatable? returns true when there are selectable settlements" do
     ctx = setup_board { |s| s.place_settlement(0, 0, @chris.order) }
     assert @tile.activatable?(
-      player_order: @chris.order, board_contents: ctx[:board_contents], board: ctx[:board]
+      player_order: @chris.order, board_contents: with_terrain(ctx[:board_contents], ctx[:board])
     )
   end
 
   test "activatable? returns false when no settlements present" do
     ctx = setup_board
     refute @tile.activatable?(
-      player_order: @chris.order, board_contents: ctx[:board_contents], board: ctx[:board]
+      player_order: @chris.order, board_contents: with_terrain(ctx[:board_contents], ctx[:board])
     )
   end
 end

--- a/test/models/tiles/nomad/sword_tile_test.rb
+++ b/test/models/tiles/nomad/sword_tile_test.rb
@@ -6,7 +6,7 @@ class Tiles::Nomad::SwordTileTest < ActiveSupport::TestCase
   end
 
   test "activatable? returns true" do
-    assert @tile.activatable?(player_order: 0, board_contents: BoardState.new, board: nil)
+    assert @tile.activatable?(player_order: 0, board_contents: with_terrain(BoardState.new, nil))
   end
 
   test "nomad_tile? returns true" do

--- a/test/models/tiles/oasis_tile_test.rb
+++ b/test/models/tiles/oasis_tile_test.rb
@@ -15,18 +15,18 @@ class Tiles::OasisTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    { board_contents: game.board_contents, board: game.board, chris: chris }
+    { board_contents: with_terrain(game.board_contents, game.board), chris: chris }
   end
 
   test "valid_destinations returns adjacent Desert hexes when available" do
     ctx = setup_board
     tile = Tiles::OasisTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_includes result, [ 0, 1 ], "Desert hex adjacent to settlement must be included"
     result.each do |r, c|
-      assert_equal "D", ctx[:board].terrain_at(r, c), "every destination must be Desert"
+      assert_equal "D", ctx[:board_contents].terrain_at(r, c), "every destination must be Desert"
     end
   end
 
@@ -34,7 +34,7 @@ class Tiles::OasisTileTest < ActiveSupport::TestCase
     ctx = setup_board { |s| s.place_settlement(0, 1, 1) }
     tile = Tiles::OasisTile.new(0)
 
-    result = tile.valid_destinations(board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order)
+    result = tile.valid_destinations(board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order)
 
     assert_not_includes result, [ 0, 1 ], "occupied Desert hex must be excluded"
   end
@@ -49,7 +49,7 @@ class Tiles::OasisTileTest < ActiveSupport::TestCase
     game.instantiate
     tile = Tiles::OasisTile.new(0)
 
-    result = tile.valid_destinations(board_contents: game.board_contents, board: game.board, player_order: chris.order)
+    result = tile.valid_destinations(board_contents: with_terrain(game.board_contents, game.board), player_order: chris.order)
 
     assert_includes result, [ 0, 0 ], "fallback must include non-adjacent Desert hex"
     assert_includes result, [ 5, 8 ], "fallback must include distant Desert hex"
@@ -80,7 +80,7 @@ class Tiles::OasisTileTest < ActiveSupport::TestCase
     game.instantiate
     tile = Tiles::OasisTile.new(0)
 
-    result = tile.valid_destinations(board_contents: game.board_contents, board: game.board, player_order: chris.order)
+    result = tile.valid_destinations(board_contents: with_terrain(game.board_contents, game.board), player_order: chris.order)
 
     assert_empty result
   end
@@ -102,7 +102,7 @@ class Tiles::OasisTileTest < ActiveSupport::TestCase
   test "activatable? is true when desert hexes are reachable" do
     ctx = setup_board
     tile = Tiles::OasisTile.new(0)
-    assert tile.activatable?(player_order: ctx[:chris].order, board_contents: ctx[:board_contents], board: ctx[:board])
+    assert tile.activatable?(player_order: ctx[:chris].order, board_contents: with_terrain(ctx[:board_contents], ctx[:board]))
   end
 
   test "activatable? is false when all desert hexes are occupied" do
@@ -124,7 +124,7 @@ class Tiles::OasisTileTest < ActiveSupport::TestCase
     game.save
     game.instantiate
     tile = Tiles::OasisTile.new(0)
-    assert_not tile.activatable?(player_order: chris.order, board_contents: game.board_contents, board: game.board)
+    assert_not tile.activatable?(player_order: chris.order, board_contents: with_terrain(game.board_contents, game.board))
   end
 
   test "builds_settlement? returns true" do

--- a/test/models/tiles/oracle_tile_test.rb
+++ b/test/models/tiles/oracle_tile_test.rb
@@ -15,7 +15,7 @@ class Tiles::OracleTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    @ctx = { board_contents: game.board_contents, board: game.board }
+    @ctx = { board_contents: with_terrain(game.board_contents, game.board) }
   end
 
   # row 8: W W W D D D D M C C — neighbors of (8,0) are all W/C, no Grass
@@ -26,7 +26,7 @@ class Tiles::OracleTileTest < ActiveSupport::TestCase
     result = tile.valid_destinations(**@ctx, player_order: @chris.order, hand: "G")
 
     assert result.any?
-    result.each { |r, c| assert_equal "G", @ctx[:board].terrain_at(r, c) }
+    result.each { |r, c| assert_equal "G", @ctx[:board_contents].terrain_at(r, c) }
   end
 
   test "valid_destinations uses hand to determine terrain" do
@@ -36,7 +36,7 @@ class Tiles::OracleTileTest < ActiveSupport::TestCase
     result = tile.valid_destinations(**@ctx, player_order: @chris.order, hand: "D")
 
     assert result.any?
-    result.each { |r, c| assert_equal "D", @ctx[:board].terrain_at(r, c) }
+    result.each { |r, c| assert_equal "D", @ctx[:board_contents].terrain_at(r, c) }
   end
 
   test "valid_destinations excludes occupied hexes" do
@@ -55,6 +55,6 @@ class Tiles::OracleTileTest < ActiveSupport::TestCase
     result = tile.valid_destinations(**@ctx, player_order: @chris.order, hand: "G")
 
     assert_includes result, [ 0, 2 ]
-    result.each { |r, c| assert_equal "G", @ctx[:board].terrain_at(r, c) }
+    result.each { |r, c| assert_equal "G", @ctx[:board_contents].terrain_at(r, c) }
   end
 end

--- a/test/models/tiles/paddock_tile_test.rb
+++ b/test/models/tiles/paddock_tile_test.rb
@@ -15,14 +15,14 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    { board_contents: game.board_contents, board: game.board, chris: chris }
+    { board_contents: with_terrain(game.board_contents, game.board), chris: chris }
   end
 
   test "valid_destinations returns buildable empty 2-hop cells" do
     ctx = setup_board
     tile = Tiles::PaddockTile.new(0)
 
-    result = tile.valid_destinations(from_row: 0, from_col: 14, board_contents: ctx[:board_contents], board: ctx[:board])
+    result = tile.valid_destinations(from_row: 0, from_col: 14, board_contents: with_terrain(ctx[:board_contents], ctx[:board]))
 
     assert_includes result, [ 0, 12 ], "C terrain straight W 2 hops away"
     assert_includes result, [ 0, 16 ], "D terrain straight E 2 hops away"
@@ -37,7 +37,7 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
     ctx = setup_board { |s| s.place_settlement(0, 12, 1) }
     tile = Tiles::PaddockTile.new(0)
 
-    result = tile.valid_destinations(from_row: 0, from_col: 14, board_contents: ctx[:board_contents], board: ctx[:board])
+    result = tile.valid_destinations(from_row: 0, from_col: 14, board_contents: with_terrain(ctx[:board_contents], ctx[:board]))
 
     assert_not_includes result, [ 0, 12 ], "occupied cell excluded"
     assert_includes result, [ 0, 16 ]
@@ -48,7 +48,7 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
     tile = Tiles::PaddockTile.new(0)
 
     result = tile.selectable_settlements(player_order: ctx[:chris].order,
-      board_contents: ctx[:board_contents], board: ctx[:board])
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]))
 
     assert_includes result, [ 0, 14 ]
   end
@@ -61,7 +61,7 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
     tile = Tiles::PaddockTile.new(0)
 
     result = tile.selectable_settlements(player_order: ctx[:chris].order,
-      board_contents: ctx[:board_contents], board: ctx[:board])
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]))
 
     assert_empty result
   end
@@ -72,7 +72,7 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
     state.place_settlement(10, 10, 0)
     state.place_city_hall_hex(10, 14, 0)
     tile = Tiles::PaddockTile.new(0)
-    result = tile.selectable_settlements(player_order: 0, board_contents: state, board: all_grass)
+    result = tile.selectable_settlements(player_order: 0, board_contents: with_terrain(state, all_grass))
     assert_includes result, [ 10, 10 ]
     assert_not_includes result, [ 10, 14 ]
   end
@@ -95,7 +95,7 @@ class Tiles::PaddockTileTest < ActiveSupport::TestCase
     tile = Tiles::PaddockTile.new(0)
     result = tile.valid_destinations(
       from_row: 0, from_col: 14,
-      board_contents: ctx[:board_contents], board: ctx[:board], player_order: ctx[:chris].order
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]), player_order: ctx[:chris].order
     )
     assert_not_includes result, [ 0, 12 ]
   end

--- a/test/models/tiles/quarry_tile_test.rb
+++ b/test/models/tiles/quarry_tile_test.rb
@@ -16,7 +16,7 @@ class Tiles::QuarryTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    { board_contents: game.board_contents, board: game.board, chris: chris }
+    { board_contents: with_terrain(game.board_contents, game.board), chris: chris }
   end
 
   test "places_wall? returns true" do
@@ -28,7 +28,7 @@ class Tiles::QuarryTileTest < ActiveSupport::TestCase
     tile = Tiles::QuarryTile.new(0)
 
     result = tile.valid_destinations(
-      board_contents: ctx[:board_contents], board: ctx[:board],
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]),
       player_order: ctx[:chris].order, hand: "G"
     )
 
@@ -43,7 +43,7 @@ class Tiles::QuarryTileTest < ActiveSupport::TestCase
     tile = Tiles::QuarryTile.new(0)
 
     result = tile.valid_destinations(
-      board_contents: ctx[:board_contents], board: ctx[:board],
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]),
       player_order: ctx[:chris].order, hand: "G"
     )
 
@@ -56,7 +56,7 @@ class Tiles::QuarryTileTest < ActiveSupport::TestCase
     tile = Tiles::QuarryTile.new(0)
 
     result = tile.valid_destinations(
-      board_contents: ctx[:board_contents], board: ctx[:board],
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]),
       player_order: ctx[:chris].order, hand: "G"
     )
 
@@ -69,7 +69,7 @@ class Tiles::QuarryTileTest < ActiveSupport::TestCase
     tile = Tiles::QuarryTile.new(0)
 
     result = tile.valid_destinations(
-      board_contents: ctx[:board_contents], board: ctx[:board],
+      board_contents: with_terrain(ctx[:board_contents], ctx[:board]),
       player_order: ctx[:chris].order, hand: nil
     )
 

--- a/test/models/tiles/tavern_tile_test.rb
+++ b/test/models/tiles/tavern_tile_test.rb
@@ -38,8 +38,7 @@ class Tiles::TavernTileTest < ActiveSupport::TestCase
     tile = Tiles::TavernTile.new(0)
 
     result = tile.valid_destinations(
-      board_contents: ctx[:game].board_contents,
-      board: ctx[:game].board,
+      board_contents: with_terrain(ctx[:game].board_contents, ctx[:game].board),
       player_order: ctx[:chris].order
     )
 
@@ -51,8 +50,7 @@ class Tiles::TavernTileTest < ActiveSupport::TestCase
     tile = Tiles::TavernTile.new(0)
 
     result = tile.valid_destinations(
-      board_contents: ctx[:game].board_contents,
-      board: ctx[:game].board,
+      board_contents: with_terrain(ctx[:game].board_contents, ctx[:game].board),
       player_order: ctx[:chris].order
     )
 
@@ -66,8 +64,7 @@ class Tiles::TavernTileTest < ActiveSupport::TestCase
     tile = Tiles::TavernTile.new(0)
 
     result = tile.valid_destinations(
-      board_contents: ctx[:game].board_contents,
-      board: ctx[:game].board,
+      board_contents: with_terrain(ctx[:game].board_contents, ctx[:game].board),
       player_order: ctx[:chris].order
     )
 
@@ -81,8 +78,7 @@ class Tiles::TavernTileTest < ActiveSupport::TestCase
     tile = Tiles::TavernTile.new(0)
 
     result = tile.valid_destinations(
-      board_contents: ctx[:game].board_contents,
-      board: ctx[:game].board,
+      board_contents: with_terrain(ctx[:game].board_contents, ctx[:game].board),
       player_order: ctx[:chris].order
     )
 
@@ -103,8 +99,7 @@ class Tiles::TavernTileTest < ActiveSupport::TestCase
     tile = Tiles::TavernTile.new(0)
 
     result = tile.valid_destinations(
-      board_contents: game.board_contents,
-      board: game.board,
+      board_contents: with_terrain(game.board_contents, game.board),
       player_order: chris.order
     )
 
@@ -118,8 +113,7 @@ class Tiles::TavernTileTest < ActiveSupport::TestCase
     tile = Tiles::TavernTile.new(0)
 
     result = tile.valid_destinations(
-      board_contents: ctx[:game].board_contents,
-      board: ctx[:game].board,
+      board_contents: with_terrain(ctx[:game].board_contents, ctx[:game].board),
       player_order: ctx[:chris].order
     )
 
@@ -135,8 +129,7 @@ class Tiles::TavernTileTest < ActiveSupport::TestCase
     tile = Tiles::TavernTile.new(0)
     assert tile.activatable?(
       player_order: ctx[:chris].order,
-      board_contents: ctx[:game].board_contents,
-      board: ctx[:game].board
+      board_contents: with_terrain(ctx[:game].board_contents, ctx[:game].board)
     )
   end
 
@@ -145,8 +138,7 @@ class Tiles::TavernTileTest < ActiveSupport::TestCase
     tile = Tiles::TavernTile.new(0)
     assert_not tile.activatable?(
       player_order: ctx[:chris].order,
-      board_contents: ctx[:game].board_contents,
-      board: ctx[:game].board
+      board_contents: with_terrain(ctx[:game].board_contents, ctx[:game].board)
     )
   end
 

--- a/test/models/tiles/tile_test.rb
+++ b/test/models/tiles/tile_test.rb
@@ -5,15 +5,15 @@ require "test_helper"
 
 class Tiles::TileTest < ActiveSupport::TestCase
   test "valid_destinations returns empty array" do
-    assert_equal [], Tiles::Tile.new(0).valid_destinations(board_contents: BoardState.new, board: nil, player_order: 0)
+    assert_equal [], Tiles::Tile.new(0).valid_destinations(board_contents: with_terrain(BoardState.new, nil), player_order: 0)
   end
 
   test "selectable_settlements returns empty array" do
-    assert_equal [], Tiles::Tile.new(0).selectable_settlements(player_order: 0, board_contents: BoardState.new, board: nil)
+    assert_equal [], Tiles::Tile.new(0).selectable_settlements(player_order: 0, board_contents: with_terrain(BoardState.new, nil))
   end
 
   test "activatable? returns false when no terrain defined" do
-    assert_not Tiles::Tile.new(0).activatable?(player_order: 0, board_contents: BoardState.new, board: nil)
+    assert_not Tiles::Tile.new(0).activatable?(player_order: 0, board_contents: with_terrain(BoardState.new, nil))
   end
 
   test "builds_settlement? returns false" do
@@ -44,7 +44,7 @@ class Tiles::TileTest < ActiveSupport::TestCase
     tile = Tiles::BarnTile.new(0)
     all_grass = Object.new
     all_grass.define_singleton_method(:terrain_at) { |r, c| "G" }
-    result = tile.selectable_settlements(player_order: 0, board_contents: state, board: all_grass, hand: "G")
+    result = tile.selectable_settlements(player_order: 0, board_contents: with_terrain(state, all_grass), hand: "G")
     assert_includes result, [ 5, 5 ]
     assert_not_includes result, [ 6, 5 ]
   end

--- a/test/models/tiles/tower_tile_test.rb
+++ b/test/models/tiles/tower_tile_test.rb
@@ -15,7 +15,7 @@ class Tiles::TowerTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    @ctx = { board_contents: game.board_contents, board: game.board }
+    @ctx = { board_contents: with_terrain(game.board_contents, game.board) }
   end
 
   test "builds_settlement? returns true" do
@@ -44,14 +44,14 @@ class Tiles::TowerTileTest < ActiveSupport::TestCase
     game.board_contents = BoardState.new.tap { |s| s.place_settlement(5, 5, chris.order) }
     game.save
     game.instantiate
-    ctx = { board_contents: game.board_contents, board: game.board }
+    ctx = { board_contents: with_terrain(game.board_contents, game.board) }
     tile = Tiles::TowerTile.new(0)
 
     result = tile.valid_destinations(**ctx, player_order: chris.order)
 
     assert result.any?
     result.each { |r, c| assert(r == 0 || r == 19 || c == 0 || c == 19, "#{[ r, c ]} is not a border hex") }
-    result.each { |r, c| assert_includes %w[C D F G T], ctx[:board].terrain_at(r, c) }
+    result.each { |r, c| assert_includes %w[C D F G T], ctx[:board_contents].terrain_at(r, c) }
   end
 
   test "valid_destinations excludes occupied border hexes" do

--- a/test/models/tiles/village_tile_test.rb
+++ b/test/models/tiles/village_tile_test.rb
@@ -23,7 +23,7 @@ class Tiles::VillageTileTest < ActiveSupport::TestCase
     game.board_contents = state
     game.save
     game.instantiate
-    @ctx = { board_contents: game.board_contents, board: game.board }
+    @ctx = { board_contents: with_terrain(game.board_contents, game.board) }
   end
 
   test "valid_destinations includes hexes adjacent to 3+ own settlements" do
@@ -77,7 +77,7 @@ class Tiles::VillageTileTest < ActiveSupport::TestCase
 
     result = tile.valid_destinations(**@ctx, player_order: @chris.order)
 
-    result.each { |r, c| assert_includes Tiles::Tile::BUILDABLE_TERRAIN, @ctx[:board].terrain_at(r, c) }
+    result.each { |r, c| assert_includes Tiles::Tile::BUILDABLE_TERRAIN, @ctx[:board_contents].terrain_at(r, c) }
   end
 
   test "valid_destinations ignores opponent settlements" do

--- a/test/models/tiles/wagon_tile_test.rb
+++ b/test/models/tiles/wagon_tile_test.rb
@@ -41,32 +41,32 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
 
   test "activatable? is true when wagon in supply" do
     state = BoardState.new
-    assert tile.activatable?(player_order: 0, board_contents: state, board: all_grass_board, supply: { "wagon" => 1 })
+    assert tile.activatable?(player_order: 0, board_contents: with_terrain(state, all_grass_board), supply: { "wagon" => 1 })
   end
 
   test "activatable? is true when wagon already on board" do
     state = BoardState.new
     state.place_wagon(5, 5, 0)
-    assert tile.activatable?(player_order: 0, board_contents: state, board: all_grass_board, supply: { "wagon" => 0 })
+    assert tile.activatable?(player_order: 0, board_contents: with_terrain(state, all_grass_board), supply: { "wagon" => 0 })
   end
 
   test "activatable? is false when no supply and no wagon on board" do
     state = BoardState.new
-    assert_not tile.activatable?(player_order: 0, board_contents: state, board: all_grass_board, supply: { "wagon" => 0 })
+    assert_not tile.activatable?(player_order: 0, board_contents: with_terrain(state, all_grass_board), supply: { "wagon" => 0 })
   end
 
   # --- valid_destinations (placement) ---
 
   test "valid_destinations (placement) returns empty when wagon supply 0 and no wagon on board" do
     state = BoardState.new
-    assert_equal [], tile.valid_destinations(board_contents: state, board: all_grass_board, player_order: 0, supply: { "wagon" => 0 })
+    assert_equal [], tile.valid_destinations(board_contents: with_terrain(state, all_grass_board), player_order: 0, supply: { "wagon" => 0 })
   end
 
   test "valid_destinations (placement) returns adjacent suitable hexes when own settlements present" do
     state = BoardState.new
     state.place_settlement(5, 5, 0)
     neighbors = state.neighbors(5, 5)
-    destinations = tile.valid_destinations(board_contents: state, board: all_grass_board, player_order: 0, supply: { "wagon" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, all_grass_board), player_order: 0, supply: { "wagon" => 1 })
     neighbors.each { |r, c| assert_includes destinations, [ r, c ] }
     assert_not_includes destinations, [ 0, 0 ]
   end
@@ -78,7 +78,7 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
     land_neighbors.each { |(r, c)| terrain[[ r, c ]] = "W" }
     state = BoardState.new
     state.place_settlement(5, 5, 0)
-    destinations = tile.valid_destinations(board_contents: state, board: BoardStub.new(terrain), player_order: 0, supply: { "wagon" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, BoardStub.new(terrain)), player_order: 0, supply: { "wagon" => 1 })
     assert_includes destinations, [ 0, 0 ]
   end
 
@@ -86,14 +86,14 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
     state = BoardState.new
     state.place_settlement(5, 5, 0)
     state.place_settlement(5, 4, 1)
-    destinations = tile.valid_destinations(board_contents: state, board: all_grass_board, player_order: 0, supply: { "wagon" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, all_grass_board), player_order: 0, supply: { "wagon" => 1 })
     assert_not_includes destinations, [ 5, 4 ]
   end
 
   test "valid_destinations (placement) includes own wagon hex when wagon is on board" do
     state = BoardState.new
     state.place_wagon(3, 3, 0)
-    destinations = tile.valid_destinations(board_contents: state, board: all_grass_board, player_order: 0, supply: { "wagon" => 0 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, all_grass_board), player_order: 0, supply: { "wagon" => 0 })
     assert_includes destinations, [ 3, 3 ]
   end
 
@@ -102,14 +102,14 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
     20.times { |r| 20.times { |c| terrain[[ r, c ]] = "M" } }
     state = BoardState.new
     state.place_settlement(5, 5, 0)
-    destinations = tile.valid_destinations(board_contents: state, board: BoardStub.new(terrain), player_order: 0, supply: { "wagon" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, BoardStub.new(terrain)), player_order: 0, supply: { "wagon" => 1 })
     state.neighbors(5, 5).each { |r, c| assert_includes destinations, [ r, c ] }
   end
 
   test "valid_destinations (placement) excludes water hexes" do
     state = BoardState.new
     state.place_settlement(5, 5, 0)
-    destinations = tile.valid_destinations(board_contents: state, board: all_water_board, player_order: 0, supply: { "wagon" => 1 })
+    destinations = tile.valid_destinations(board_contents: with_terrain(state, all_water_board), player_order: 0, supply: { "wagon" => 1 })
     assert_equal [], destinations
   end
 
@@ -120,7 +120,7 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
     state.place_wagon(5, 5, 0)
     destinations = tile.valid_destinations(
       from_row: 5, from_col: 5,
-      board_contents: state, board: all_water_board, player_order: 0
+      board_contents: with_terrain(state, all_water_board), player_order: 0
     )
     assert_equal [], destinations
   end
@@ -130,7 +130,7 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
     state.place_wagon(10, 10, 0)
     dests = tile.valid_destinations(
       from_row: 10, from_col: 10,
-      board_contents: state, board: all_grass_board, player_order: 0
+      board_contents: with_terrain(state, all_grass_board), player_order: 0
     )
     assert_includes dests, [ 10, 11 ]
     assert_not_includes dests, [ 10, 12 ]
@@ -146,7 +146,7 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
     state.place_wagon(10, 10, 0)
     dests = tile.valid_destinations(
       from_row: 10, from_col: 10,
-      board_contents: state, board: BoardStub.new(terrain), player_order: 0
+      board_contents: with_terrain(state, BoardStub.new(terrain)), player_order: 0
     )
     assert_not_includes dests, [ 10, 11 ]
   end
@@ -157,7 +157,7 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
     state.place_settlement(10, 11, 1)
     dests = tile.valid_destinations(
       from_row: 10, from_col: 10,
-      board_contents: state, board: all_grass_board, player_order: 0
+      board_contents: with_terrain(state, all_grass_board), player_order: 0
     )
     assert_not_includes dests, [ 10, 11 ]
   end
@@ -169,7 +169,7 @@ class Tiles::WagonTileTest < ActiveSupport::TestCase
     state.place_wagon(10, 10, 0)
     dests = tile.valid_destinations(
       from_row: 10, from_col: 10,
-      board_contents: state, board: BoardStub.new(terrain), player_order: 0
+      board_contents: with_terrain(state, BoardStub.new(terrain)), player_order: 0
     )
     assert_includes dests, [ 10, 11 ]
     assert_not_includes dests, [ 10, 12 ]

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -435,7 +435,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.instantiate
     dest = Tiles::Nomad::ResettlementTile.new(0).valid_destinations(
       from_row: from_hex[0], from_col: from_hex[1],
-      board_contents: @game.board_contents, board: @game.board,
+      board_contents: with_terrain(@game.board_contents, @game.board),
       player_order: player.order, budget: 4
     ).first
     raise "No adjacent step available" unless dest
@@ -465,7 +465,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.instantiate
     step = Tiles::Nomad::ResettlementTile.new(0).valid_destinations(
       from_row: from_hex[0], from_col: from_hex[1],
-      board_contents: @game.board_contents, board: @game.board,
+      board_contents: with_terrain(@game.board_contents, @game.board),
       player_order: player.order, budget: 4
     ).first
     raise "No adjacent step available" unless step
@@ -785,7 +785,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.instantiate
     expected = Tiles::PaddockTile.new(0).valid_destinations(
       from_row: spot[0], from_col: spot[1],
-      board_contents: @game.board_contents, board: @game.board
+      board_contents: with_terrain(@game.board_contents, @game.board)
     )
     assert_equal expected.sort, cells.sort
   end
@@ -1499,8 +1499,7 @@ class TurnEngineTest < ActiveSupport::TestCase
 
     non_adjacent_grass = [ 4, 4 ]
     destinations = Tiles::FarmTile.new(0).valid_destinations(
-      board_contents: @game.board_contents,
-      board: @game.instantiate,
+      board_contents: with_terrain(@game.board_contents, @game.instantiate),
       player_order: player.order
     )
     assert_not_includes destinations, non_adjacent_grass
@@ -1779,7 +1778,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert @game.board_contents.ship_at?(0, 4)
     assert_empty player.reload.tiles.reject { |tile| tile["klass"] == "LighthouseTile" }
     assert @game.moves.where(action: "move_ship").all?(&:deliberate?)
-    assert_equal [[ "[0, 3]", "[1, 3]" ], [ "[1, 3]", "[0, 4]" ]],
+    assert_equal [ [ "[0, 3]", "[1, 3]" ], [ "[1, 3]", "[0, 4]" ] ],
       @game.moves.where(action: "move_ship").order(:order).pluck(:from, :to)
     assert @game.moves.exists?(action: "pick_up_tile", from: "[2, 4]")
     assert @game.moves.exists?(action: "forfeit_tile", from: "[2, 4]")
@@ -1823,7 +1822,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert @game.board_contents.wagon_at?(1, 2)
     assert_empty player.reload.tiles.reject { |tile| tile["klass"] == "WagonTile" }
     assert @game.moves.where(action: "move_wagon").all?(&:deliberate?)
-    assert_equal [[ "[4, 3]", "[3, 3]" ], [ "[3, 3]", "[2, 3]" ], [ "[2, 3]", "[1, 2]" ]],
+    assert_equal [ [ "[4, 3]", "[3, 3]" ], [ "[3, 3]", "[2, 3]" ], [ "[2, 3]", "[1, 2]" ] ],
       @game.moves.where(action: "move_wagon").order(:order).pluck(:from, :to)
     assert @game.moves.exists?(action: "pick_up_tile", from: "[2, 4]")
     assert @game.moves.exists?(action: "forfeit_tile", from: "[2, 4]")
@@ -1895,13 +1894,13 @@ class TurnEngineTest < ActiveSupport::TestCase
     engine = TurnEngine.new(@game.reload)
     first_step = source_tile.valid_destinations(
       from_row: 4, from_col: 3,
-      board_contents: @game.board_contents, board: @game.board,
+      board_contents: with_terrain(@game.board_contents, @game.board),
       player_order: player.order,
       budget: 4
     ).first
     second_step = source_tile.valid_destinations(
       from_row: 2, from_col: 7,
-      board_contents: @game.board_contents, board: @game.board,
+      board_contents: with_terrain(@game.board_contents, @game.board),
       player_order: player.order,
       budget: 4
     ).first
@@ -1924,7 +1923,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert @game.moves.where(action: "move_settlement").all?(&:deliberate?)
     assert_equal [
       [ "[4, 3]", Coordinate.new(*first_step).to_key ],
-      [ "[2, 7]", Coordinate.new(*second_step).to_key ],
+      [ "[2, 7]", Coordinate.new(*second_step).to_key ]
     ],
       @game.moves.where(action: "move_settlement").order(:order).pluck(:from, :to)
     assert_nil @game.current_action["from"]
@@ -2283,8 +2282,7 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.instantiate
     tile = Tiles::Tile.for_klass(tile_klass).new(0)
     tile.valid_destinations(
-      board_contents: @game.board_contents,
-      board: @game.board,
+      board_contents: with_terrain(@game.board_contents, @game.board),
       player_order: @game.current_player.order,
       supply: @game.current_player.supply_hash
     )

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,14 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
 
-    # Add more helper methods to be used by all tests here...
+    # Attach a terrain source to a BoardState and return it, so tile methods can
+    # call board_contents.terrain_at without a separate board: argument. In
+    # production game.instantiate does this; tests pass a BoardStub (or the real
+    # Boards::Board). Idempotent.
+    def with_terrain(board_contents, terrain_source)
+      return board_contents if board_contents.nil?
+      board_contents.terrain_source = terrain_source if terrain_source
+      board_contents
+    end
   end
 end


### PR DESCRIPTION
## Context

A board hex is one concept — *terrain, maybe a piece* — but it was modelled as two objects. `BoardState` (the `board_contents` JSON column) owns occupancy (`empty?`, `player_at`, `neighbors`, …); `Boards::Board` owns terrain (`terrain_at`, from `game.boards` + section layouts) plus a parallel `@content` copy of the pieces. Because no single object could answer *"is this hex passable for a ship?"*, the `board:` + `board_contents:` parameter pair was threaded through ~14 tile methods, the scoring code, the engine, and ~120 test call sites.

A full audit confirmed **every non-view use of `board:` is only for `terrain_at`** (the engine's `available_list` also used `board.content_at` for occupancy, which `BoardState` already answers).

## Change

- **`BoardState` gains `terrain_at`**, delegating to an injected, duck-typed terrain source attached at `Game#instantiate` — the `Boards::Board` in production, a stub in tests. Terrain is static config, so it is **never serialized** (`BoardState.dump` still emits occupancy only); `terrain_at` raises if no source is attached (catches a missing `instantiate`).
- **Dropped the `board:` keyword** from `Tiles::Tile#valid_destinations`/`activatable?`/`selectable_settlements` and all ~18 overrides; internal `board.terrain_at` → `board_contents.terrain_at` across tiles, scoring, and the engine. `available_list`'s `content_at` occupancy reads → `board_contents.player_at`/`empty?`.
- **`Boards::Board` stays** for view rendering — the audit found `_quadrant.html.erb` genuinely needs `@content` (`.tile_css_class`/`.qty`/`.description`, settlement `.player`/`.warrior?`/…). Collapsing `@content`/`Boards::Board` is a separate, larger view-rework slice (04b), intentionally out of scope.

One object now answers both terrain and occupancy for all logic/scoring; **no behaviour change.**

This is candidate 04 of the architecture review (order 02 → 04 → 01 → 03), scoped to the param-pair elimination only.

## Tests

- Added a `with_terrain(board_contents, source)` helper (attaches terrain to a `BoardState`, idempotent); mechanically rewrapped ~21 tile test files + `turn_engine_test` so calls pass only `board_contents:`, and repointed `ctx[:board].terrain_at` assertions to `board_contents`.
- `board_state_test` covers `terrain_at` (delegates / raises without a source / survives `dup`).
- Full suite: **878 runs, 0 failures, 0 errors**. RuboCop: clean. Scenario net (real games, exercises terrain end-to-end) green and untouched as the safety harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)