### PR TITLE
Phase-interface strangler: Slices 3+4 — is_a?(TurnPhase::) reaches 0

### DIFF
--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -83,10 +83,24 @@ class TurnPhase
   # Phase-kind / capability questions the engine asks instead of probing the
   # concrete class. Phases that qualify override these.
   def meeple_movement? = false
+  def mandatory_build? = false
+  def city_hall? = false
   def tile_action_endable? = false
   # Clicking one of your own pieces starts a transition(SourceSelected) rather
   # than the LegacyPhase fallback. True for the move/resettlement phases.
   def accepts_source_selection? = false
+
+  # Return a copy of this phase with the outpost power active. Non-build phases
+  # fall back to a fresh mandatory build (the engine only activates the outpost
+  # during a build action).
+  def with_outpost_active
+    TurnPhase::MandatoryBuildPhase.new(chosen_terrain: chosen_terrain, builds: [], outpost_active: true)
+  end
+
+  # Return a copy of this phase with its terrain locked in.
+  def with_chosen_terrain(terrain)
+    TurnPhase::MandatoryBuildPhase.new(chosen_terrain: terrain, builds: [], outpost_active: outpost_active?)
+  end
 
   # Remove one targeted owner and advance. Lives on the base so the engine can
   # ask any current phase uniformly: a phase with remaining orders yields the
@@ -140,6 +154,16 @@ class TurnPhase::MandatoryBuildPhase < TurnPhase
 
   def outpost_active?
     outpost_active_value == true
+  end
+
+  def mandatory_build? = true
+
+  def with_outpost_active
+    self.class.new(chosen_terrain: chosen_terrain, builds: builds, outpost_active: true)
+  end
+
+  def with_chosen_terrain(terrain)
+    self.class.new(chosen_terrain: terrain, builds: builds, outpost_active: outpost_active?)
   end
 
   def transition(event, facts)
@@ -214,6 +238,27 @@ class TurnPhase::TileBuildPhase < TurnPhase
   end
 
   def tile_action_endable? = walls_placed.to_i >= 1
