### PR TITLE
Candidate 05: replace tile is_a? probes with polymorphic predicates

### DIFF
--- a/app/models/tiles/nomad/donation_tile.rb
+++ b/app/models/tiles/nomad/donation_tile.rb
@@ -10,6 +10,8 @@ module Tiles
       end
 
       def builds_settlement? = true
+      def repeats_build? = true
+      def build_quota = 3
 
       # build_terrain must be defined by subclasses
       def build_terrain

--- a/app/models/tiles/nomad/resettlement_tile.rb
+++ b/app/models/tiles/nomad/resettlement_tile.rb
@@ -5,6 +5,7 @@ module Tiles
       DESCRIPTION = "Move settlements using a shared budget of 4 steps.".freeze
 
       def moves_settlement? = true
+      def resettles? = true
 
       # The single move step from (from_row, from_col): adjacent empty buildable
       # hexes. `budget` gates whether any step remains this turn.

--- a/app/models/tiles/nomad/treasure_tile.rb
+++ b/app/models/tiles/nomad/treasure_tile.rb
@@ -3,6 +3,8 @@ module Tiles
     class TreasureTile < Tiles::NomadTile
       CREATOR = "Icon by Vector Place".freeze
       DESCRIPTION = "Immediately score 3 points when picked up.".freeze
+
+      def scores_on_pickup? = true
     end
   end
 end

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -92,6 +92,28 @@ module Tiles
       false
     end
 
+    # Settlement movement with a per-turn budget (ResettlementTile), as opposed
+    # to the single-step movers handled by SettlementMovePhase.
+    def resettles?
+      false
+    end
+
+    # Grants more than one settlement build in a row (DonationTile); build_quota
+    # is how many.
+    def repeats_build?
+      false
+    end
+
+    def build_quota
+      1
+    end
+
+    # Consumed for points the moment it is picked up (TreasureTile), rather than
+    # being held with an expiry.
+    def scores_on_pickup?
+      false
+    end
+
     def crossroads_tile?
       false
     end

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -34,7 +34,7 @@ class TurnPhase
 
     if tile&.fort_tile?
       FortPhase.from_hash(hash)
-    elsif tile&.is_a?(Tiles::Nomad::ResettlementTile)
+    elsif tile&.resettles?
       ResettlementPhase.from_hash(hash)
     elsif tile && (tile.builds_settlement? || tile.places_wall?)
       TileBuildPhase.from_hash(hash)

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -349,7 +349,7 @@ class TurnEngine
       lock_terrain!(@game.board_contents.terrain_at(row, col), chosen_terrain_before)
     end
     build_on_terrain(@game.board_contents.terrain_at(row, col), row, col, game_player, tile_klass: tile_klass)
