### PR TITLE
Tile-pickup and resettlement-budget follow-ups

### DIFF
--- a/app/models/tiles/caravan_tile.rb
+++ b/app/models/tiles/caravan_tile.rb
@@ -7,7 +7,7 @@ module Tiles
 
     def moves_settlement? = true
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order: nil, hand: nil)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order: nil, hand: nil, budget: nil)
       return [] if from_row.nil? || from_col.nil?
       STRAIGHT_LINES.filter_map do |steps|
         last = nil
@@ -25,7 +25,7 @@ module Tiles
       end
     end
 
-    def selectable_settlements(player_order:, board_contents:, hand: nil)
+    def selectable_settlements(player_order:, board_contents:, hand: nil, budget: nil)
       board_contents.settlements_for(player_order).filter_map do |r, c|
         next if board_contents.city_hall_at?(r, c)
         [ r, c ] if valid_destinations(from_row: r, from_col: c, board_contents:).any?

--- a/app/models/tiles/harbor_tile.rb
+++ b/app/models/tiles/harbor_tile.rb
@@ -6,7 +6,7 @@ module Tiles
     def moves_settlement? = true
     def move_terrain(hand:) = "W"
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil, budget: nil)
       other_settlements = board_contents.settlements_for(player_order).reject { |r, c| r == from_row && c == from_col }
 
       adjacent = other_settlements.flat_map do |r, c|

--- a/app/models/tiles/nomad/treasure_tile.rb
+++ b/app/models/tiles/nomad/treasure_tile.rb
@@ -4,7 +4,7 @@ module Tiles
       CREATOR = "Icon by Vector Place".freeze
       DESCRIPTION = "Immediately score 3 points when picked up.".freeze
 
-      def scores_on_pickup? = true
+      def pickup_score = [ "treasure", 3 ]
     end
   end
 end

--- a/app/models/tiles/paddock_tile.rb
+++ b/app/models/tiles/paddock_tile.rb
@@ -17,7 +17,7 @@ module Tiles
 
     def moves_settlement? = true
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order: nil, hand: nil)
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order: nil, hand: nil, budget: nil)
       return [] if from_row.nil? || from_col.nil?
       STRAIGHT_LINES.filter_map do |steps|
         dr1, dc1 = steps[from_row % 2]
@@ -38,7 +38,7 @@ module Tiles
       selectable_settlements(player_order:, board_contents:, hand:).any?
     end
 
-    def selectable_settlements(player_order:, board_contents:, hand: nil)
+    def selectable_settlements(player_order:, board_contents:, hand: nil, budget: nil)
       board_contents.settlements_for(player_order).filter_map do |r, c|
         next if board_contents.city_hall_at?(r, c)
         [ r, c ] if valid_destinations(from_row: r, from_col: c, board_contents:).any?

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -18,7 +18,7 @@ module Tiles
 
     def build_terrain = nil
 
-    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil, supply: Hash.new(0))
+    def valid_destinations(from_row: nil, from_col: nil, board_contents:, player_order:, hand: nil, supply: Hash.new(0), budget: nil)
       terrain = build_terrain || hand
       return [] unless terrain
 
@@ -40,7 +40,7 @@ module Tiles
       end
     end
 
-    def selectable_settlements(player_order:, board_contents:, hand: nil, supply: Hash.new(0))
+    def selectable_settlements(player_order:, board_contents:, hand: nil, supply: Hash.new(0), budget: nil)
       return [] unless moves_settlement?
       return [] unless valid_destinations(board_contents:, player_order:, hand:).any?
       board_contents.settlements_for(player_order).reject { |r, c| board_contents.city_hall_at?(r, c) }
@@ -108,10 +108,11 @@ module Tiles
       1
     end
 
-    # Consumed for points the moment it is picked up (TreasureTile), rather than
-    # being held with an expiry.
-    def scores_on_pickup?
-      false
+    # A nomad tile that is consumed for points the instant it is picked up
+    # returns [goal, points] here (TreasureTile); tiles that are instead held
+    # with an expiry return nil.
+    def pickup_score
+      nil
     end
 
     def crossroads_tile?

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -812,44 +812,30 @@ class TurnEngine
               )
             end
           elsif tile_obj.moves_settlement?
+            # budget only gates ResettlementTile; every other mover accepts and
+            # ignores it, so it can be passed uniformly without special-casing.
             hand_arg = effective_terrain(player) || player.hand.first
+            budget = current_phase.budget.to_i
             if current_phase.from
               from = Coordinate.from_key(current_phase.from)
