### PR TITLE
Slice 0: TurnPhase null-object defaults, drop respond_to? guards

### DIFF
--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -69,6 +69,17 @@ class TurnPhase
     serialize["from"]
   end
 
+  # Null-object defaults so the engine can ask any phase for these without a
+  # respond_to? guard. Phases that own a concept override the accessor; phases
+  # that don't return the neutral value the engine would otherwise default to.
+  def budget = nil
+  def moves = nil
+  def remaining = nil
+  def walls_placed = nil
+  def fort_terrain = nil
+  def pending_orders = []
+  def outpost_active? = false
+
   def transition(_event, _facts)
     raise InvalidTransition, "#{self.class.name} does not accept that event"
   end
@@ -470,7 +481,7 @@ class TurnPhase::TargetedRemovalPhase < TurnPhase
   end
 
   def consume_target(owner_order)
-    remaining = pending_orders - [owner_order]
+    remaining = pending_orders - [ owner_order ]
     if remaining.empty?
       TurnPhase::TransitionResult.new(
         next_phase: TurnPhase::MandatoryBuildPhase.new,

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -162,7 +162,7 @@ class TurnEngine
 
     return "Not a valid target" unless legal_targets.include?([ row, col ])
     current_phase = @game.turn_phase
-    pending_orders = current_phase.respond_to?(:pending_orders) ? current_phase.pending_orders : []
+    pending_orders = current_phase.pending_orders
     owner_order = @game.board_contents.player_at(row, col)
 
     owner = @game.game_players.find { |gp| gp.order == owner_order }
@@ -580,8 +580,8 @@ class TurnEngine
     game_player = @game.current_player
     tile_klass_name = current_action_tile_klass
     current_phase = @game.turn_phase
-    moves_made = current_phase.respond_to?(:moves) ? current_phase.moves.to_i : 0
-    walls_placed = current_phase.respond_to?(:walls_placed) ? current_phase.walls_placed.to_i : 0
+    moves_made = current_phase.moves.to_i
+    walls_placed = current_phase.walls_placed.to_i
     return "Not allowed" unless moves_made >= 1 || walls_placed >= 1
 
     game_player.mark_tile_used!(tile_klass_name.demodulize)
@@ -608,7 +608,7 @@ class TurnEngine
     end
     wall_terrain = effective_terrain(game_player)
 
-    walls_placed = current_phase.respond_to?(:walls_placed) ? current_phase.walls_placed.to_i + 1 : 1
+    walls_placed = current_phase.walls_placed.to_i + 1
 
     record_move(
       action: "place_wall",
@@ -660,7 +660,7 @@ class TurnEngine
   def outpost_activatable?(tile)
     return false if tile["used"]
     return false unless build_action?
-    return false if @game.turn_phase.respond_to?(:outpost_active?) && @game.turn_phase.outpost_active?
+    return false if @game.turn_phase.outpost_active?
     @game.current_player.settlements_remaining?
   end
 
@@ -688,7 +688,7 @@ class TurnEngine
     tile_klass = Tiles::Tile.for_klass(current_action_tile_klass) if action_type != "mandatory"
     if tile_klass
       tile_for_msg = tile_klass.new(0)
-      hand_for_msg = if tile_for_msg.fort_tile? && current_phase.respond_to?(:fort_terrain)
+      hand_for_msg = if tile_for_msg.fort_tile?
         current_phase.fort_terrain
       else
         @game.current_player.hand.first
@@ -698,7 +698,7 @@ class TurnEngine
         terrain_names: Boards::Board::TERRAIN_NAMES,
         hand: hand_for_msg
       )
-      remaining = current_phase.respond_to?(:remaining) ? current_phase.remaining : nil
+      remaining = current_phase.remaining
       remaining ? "#{msg} (#{remaining} remaining)" : msg
     else
       has_activatable = (@game.current_player.tiles || []).any? { |t| tile_activatable?(t) }
@@ -785,7 +785,7 @@ class TurnEngine
 
       if action == "mandatory"
         if player.settlements_remaining? && @game.mandatory_count > 0
-          if current_phase.respond_to?(:outpost_active?) && current_phase.outpost_active?
+          if current_phase.outpost_active?
             terrains = effective_terrain(player) ? [ effective_terrain(player) ] : player.hand
             (0..19).flat_map do |r|
               (0..19).filter_map do |c|
@@ -809,14 +809,14 @@ class TurnEngine
         if tile
           tile_obj = Tiles::Tile.from_hash(tile)
           if tile_obj.sword_tile?
-            pending_orders = current_phase.respond_to?(:pending_orders) ? current_phase.pending_orders : []
+            pending_orders = current_phase.pending_orders
             pending_orders.flat_map { |order|
               @game.board_contents.settlements_for(order).reject { |r, c| @game.board_contents.city_hall_at?(r, c) }
             }
           elsif tile_obj.places_meeple?
             if current_phase.from
               from = Coordinate.from_key(current_phase.from)
-              if current_phase.respond_to?(:budget) && current_phase.budget.to_i <= 0
+              if current_phase.budget.to_i <= 0
                 []
               else
                 @game.board_contents.neighbors(from.row, from.col).select do |row, col|
@@ -871,7 +871,7 @@ class TurnEngine
               extra_kwargs = {}
               if tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
                 extra_kwargs = {
-                  budget: current_phase.respond_to?(:budget) ? current_phase.budget.to_i : 0
+                  budget: current_phase.budget.to_i
                 }
               end
               if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
@@ -890,7 +890,7 @@ class TurnEngine
               board_contents: @game.board_contents, player_order: player.order, supply: player.supply_hash
             )
           else