+
+  def with_outpost_active
+    self.class.new(
+      action_type: action_type,
+      klass_name: klass_name,
+      chosen_terrain: chosen_terrain,
+      remaining: remaining,
+      walls_placed: walls_placed,
+      outpost_active: true
+    )
+  end
+
+  def with_chosen_terrain(terrain)
+    self.class.new(
+      action_type: action_type,
+      klass_name: klass_name,
+      chosen_terrain: terrain,
+      remaining: remaining,
+      walls_placed: walls_placed
+    )
+  end
 
   def decrement_remaining
     self.class.new(
@@ -587,6 +632,8 @@ class TurnPhase::CityHallPhase < TurnPhase
   def klass_name
     klass_value
   end
+
+  def city_hall? = true
 
   def serialize
     {

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -84,6 +84,9 @@ class TurnPhase
   # concrete class. Phases that qualify override these.
   def meeple_movement? = false
   def tile_action_endable? = false
+  # Clicking one of your own pieces starts a transition(SourceSelected) rather
+  # than the LegacyPhase fallback. True for the move/resettlement phases.
+  def accepts_source_selection? = false
 
   # Remove one targeted owner and advance. Lives on the base so the engine can
   # ask any current phase uniformly: a phase with remaining orders yields the
@@ -306,6 +309,8 @@ class TurnPhase::SettlementMovePhase < TurnPhase
     from_value
   end
 
+  def accepts_source_selection? = true
+
   def transition(event, facts)
     case event
     when TurnPhase::Events::SourceSelected
@@ -358,6 +363,7 @@ class TurnPhase::ResettlementPhase < TurnPhase
   end
 
   def tile_action_endable? = moves.to_i >= 1
+  def accepts_source_selection? = true
 
   def klass_name
     "ResettlementTile"
@@ -452,6 +458,7 @@ class TurnPhase::MeepleMovementPhase < TurnPhase
 
   def meeple_movement? = true
   def tile_action_endable? = moves.to_i >= 1
+  def accepts_source_selection? = true
 
   def transition(event, facts)
     case event

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -307,7 +307,7 @@ class TurnEngine
       message: "#{game_player.player.handle} selected their #{action_word} at [#{row}, #{col}]"
     )
     current_phase = @game.turn_phase
-    if current_phase.meeple_movement?
+    if current_phase.accepts_source_selection?
       phase_result = current_phase.transition(
         TurnPhase::Events::SourceSelected.new(coordinate_key: "[#{row}, #{col}]"),
         nil
@@ -467,7 +467,7 @@ class TurnEngine
       message: "#{@game.current_player.player.handle} selected a settlement at [#{row}, #{col}]"
     )
     current_phase = @game.turn_phase
-    if current_phase.is_a?(TurnPhase::SettlementMovePhase) || current_phase.is_a?(TurnPhase::ResettlementPhase)
+    if current_phase.accepts_source_selection?
       phase_result = current_phase.transition(
         TurnPhase::Events::SourceSelected.new(coordinate_key: "[#{row}, #{col}]"),
         nil

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -43,7 +43,7 @@ class TurnEngine
     chosen_terrain_before = current_phase.chosen_terrain
     card_terrain = effective_terrain(game_player)
 
-    if current_phase.is_a?(TurnPhase::MandatoryBuildPhase) && current_phase.outpost_active?
+    if current_phase.mandatory_build? && current_phase.outpost_active?
       return "Not available" unless legal_targets.include?([ row, col ])
       card_terrain ||= game_player.hand.find { |t| @game.board_contents.terrain_at(row, col) == t }
       lock_terrain!(card_terrain, chosen_terrain_before) unless chosen_terrain_before
@@ -98,24 +98,7 @@ class TurnEngine
       message: "#{game_player.player.handle} activated the Outpost tile"
     )
     game_player.mark_tile_used!("OutpostTile")
-    current_phase = @game.turn_phase
-    @game.turn_phase =
-      if current_phase.is_a?(TurnPhase::TileBuildPhase)
-        TurnPhase::TileBuildPhase.new(
-          action_type: current_phase.type,
-          klass_name: current_phase.klass_name,
-          chosen_terrain: current_phase.chosen_terrain,
-          remaining: current_phase.remaining,
-          walls_placed: current_phase.walls_placed,
-          outpost_active: true
-        )
-      else
-        TurnPhase::MandatoryBuildPhase.new(
-          chosen_terrain: current_phase.chosen_terrain,
-          builds: current_phase.is_a?(TurnPhase::MandatoryBuildPhase) ? current_phase.builds : [],
-          outpost_active: true
-        )
-      end
+    @game.turn_phase = @game.turn_phase.with_outpost_active
     game_player.save
     @game.save
   end
@@ -124,7 +107,7 @@ class TurnEngine
     capture_undo_snapshot
     @game.instantiate
     game_player = @game.current_player
-    return "Not available" unless @game.turn_phase.is_a?(TurnPhase::MandatoryBuildPhase)
+    return "Not available" unless @game.turn_phase.mandatory_build?
     return "Not available" unless game_player.find_unused_tile("FortTile")
     return "No settlements left" unless game_player.settlements_remaining?
 
@@ -630,7 +613,7 @@ class TurnEngine
   def tile_activatable?(tile)
     return false if tile["used"]
     return false unless Tiles::Tile.for_klass(tile["klass"])
-    return false unless @game.turn_phase.is_a?(TurnPhase::MandatoryBuildPhase) &&
+    return false unless @game.turn_phase.mandatory_build? &&
       (@game.mandatory_count == Game::MANDATORY_COUNT || @game.mandatory_count <= 0 || !@game.current_player.settlements_remaining?)
     @game.instantiate
     tile_obj = Tiles::Tile.from_hash(tile)
@@ -642,7 +625,7 @@ class TurnEngine
 
   def turn_endable?
     @game.playing? &&
-      @game.turn_phase.is_a?(TurnPhase::MandatoryBuildPhase) &&
+      @game.turn_phase.mandatory_build? &&
       (@game.mandatory_count <= 0 || !@game.current_player.settlements_remaining?)
   end
 
@@ -919,7 +902,7 @@ class TurnEngine
   end
 
   def city_hall_clusters
-    return {} unless @game.turn_phase.is_a?(TurnPhase::CityHallPhase)
+    return {} unless @game.turn_phase.city_hall?
     @game.instantiate
     player = @game.current_player
     tile_obj = Tiles::CityHallTile.new(0)
@@ -973,7 +956,7 @@ class TurnEngine
   end
 
   def build_action?
-    return true if @game.turn_phase.is_a?(TurnPhase::MandatoryBuildPhase)
+    return true if @game.turn_phase.mandatory_build?
     klass = Tiles::Tile.for_klass(current_action_tile_klass)
     klass&.new(0)&.builds_settlement? || false
   end
@@ -1258,22 +1241,7 @@ class TurnEngine
   def lock_terrain!(terrain, before)
     phase = @game.turn_phase
     return if phase.chosen_terrain
-    @game.turn_phase =
-      if phase.is_a?(TurnPhase::TileBuildPhase)
-        TurnPhase::TileBuildPhase.new(
-          action_type: phase.type,
-          klass_name: phase.klass_name,
-          chosen_terrain: terrain,
-          remaining: phase.remaining,
-          walls_placed: phase.walls_placed
-        )
-      else
-        TurnPhase::MandatoryBuildPhase.new(
-          chosen_terrain: terrain,
-          builds: phase.is_a?(TurnPhase::MandatoryBuildPhase) ? phase.builds : [],
-          outpost_active: phase.outpost_active?
-        )
-      end
+    @game.turn_phase = phase.with_chosen_terrain(terrain)
   end
 
   def reset_to_mandatory

--- a/test/models/turn_phase_test.rb
+++ b/test/models/turn_phase_test.rb
@@ -170,6 +170,18 @@ class TurnPhaseTest < ActiveSupport::TestCase
     assert_equal true, walled.tile_action_endable?
   end
 
+  test "move and resettlement phases accept source selection; others fall back" do
+    paddock = TurnPhase.deserialize({ "type" => "paddock", "klass" => "PaddockTile" })
+    resettlement = TurnPhase.deserialize({ "type" => "resettlement", "klass" => "ResettlementTile", "budget" => 3, "moves" => 0 })
+    lighthouse = TurnPhase.deserialize({ "type" => "lighthouse", "klass" => "LighthouseTile" })
+    barracks = TurnPhase.deserialize({ "type" => "barracks", "klass" => "BarracksTile" })
+
+    assert_equal true, paddock.accepts_source_selection?
+    assert_equal true, resettlement.accepts_source_selection?
+    assert_equal true, lighthouse.accepts_source_selection?
+    assert_equal false, barracks.accepts_source_selection?
+  end
+
   test "a phase that owns none of the optional concepts exposes neutral defaults" do
     # The engine asks every current phase for these without a respond_to? guard
     # (e.g. turn_endable? reads outpost_active?, the move counter reads moves and

--- a/test/models/turn_phase_test.rb
+++ b/test/models/turn_phase_test.rb
@@ -182,6 +182,52 @@ class TurnPhaseTest < ActiveSupport::TestCase
     assert_equal false, barracks.accepts_source_selection?
   end
 
+  test "phases identify their build kind" do
+    mandatory = TurnPhase.deserialize({ "type" => "mandatory" })
+    tile_build = TurnPhase.deserialize({ "type" => "oasis", "klass" => "OasisTile" })
+    city_hall = TurnPhase.deserialize({ "type" => "cityhall", "klass" => "CityHallTile" })
+
+    assert_equal true, mandatory.mandatory_build?
+    assert_equal false, tile_build.mandatory_build?
+    assert_equal false, mandatory.city_hall?
+    assert_equal true, city_hall.city_hall?
+  end
+
+  test "with_outpost_active returns the same phase kind with outpost on" do
+    mandatory = TurnPhase::MandatoryBuildPhase.new(chosen_terrain: "G", builds: [ [ 1, 1 ] ])
+    activated = mandatory.with_outpost_active
+    assert_instance_of TurnPhase::MandatoryBuildPhase, activated
+    assert_equal true, activated.outpost_active?
+    assert_equal "G", activated.chosen_terrain
+    assert_equal [ [ 1, 1 ] ], activated.builds
+
+    tile_build = TurnPhase::TileBuildPhase.new(action_type: "quarry", klass_name: "QuarryTile", walls_placed: 1)
+    tile_activated = tile_build.with_outpost_active
+    assert_instance_of TurnPhase::TileBuildPhase, tile_activated
+    assert_equal true, tile_activated.outpost_active?
+    assert_equal 1, tile_activated.walls_placed
+
+    # A non-build phase falls back to a fresh outpost-active mandatory build.
+    fallback = TurnPhase.deserialize({ "type" => "barracks", "klass" => "BarracksTile" }).with_outpost_active
+    assert_instance_of TurnPhase::MandatoryBuildPhase, fallback
+    assert_equal true, fallback.outpost_active?
+  end
+
+  test "with_chosen_terrain locks terrain and preserves phase kind" do
+    mandatory = TurnPhase::MandatoryBuildPhase.new(builds: [ [ 0, 0 ] ], outpost_active: true)
+    locked = mandatory.with_chosen_terrain("D")
+    assert_instance_of TurnPhase::MandatoryBuildPhase, locked
+    assert_equal "D", locked.chosen_terrain
+    assert_equal [ [ 0, 0 ] ], locked.builds
+    assert_equal true, locked.outpost_active?
+
+    tile_build = TurnPhase::TileBuildPhase.new(action_type: "oasis", klass_name: "OasisTile", remaining: 2)
+    tile_locked = tile_build.with_chosen_terrain("S")
+    assert_instance_of TurnPhase::TileBuildPhase, tile_locked
+    assert_equal "S", tile_locked.chosen_terrain
+    assert_equal 2, tile_locked.remaining
+  end
+
   test "a phase that owns none of the optional concepts exposes neutral defaults" do
     # The engine asks every current phase for these without a respond_to? guard
     # (e.g. turn_endable? reads outpost_active?, the move counter reads moves and


### PR DESCRIPTION
Final slices of architecture candidate **03** (sub-phases own their behaviour), after #229 (Slice 0) and #230 (Slices 1+2). After this, **`TurnEngine` no longer probes any phase's concrete class.** See `docs/adr/0001-retire-large-turn-engine-deepening-plans.md`.

## Slice 3 — `accepts_source_selection?`

`select_settlement` gated source selection behind `is_a?(SettlementMovePhase) || is_a?(ResettlementPhase)` — the same shape as `select_meeple_for_move`. Introduced `accepts_source_selection?` (base `false`; SettlementMove/Resettlement/MeepleMovement `true`) and used it at both source-selection sites.

## Slice 4 — build-kind queries + outpost/terrain transitions

- **Kind predicates** `mandatory_build?` and `city_hall?` replace `is_a?(MandatoryBuildPhase)`/`is_a?(CityHallPhase)` in `build_settlement`, `activate_fort_tile`, `tile_activatable?`, `turn_endable?`, `build_action?`, and `city_hall_clusters`.
- **Copy-with builders** `with_outpost_active` and `with_chosen_terrain` move the phase-rebuild `if/else` out of `activate_outpost` and `lock_terrain!` onto the phases: each concrete phase returns a copy *of its own kind* with the field set; a non-build phase falls back to a fresh mandatory build — matching the former else-branches exactly (including `TileBuildPhase` dropping `outpost_active` on terrain lock). The engine sheds ~32 lines of inline reconstruction.

## ADR-0001 questions

- **Behaviour moved:** source-selection routing, build-kind identity, and outpost/terrain phase reconstruction → onto the phase objects.
- **Callers simplified:** `select_settlement`, `activate_outpost`, `lock_terrain!`, plus six predicate sites.
- **Tests proving it:** full `bin/test-all` green (886 unit + 6 system, 0 failures, ~95.3% merged coverage); new `turn_phase_test` cases pin every new predicate and both copy-with builders; the scenario net is unchanged.
- **Probe count:** `is_a?(TurnPhase::)` **10 → 0**. Combined across candidate 03: `respond_to?` **18 → 0**, `is_a?(TurnPhase::)` **17 → 0**.

## Scope boundary

The 10 `is_a?(Tiles::…)` *tile*-type probes remain untouched — a separate polymorphic-tile-dispatch concern, deliberately out of scope per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)