-              if tile_obj.resettles?
-                tile_obj.valid_destinations(
-                  from_row: from.row, from_col: from.col,
-                  board_contents: @game.board_contents,
-                  player_order: player.order, budget: current_phase.budget.to_i
-                )
-              else
-                extra_kwargs = {}
-                if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
-                  player.hand.flat_map { |t|
-                    tile_obj.valid_destinations(from_row: from.row, from_col: from.col, board_contents: @game.board_contents, player_order: player.order, hand: t, **extra_kwargs)
-                  }.uniq
-                else
-                  tile_obj.valid_destinations(
-                    from_row: from.row, from_col: from.col,
-                    board_contents: @game.board_contents, player_order: player.order, hand: hand_arg,
-                    **extra_kwargs
-                  )
-                end
-              end
-            else
-              extra_kwargs = {}
-              if tile_obj.resettles?
-                extra_kwargs = {
-                  budget: current_phase.budget.to_i
-                }
-              end
               if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
                 player.hand.flat_map { |t|
-                  tile_obj.selectable_settlements(player_order: player.order, board_contents: @game.board_contents, hand: t, **extra_kwargs)
+                  tile_obj.valid_destinations(from_row: from.row, from_col: from.col, board_contents: @game.board_contents, player_order: player.order, hand: t, budget:)
+                }.uniq
+              else
+                tile_obj.valid_destinations(
+                  from_row: from.row, from_col: from.col,
+                  board_contents: @game.board_contents, player_order: player.order, hand: hand_arg, budget:
+                )
+              end
+            else
+              if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
+                player.hand.flat_map { |t|
+                  tile_obj.selectable_settlements(player_order: player.order, board_contents: @game.board_contents, hand: t, budget:)
                 }.uniq
               else
                 tile_obj.selectable_settlements(
-                  player_order: player.order, board_contents: @game.board_contents, hand: hand_arg,
-                  **extra_kwargs
+                  player_order: player.order, board_contents: @game.board_contents, hand: hand_arg, budget:
                 )
               end
             end
@@ -1145,10 +1131,11 @@ class TurnEngine
       )
     end
     if tile_obj&.nomad_tile?
-      if tile_obj.scores_on_pickup?
-        # Score 3 points immediately and remove the tile
+      if (scoring = tile_obj.pickup_score)
+        goal, points = scoring
+        # Score immediately and remove the tile
         game_player.tiles = (game_player.tiles || []).reject { |t| t["klass"] == tile[:klass] && t["from"] == tile[:key] }
-        score_goal(game_player, "treasure", 3, "#{game_player.player.handle} scored 3 points from a Treasure tile")
+        score_goal(game_player, goal, points, "#{game_player.player.handle} scored #{points} points from a #{tile[:klass].delete_suffix("Tile")} tile")
       else
         # Set expiry on the tile
         expires = @game.turn_number + @game.game_players.count

--- a/test/models/tiles/nomad/treasure_tile_test.rb
+++ b/test/models/tiles/nomad/treasure_tile_test.rb
@@ -9,8 +9,8 @@ class Tiles::Nomad::TreasureTileTest < ActiveSupport::TestCase
     assert @tile.nomad_tile?
   end
 
-  test "scores_on_pickup? returns true" do
-    assert @tile.scores_on_pickup?
+  test "pickup_score awards 3 points to the treasure goal" do
+    assert_equal [ "treasure", 3 ], @tile.pickup_score
   end
 
   test "DESCRIPTION is set" do

--- a/test/models/tiles/tile_test.rb
+++ b/test/models/tiles/tile_test.rb
@@ -45,8 +45,8 @@ class Tiles::TileTest < ActiveSupport::TestCase
     assert_equal 1, Tiles::Tile.new(0).build_quota
   end
 
-  test "scores_on_pickup? returns false by default" do
-    assert_not Tiles::Tile.new(0).scores_on_pickup?
+  test "pickup_score is nil by default" do
+    assert_nil Tiles::Tile.new(0).pickup_score
   end
 
   test "selectable_settlements excludes city_hall hexes" do


### PR DESCRIPTION
The two deeper follow-ups noted on #232 — moving the last tile-specific knowledge the engine held for these paths onto the tiles. Both on one branch as requested.

## 1. TreasureTile owns its pickup scoring

`apply_tile_pickup` hardcoded the treasure score (`score_goal(player, "treasure", 3, "...Treasure tile")`) behind the `scores_on_pickup?` predicate. Replaced `scores_on_pickup?` with `pickup_score`, which returns `[goal, points]` (or `nil` for tiles held with an expiry). The engine now reads the goal, points, and tile label from the tile — no treasure constants in `TurnEngine`. `score_goal` itself stays in the engine because it records a reversible `Move` (undo concern).

## 2. Resettlement `budget:` kwarg unified

`buildable_cells` special-cased `if tile_obj.resettles?` to pass `budget:` to `valid_destinations`/`selectable_settlements`. Those methods on the base `Tile` and the non-resettlement movers (Harbor/Paddock/Caravan; Barn inherits the base) now accept and ignore an optional `budget:`, exactly like the existing ignored `supply:` kwarg. The engine passes `budget:` uniformly and both `resettles?` branches (plus the `extra_kwargs` plumbing) collapse. The remaining `resettles?` checks (phase selection in `select_action`, the budget-decrement move in `move_settlement`) are genuine behaviour dispatch and are left as-is.

## Verification

- `is_a?`/special-case removal: the two `budget:` `resettles?` branches in `buildable_cells` are gone; `scores_on_pickup?` removed entirely.
- Full `bin/test-all` green (892 unit + 6 system, 0 failures, ~95.3% merged coverage).
- `bin/rubocop` clean.
- `tile_test`/`treasure_tile_test` updated to the `pickup_score` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)