-            if tile_obj.builds_settlement? && current_phase.respond_to?(:outpost_active?) && current_phase.outpost_active?
+            if tile_obj.builds_settlement? && current_phase.outpost_active?
               terrains = outpost_build_terrains(tile_obj, current_phase, player)
               (0..19).flat_map do |r|
                 (0..19).filter_map do |c|
@@ -899,7 +899,7 @@ class TurnEngine
                 end
               end
             elsif tile_obj.fort_tile?
-              hand = current_phase.respond_to?(:fort_terrain) ? current_phase.fort_terrain : nil
+              hand = current_phase.fort_terrain
               tile_obj.valid_destinations(
                 board_contents: @game.board_contents, player_order: player.order, hand: hand
               )
@@ -995,7 +995,7 @@ class TurnEngine
 
   def outpost_build_terrains(tile_obj, current_phase, game_player)
     if tile_obj.fort_tile?
-      [ current_phase.respond_to?(:fort_terrain) ? current_phase.fort_terrain : nil ].compact
+      [ current_phase.fort_terrain ].compact
     elsif tile_obj.uses_played_terrain? && effective_terrain(game_player).nil?
       game_player.hand
     else
@@ -1272,7 +1272,7 @@ class TurnEngine
 
   def lock_terrain!(terrain, before)
     phase = @game.turn_phase