-    if tile_obj.is_a?(Tiles::Nomad::DonationTile)
+    if tile_obj.repeats_build?
       remaining = current_phase.remaining.to_i - 1
       if remaining > 0
         @game.turn_phase = TurnPhase::TileBuildPhase.new(
@@ -381,15 +381,15 @@ class TurnEngine
         TurnPhase::TileBuildPhase.new(
           action_type: type,
           klass_name: klass_name,
-          remaining: (3 if tile_obj.is_a?(Tiles::Nomad::DonationTile)),
-          walls_placed: (0 if tile_obj.is_a?(Tiles::QuarryTile))
+          remaining: (tile_obj.build_quota if tile_obj.repeats_build?),
+          walls_placed: (0 if tile_obj.places_wall?)
         )
-      elsif tile_obj&.moves_settlement? && !tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
+      elsif tile_obj&.moves_settlement? && !tile_obj.resettles?
         TurnPhase::SettlementMovePhase.new(
           action_type: type,
           klass_name: klass_name
         )
-      elsif tile_obj&.is_a?(Tiles::Nomad::ResettlementTile)
+      elsif tile_obj&.resettles?
         TurnPhase::ResettlementPhase.new(
           budget: 4,
           moves: 0
@@ -410,7 +410,7 @@ class TurnEngine
         action = { "type" => type, "klass" => klass_name }
         TurnPhase::LegacyPhase.new(action)
       end
-    if tile_obj&.is_a?(Tiles::Nomad::SwordTile)
+    if tile_obj&.sword_tile?
       opponents = @game.game_players
         .reject { |gp| gp == @game.current_player }
         .select { |gp| @game.board_contents.settlements_for(gp.order).any? }
@@ -476,7 +476,7 @@ class TurnEngine
     if tile_obj&.uses_played_terrain? && chosen_terrain_before.nil? && @game.current_player.hand.size > 1
       lock_terrain!(@game.board_contents.terrain_at(row, col), chosen_terrain_before)
     end
-    if tile_obj&.is_a?(Tiles::Nomad::ResettlementTile)
+    if tile_obj&.resettles?
       return "Not available" unless current_phase.budget.to_i > 0 &&
         tile_obj.valid_destinations(
           from_row: from_coord.row, from_col: from_coord.col,
@@ -815,7 +815,7 @@ class TurnEngine
             hand_arg = effective_terrain(player) || player.hand.first
             if current_phase.from
               from = Coordinate.from_key(current_phase.from)
-              if tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
+              if tile_obj.resettles?
                 tile_obj.valid_destinations(
                   from_row: from.row, from_col: from.col,
                   board_contents: @game.board_contents,
@@ -837,7 +837,7 @@ class TurnEngine
               end
             else
               extra_kwargs = {}
-              if tile_obj.is_a?(Tiles::Nomad::ResettlementTile)
+              if tile_obj.resettles?
                 extra_kwargs = {
                   budget: current_phase.budget.to_i
                 }
@@ -1145,7 +1145,7 @@ class TurnEngine
       )
     end
     if tile_obj&.nomad_tile?
-      if tile_obj.is_a?(Tiles::Nomad::TreasureTile)
+      if tile_obj.scores_on_pickup?
         # Score 3 points immediately and remove the tile
         game_player.tiles = (game_player.tiles || []).reject { |t| t["klass"] == tile[:klass] && t["from"] == tile[:key] }
         score_goal(game_player, "treasure", 3, "#{game_player.player.handle} scored 3 points from a Treasure tile")

--- a/test/models/tiles/nomad/donation_tile_test.rb
+++ b/test/models/tiles/nomad/donation_tile_test.rb
@@ -128,6 +128,12 @@ class Tiles::Nomad::DonationTileTest < ActiveSupport::TestCase
     assert_equal "C", Tiles::Nomad::DonationCanyonTile.new(0).build_terrain
   end
 
+  test "donation tiles repeat the build with a quota of 3" do
+    tile = Tiles::Nomad::DonationCanyonTile.new(0)
+    assert tile.repeats_build?
+    assert_equal 3, tile.build_quota
+  end
+
   test "DonationDesertTile build_terrain returns D" do
     assert_equal "D", Tiles::Nomad::DonationDesertTile.new(0).build_terrain
   end

--- a/test/models/tiles/nomad/resettlement_tile_test.rb
+++ b/test/models/tiles/nomad/resettlement_tile_test.rb
@@ -14,6 +14,10 @@ class Tiles::Nomad::ResettlementTileTest < ActiveSupport::TestCase
     @tile = Tiles::Nomad::ResettlementTile.new(0)
   end
 
+  test "resettles? returns true" do
+    assert @tile.resettles?
+  end
+
   def setup_board(boards: [ [ 10, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ])
     @game.boards = boards
     state = BoardState.new

--- a/test/models/tiles/nomad/treasure_tile_test.rb
+++ b/test/models/tiles/nomad/treasure_tile_test.rb
@@ -9,6 +9,10 @@ class Tiles::Nomad::TreasureTileTest < ActiveSupport::TestCase
     assert @tile.nomad_tile?
   end
 
+  test "scores_on_pickup? returns true" do
+    assert @tile.scores_on_pickup?
+  end
+
   test "DESCRIPTION is set" do
     assert_includes Tiles::Nomad::TreasureTile::DESCRIPTION, "3 points"
   end

--- a/test/models/tiles/tile_test.rb
+++ b/test/models/tiles/tile_test.rb
@@ -36,6 +36,19 @@ class Tiles::TileTest < ActiveSupport::TestCase
     assert_not Tiles::Tile.new(0).places_city_hall?
   end
 
+  test "resettles? returns false by default" do
+    assert_not Tiles::Tile.new(0).resettles?
+  end
+
+  test "repeats_build? returns false and build_quota is 1 by default" do
+    assert_not Tiles::Tile.new(0).repeats_build?
+    assert_equal 1, Tiles::Tile.new(0).build_quota
+  end
+
+  test "scores_on_pickup? returns false by default" do
+    assert_not Tiles::Tile.new(0).scores_on_pickup?
+  end
+
   test "selectable_settlements excludes city_hall hexes" do
     state = BoardState.new
     state.place_settlement(5, 5, 0)


### PR DESCRIPTION
The follow-up to candidate 03. `TurnEngine` (and `TurnPhase.deserialize`) dispatched tile behaviour by probing **concrete tile classes** with `is_a?(Tiles::…)`. This replaces all 10 with predicates on the tile model — the polymorphic-tile-dispatch pattern the codebase already uses for `sword_tile?`/`fort_tile?`/`places_wall?`.

## Mapping

| Probe | Predicate | Sites |
|---|---|---|
| `Tiles::QuarryTile` | `places_wall?` (existing) | 1 |
| `Tiles::Nomad::SwordTile` | `sword_tile?` (existing) | 1 |
| `Tiles::Nomad::ResettlementTile` | `resettles?` (new) | 6 (incl. `turn_phase.rb` deserialize) |
| `Tiles::Nomad::DonationTile` | `repeats_build?` + `build_quota` (new) | 2 |
| `Tiles::Nomad::TreasureTile` | `scores_on_pickup?` (new) | 1 |

New predicates follow the existing `sword_tile?`/`fort_tile?` shape: a default on `Tiles::Tile`, overridden in the one tile class, so each tile owns its own kind.

## Why behaviour is unchanged

- `places_wall?` is overridden `true` only by QuarryTile; `sword_tile?` only by SwordTile — verified.
- ResettlementTile and TreasureTile have no subclasses.
- `repeats_build?`/`build_quota` live on `DonationTile`, so all 7 donation variants inherit them (`is_a?(DonationTile)` matched them all before).

## Verification

- `is_a?(Tiles::)` in `turn_engine.rb` **10 → 0**; in `turn_phase.rb` **1 → 0**.
- Full `bin/test-all` green (892 unit + 6 system, 0 failures, ~95.3% merged coverage).
- `bin/rubocop` clean.
- Base defaults pinned in `tile_test.rb`; each override pinned in that tile's own test (subclass behaviour in subclass tests).

## Noted follow-ups (not in this PR)

Pushing TreasureTile's scoring fully into an `on_pickup`-style hook, and unifying the resettlement `budget:` kwarg so the engine needn't special-case it at all — left as separate, deeper refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)