### PR TITLE
Phase-interface strangler: Slices 1+2 (consume_target, meeple-movement)

### DIFF
--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -80,6 +80,11 @@ class TurnPhase
   def pending_orders = []
   def outpost_active? = false
 
+  # Phase-kind / capability questions the engine asks instead of probing the
+  # concrete class. Phases that qualify override these.
+  def meeple_movement? = false
+  def tile_action_endable? = false
+
   # Remove one targeted owner and advance. Lives on the base so the engine can
   # ask any current phase uniformly: a phase with remaining orders yields the
   # next TargetedRemovalPhase, otherwise the action completes back to mandatory.
@@ -204,6 +209,8 @@ class TurnPhase::TileBuildPhase < TurnPhase
   def outpost_active?
     outpost_active_value == true
   end
+
+  def tile_action_endable? = walls_placed.to_i >= 1
 
   def decrement_remaining
     self.class.new(
@@ -350,6 +357,8 @@ class TurnPhase::ResettlementPhase < TurnPhase
     "resettlement"
   end
 
+  def tile_action_endable? = moves.to_i >= 1
+
   def klass_name
     "ResettlementTile"
   end
@@ -440,6 +449,9 @@ class TurnPhase::MeepleMovementPhase < TurnPhase
   def moves
     moves_value
   end
+
+  def meeple_movement? = true
+  def tile_action_endable? = moves.to_i >= 1
 
   def transition(event, facts)
     case event

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -80,6 +80,30 @@ class TurnPhase
   def pending_orders = []
   def outpost_active? = false
 
+  # Remove one targeted owner and advance. Lives on the base so the engine can
+  # ask any current phase uniformly: a phase with remaining orders yields the
+  # next TargetedRemovalPhase, otherwise the action completes back to mandatory.
+  def consume_target(owner_order)
+    remaining = pending_orders - [ owner_order ]
+    if remaining.empty?
+      TurnPhase::TransitionResult.new(
+        next_phase: TurnPhase::MandatoryBuildPhase.new,
+        action_completed: true,
+        source_cleared: true
+      )
+    else
+      TurnPhase::TransitionResult.new(
+        next_phase: TurnPhase::TargetedRemovalPhase.new(
+          action_type: type,
+          klass_name: klass_name,
+          pending_orders: remaining
+        ),
+        action_completed: false,
+        source_cleared: true
+      )
+    end
+  end
+
   def transition(_event, _facts)
     raise InvalidTransition, "#{self.class.name} does not accept that event"
   end
@@ -480,26 +504,7 @@ class TurnPhase::TargetedRemovalPhase < TurnPhase
     pending_orders_value
   end
 
-  def consume_target(owner_order)
-    remaining = pending_orders - [ owner_order ]
-    if remaining.empty?
-      TurnPhase::TransitionResult.new(
-        next_phase: TurnPhase::MandatoryBuildPhase.new,
-        action_completed: true,
-        source_cleared: true
-      )
-    else
-      TurnPhase::TransitionResult.new(
-        next_phase: self.class.new(
-          action_type: action_type,
-          klass_name: klass_name,
-          pending_orders: remaining
-        ),
-        action_completed: false,
-        source_cleared: true
-      )
-    end
-  end
+  # consume_target is inherited from TurnPhase — its self.class is this class.
 
   def serialize
     {

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -162,14 +162,11 @@ class TurnEngine
 
     return "Not a valid target" unless legal_targets.include?([ row, col ])
     current_phase = @game.turn_phase
-    pending_orders = current_phase.pending_orders
     owner_order = @game.board_contents.player_at(row, col)
-
     owner = @game.game_players.find { |gp| gp.order == owner_order }
 
-    phase_result = current_phase.is_a?(TurnPhase::TargetedRemovalPhase) ? current_phase.consume_target(owner_order) : nil
-    remaining_orders = pending_orders - [ owner_order ]
-    tile_used = phase_result ? phase_result.action_completed : remaining_orders.empty?
+    phase_result = current_phase.consume_target(owner_order)
+    tile_used = phase_result.action_completed
     meeple = @game.board_contents.meeple_at(row, col)
 
     record_move(
@@ -193,15 +190,7 @@ class TurnEngine
       game_player.mark_tile_used!(klass_name.demodulize)
       @game.turn_phase = TurnPhase::MandatoryBuildPhase.new
     else
-      if phase_result
-        @game.turn_phase = phase_result.next_phase
-      else
-        @game.turn_phase = TurnPhase::TargetedRemovalPhase.new(
-          action_type: current_phase.type,
-          klass_name: current_phase.klass_name,
-          pending_orders: remaining_orders
-        )
-      end
+      @game.turn_phase = phase_result.next_phase
     end
 
     owner.save

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -238,7 +238,7 @@ class TurnEngine
       end
     end
 
-    unless movement_step && @game.turn_phase.is_a?(TurnPhase::MeepleMovementPhase)
+    unless movement_step && @game.turn_phase.meeple_movement?
       game_player.mark_tile_used!(tile_klass)
       reset_to_mandatory
     end
@@ -307,7 +307,7 @@ class TurnEngine
       message: "#{game_player.player.handle} selected their #{action_word} at [#{row}, #{col}]"
     )
     current_phase = @game.turn_phase
-    if current_phase.is_a?(TurnPhase::MeepleMovementPhase)
+    if current_phase.meeple_movement?
       phase_result = current_phase.transition(
         TurnPhase::Events::SourceSelected.new(coordinate_key: "[#{row}, #{col}]"),
         nil
@@ -654,11 +654,7 @@ class TurnEngine
   end
 
   def tile_action_endable?
-    @game.playing? && (
-      (@game.turn_phase.is_a?(TurnPhase::ResettlementPhase) && @game.turn_phase.moves.to_i >= 1) ||
-      (@game.turn_phase.is_a?(TurnPhase::MeepleMovementPhase) && @game.turn_phase.moves.to_i >= 1) ||
-      (@game.turn_phase.is_a?(TurnPhase::TileBuildPhase) && @game.turn_phase.walls_placed.to_i >= 1)
-    )
+    @game.playing? && @game.turn_phase.tile_action_endable?
   end
 
   def tile_used?(tile)

--- a/test/models/turn_phase_test.rb
+++ b/test/models/turn_phase_test.rb
@@ -151,6 +151,25 @@ class TurnPhaseTest < ActiveSupport::TestCase
     assert_equal({ "type" => "cityhall", "klass" => "CityHallTile" }, phase.serialize)
   end
 
+  test "phases answer meeple_movement? and tile_action_endable? for themselves" do
+    barracks = TurnPhase.deserialize({ "type" => "barracks", "klass" => "BarracksTile" })
+    assert_equal false, barracks.meeple_movement?
+    assert_equal false, barracks.tile_action_endable?
+
+    movement = TurnPhase.deserialize({ "type" => "lighthouse", "klass" => "LighthouseTile", "budget" => 3, "moves" => 1 })
+    assert_equal true, movement.meeple_movement?
+    assert_equal true, movement.tile_action_endable?
+    fresh_movement = TurnPhase.deserialize({ "type" => "lighthouse", "klass" => "LighthouseTile", "budget" => 3, "moves" => 0 })
+    assert_equal false, fresh_movement.tile_action_endable?
+
+    resettlement = TurnPhase.deserialize({ "type" => "resettlement", "klass" => "ResettlementTile", "budget" => 3, "moves" => 1 })
+    assert_equal true, resettlement.tile_action_endable?
+    assert_equal false, resettlement.meeple_movement?
+
+    walled = TurnPhase.deserialize({ "type" => "quarry", "klass" => "QuarryTile", "walls_placed" => 1 })
+    assert_equal true, walled.tile_action_endable?
+  end
+
   test "a phase that owns none of the optional concepts exposes neutral defaults" do
     # The engine asks every current phase for these without a respond_to? guard
     # (e.g. turn_endable? reads outpost_active?, the move counter reads moves and


### PR DESCRIPTION
Continues architecture candidate **03** (sub-phases own their behaviour) after Slice 0 (#229). Two strangler slices that move phase-shape decisions off `TurnEngine` onto the phase objects. See `docs/adr/0001-retire-large-turn-engine-deepening-plans.md`.

## Slice 1 — `consume_target` (targeted removal)

`remove_settlement` gated `consume_target` behind `is_a?(TurnPhase::TargetedRemovalPhase)`, with an else-branch that **rebuilt the next `TargetedRemovalPhase` by hand** — i.e. duplicated `consume_target`'s own logic inline. Moved `consume_target` onto base `TurnPhase` (generalizing `self.class.new` to an explicit `TargetedRemovalPhase.new` via the base `type`/`klass_name`/`pending_orders` accessors) and deleted the subclass override. The engine now calls it unconditionally and uses `phase_result.next_phase` directly — dropping the probe, the duplicated reconstruction, and two now-unused locals.

## Slice 2 — `meeple_movement?` / `tile_action_endable?`

- `execute_meeple_action` and `select_meeple_for_move` asked `is_a?(MeepleMovementPhase)` → now `turn_phase.meeple_movement?` (base `false`, overridden `true`).
- `tile_action_endable?` was a 3-way `is_a?` disjunction (Resettlement/MeepleMovement `moves >= 1`, TileBuild `walls_placed >= 1`). Each phase now answers `tile_action_endable?` for itself (base `false`); the engine method collapses to `playing? && turn_phase.tile_action_endable?`. Converting it wholesale pulls a **narrow read-only predicate** onto Resettlement/TileBuild ahead of their slices rather than leaving the method half-probed.

## ADR-0001 questions

- **Behaviour moved:** `consume_target` and the `tile_action_endable?`/`meeple_movement?` decisions → onto the phase objects.
- **Callers simplified:** `remove_settlement`, `execute_meeple_action`, `select_meeple_for_move`, `tile_action_endable?`.
- **Tests proving it:** full suite + `bin/test-all` green (881 unit + 6 system, 0 failures, ~95.3% merged coverage); the existing targeted-removal phase test now exercises the inherited `consume_target`; new `turn_phase_test` cases pin `meeple_movement?`/`tile_action_endable?`.
- **Probe count:** `is_a?(TurnPhase::)` **16 → 11** (all MeepleMovementPhase probes gone; `respond_to?` already at 0 from #229).

## ADR §5 reassessment

After Slice 1 the interface is confirmed "deep enough to keep": each slice deletes a probe **and** real duplication, callers get simpler, and the scenario net proves behaviour identical — not awkward methods invented to dodge `is_a?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)