-    return if phase.respond_to?(:chosen_terrain) && phase.chosen_terrain
+    return if phase.chosen_terrain
     @game.turn_phase =
       if phase.is_a?(TurnPhase::TileBuildPhase)
         TurnPhase::TileBuildPhase.new(
@@ -1286,14 +1286,14 @@ class TurnEngine
         TurnPhase::MandatoryBuildPhase.new(
           chosen_terrain: terrain,
           builds: phase.is_a?(TurnPhase::MandatoryBuildPhase) ? phase.builds : [],
-          outpost_active: phase.respond_to?(:outpost_active?) && phase.outpost_active?
+          outpost_active: phase.outpost_active?
         )
       end
   end
 
   def reset_to_mandatory
     current_phase = @game.turn_phase
-    ct = current_phase.respond_to?(:chosen_terrain) ? current_phase.chosen_terrain : nil
+    ct = current_phase.chosen_terrain
     @game.turn_phase = TurnPhase::MandatoryBuildPhase.new(chosen_terrain: ct)
   end
 
@@ -1303,7 +1303,7 @@ class TurnEngine
 
   def effective_terrain(player)
     current_phase = @game.turn_phase
-    (current_phase.respond_to?(:chosen_terrain) ? current_phase.chosen_terrain : nil) || (player.hand.size == 1 ? player.hand.first : nil)
+    current_phase.chosen_terrain || (player.hand.size == 1 ? player.hand.first : nil)
   end
 
   def log_piece_movement_steps(action:, game_player:, from_row:, from_col:, path:, payload:, message_piece:)

--- a/test/models/turn_phase_test.rb
+++ b/test/models/turn_phase_test.rb
@@ -128,12 +128,12 @@ class TurnPhaseTest < ActiveSupport::TestCase
   end
 
   test "targeted removal phase removes one pending order at a time" do
-    phase = TurnPhase.deserialize({ "type" => "sword", "klass" => "SwordTile", "pending_orders" => [1, 2] })
+    phase = TurnPhase.deserialize({ "type" => "sword", "klass" => "SwordTile", "pending_orders" => [ 1, 2 ] })
 
     result = phase.consume_target(1)
 
     assert_instance_of TurnPhase::TargetedRemovalPhase, result.next_phase
-    assert_equal({ "type" => "sword", "klass" => "SwordTile", "pending_orders" => [2] }, result.next_phase.serialize)
+    assert_equal({ "type" => "sword", "klass" => "SwordTile", "pending_orders" => [ 2 ] }, result.next_phase.serialize)
     assert_equal false, result.action_completed
   end
 
@@ -149,5 +149,21 @@ class TurnPhaseTest < ActiveSupport::TestCase
 
     assert_instance_of TurnPhase::CityHallPhase, phase
     assert_equal({ "type" => "cityhall", "klass" => "CityHallTile" }, phase.serialize)
+  end
+
+  test "a phase that owns none of the optional concepts exposes neutral defaults" do
+    # The engine asks every current phase for these without a respond_to? guard
+    # (e.g. turn_endable? reads outpost_active?, the move counter reads moves and
+    # walls_placed), so a phase that lacks them must answer with the neutral value.
+    phase = TurnPhase.deserialize({ "type" => "barracks", "klass" => "BarracksTile" })
+
+    assert_nil phase.budget
+    assert_nil phase.moves
+    assert_nil phase.remaining
+    assert_nil phase.walls_placed
+    assert_nil phase.fort_terrain
+    assert_nil phase.chosen_terrain
+    assert_equal [], phase.pending_orders
+    assert_equal false, phase.outpost_active?
   end
 end

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -1738,7 +1738,12 @@ class TurnEngineTest < ActiveSupport::TestCase
 
   test "placing a lighthouse ship adjacent to an oasis location picks up an Oasis tile" do
     @game.boards = [ [ 1, 1 ], [ 12, 0 ], [ 0, 0 ], [ 4, 0 ] ]
-    @game.board_contents.place_tile(2, 4, "OasisTile", 2)
+    # Start a clean board so (1, 4) is deterministically empty water. Reusing the
+    # board_contents from `start` leaves randomly-placed location/nomad tiles that
+    # can occupy (1, 4) and make the ship placement illegal (order-dependent flake).
+    @game.board_contents = BoardState.new.tap do |state|
+      state.place_tile(2, 4, "OasisTile", 2)
+    end
     @game.save!
     @engine = TurnEngine.new(@game.reload)
 


### PR DESCRIPTION
First slice of architecture candidate **03** (sub-phases own their behaviour) — the phase-interface strangler. See `docs/adr/0001-retire-large-turn-engine-deepening-plans.md`.

## What & why

`TurnEngine` probed each current phase's *shape* with **18** `current_phase.respond_to?(:x) ? current_phase.x : default` guards. They existed only because the typed phases, `LegacyPhase`, and the base `TurnPhase` didn't share a uniform interface.

This slice gives base `TurnPhase` null-object defaults (`budget`/`moves`/`remaining`/`walls_placed`/`fort_terrain` → `nil`, `pending_orders` → `[]`, `outpost_active?` → `false`; `chosen_terrain` already existed), so the engine can ask any phase unconditionally. Each literal default equals the guard's former fallback → **zero behaviour change**. `LegacyPhase` keeps its own data-backed accessors.

All 18 `respond_to?` guards in `turn_engine.rb` become direct calls. The 17 `is_a?(TurnPhase::…)` dispatches are deliberately **untouched** — those are the later per-path strangler slices.

## ADR-0001 questions

- **Behaviour moved behind the interface:** the 18 `respond_to?` accessor guards → null-object defaults on `TurnPhase`.
- **Caller simplified:** `turn_engine.rb` (every guard collapsed to a direct call).
- **Tests proving it:** full suite + `bin/test-all` green (881 unit + 6 system, 0 failures, 95.21% merged coverage); new `turn_phase_test` pins the neutral defaults.
- **Probe count now:** `respond_to?` **18 → 0**; `is_a?(TurnPhase::…)` unchanged at **17**.

## Verification

- `bin/test-all` green (units + system, merged coverage).
- `bin/rubocop` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)