### PR TITLE
Retire the fake SwordTile bugs: realistic test fixture + strip dead demodulize

### DIFF
--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -170,7 +170,7 @@ class TurnEngine
 
     if tile_used
       klass_name = current_action_tile_klass
-      game_player.mark_tile_used!(klass_name.demodulize)
+      game_player.mark_tile_used!(klass_name)
       @game.turn_phase = TurnPhase::MandatoryBuildPhase.new
     else
       @game.turn_phase = phase_result.next_phase
@@ -504,7 +504,7 @@ class TurnEngine
         message_piece: "settlement"
       )
       if budget <= 0
-        @game.current_player.mark_tile_used!(tile_klass_name.demodulize)
+        @game.current_player.mark_tile_used!(tile_klass_name)
         @game.turn_phase = next_phase
       else
         phase_result = current_phase.transition(
@@ -556,7 +556,7 @@ class TurnEngine
     walls_placed = current_phase.walls_placed.to_i
     return "Not allowed" unless moves_made >= 1 || walls_placed >= 1
 
-    game_player.mark_tile_used!(tile_klass_name.demodulize)
+    game_player.mark_tile_used!(tile_klass_name)
     reset_to_mandatory
     game_player.save
     @game.save

--- a/test/scenarios/tiles/donation_tile_test.rb
+++ b/test/scenarios/tiles/donation_tile_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-# Nomad::DonationTile (and its 7 terrain variants) grants 3 extra settlement
+# DonationTile (and its 7 terrain variants) grants 3 extra settlement
 # builds on the tile's donation terrain - adjacent to an existing settlement
 # if possible, otherwise anywhere on that terrain - without consuming the
 # mandatory build count. Unlike normal builds, donation tiles can build on
@@ -12,9 +12,9 @@ class DonationTileTest < ActiveSupport::TestCase
   test "builds 3 settlements on the donation terrain adjacent to an existing settlement" do
     scenario = GameScenario.new
     scenario.place_settlement(0, at: ADJACENT_SETTLEMENT)
-    scenario.give_tile(0, "Nomad::DonationCanyonTile", from: [ 0, 0 ])
+    scenario.give_tile(0, "DonationCanyonTile", from: [ 0, 0 ])
 
-    scenario.activate_tile(:"nomad::donationcanyon")
+    scenario.activate_tile(:donationcanyon)
 
     3.times do |i|
       destinations = scenario.buildable_cells
@@ -28,18 +28,18 @@ class DonationTileTest < ActiveSupport::TestCase
       assert_equal Game::SETTLEMENTS_PER_PLAYER - (i + 1), scenario.settlements_remaining(0)
       assert_equal Game::MANDATORY_COUNT, scenario.mandatory_remaining
       if i < 2
-        assert_includes scenario.usable_tiles(0), "Nomad::DonationCanyonTile"
+        assert_includes scenario.usable_tiles(0), "DonationCanyonTile"
       else
-        assert_not_includes scenario.usable_tiles(0), "Nomad::DonationCanyonTile"
+        assert_not_includes scenario.usable_tiles(0), "DonationCanyonTile"
       end
     end
   end
 
   test "builds anywhere on the donation terrain when no settlement is adjacent to one" do
     scenario = GameScenario.new
-    scenario.give_tile(0, "Nomad::DonationCanyonTile", from: [ 0, 0 ])
+    scenario.give_tile(0, "DonationCanyonTile", from: [ 0, 0 ])
 
-    scenario.activate_tile(:"nomad::donationcanyon")
+    scenario.activate_tile(:donationcanyon)
 
     3.times do |i|
       destinations = scenario.buildable_cells
@@ -53,15 +53,15 @@ class DonationTileTest < ActiveSupport::TestCase
       assert_equal Game::SETTLEMENTS_PER_PLAYER - (i + 1), scenario.settlements_remaining(0)
     end
 
-    assert_not_includes scenario.usable_tiles(0), "Nomad::DonationCanyonTile"
+    assert_not_includes scenario.usable_tiles(0), "DonationCanyonTile"
   end
 
   test "rejects a build on a different terrain than the donation terrain" do
     scenario = GameScenario.new
-    scenario.give_tile(0, "Nomad::DonationCanyonTile", from: [ 0, 0 ])
+    scenario.give_tile(0, "DonationCanyonTile", from: [ 0, 0 ])
     wrong_hex = scenario.empty_hexes("D", 1).first
 
-    scenario.activate_tile(:"nomad::donationcanyon")
+    scenario.activate_tile(:donationcanyon)
 
     assert_raises(GameScenario::IllegalMove) { scenario.build_settlement(at: wrong_hex) }
   end
@@ -69,9 +69,9 @@ class DonationTileTest < ActiveSupport::TestCase
   test "can build on terrain normally excluded from building (mountain)" do
     assert_not_includes Tiles::Tile::BUILDABLE_TERRAIN, "M"
     scenario = GameScenario.new
-    scenario.give_tile(0, "Nomad::DonationMountainTile", from: [ 0, 0 ])
+    scenario.give_tile(0, "DonationMountainTile", from: [ 0, 0 ])
 
-    scenario.activate_tile(:"nomad::donationmountain")
+    scenario.activate_tile(:donationmountain)
 
     3.times do |i|
       destinations = scenario.buildable_cells
@@ -85,6 +85,6 @@ class DonationTileTest < ActiveSupport::TestCase
       assert_equal Game::SETTLEMENTS_PER_PLAYER - (i + 1), scenario.settlements_remaining(0)
     end
 
-    assert_not_includes scenario.usable_tiles(0), "Nomad::DonationMountainTile"
+    assert_not_includes scenario.usable_tiles(0), "DonationMountainTile"
   end
 end

--- a/test/scenarios/tiles/sword_tile_test.rb
+++ b/test/scenarios/tiles/sword_tile_test.rb
@@ -1,20 +1,19 @@
 require "test_helper"
 
-# Nomad::SwordTile lets the player remove one settlement from each opponent
-# that has at least one on the board, returning each to its owner's supply.
+# SwordTile lets the player remove one settlement from each opponent that has
+# at least one on the board, returning each to its owner's supply.
 class SwordTileTest < ActiveSupport::TestCase
   OPPONENT_SETTLEMENT = [ 10, 10 ].freeze
 
   test "removes one settlement from the targeted opponent and returns it to their supply" do
     scenario = GameScenario.new
     scenario.place_settlement(1, at: OPPONENT_SETTLEMENT)
-    scenario.give_tile(0, "Nomad::SwordTile", from: [ 0, 0 ])
+    scenario.give_tile(0, "SwordTile", from: [ 0, 0 ])
 
-    scenario.activate_tile(:"nomad::sword")
+    scenario.activate_tile(:sword)
 
     # The opponent's settlement is highlighted as a removal target (dispatched
-    # polymorphically via sword_tile?, so it works regardless of the
-    # "nomad::sword" action-type string).
+    # polymorphically via sword_tile?).
     assert_includes scenario.buildable_cells, OPPONENT_SETTLEMENT
 
     before_supply = scenario.settlements_remaining(1)
@@ -24,17 +23,15 @@ class SwordTileTest < ActiveSupport::TestCase
     assert_equal before_supply + 1, scenario.settlements_remaining(1)
     assert_equal Game::MANDATORY_COUNT, scenario.mandatory_remaining
 
-    # Known bug: remove_settlement marks the tile used via
-    # current_action_tile_klass.demodulize ("SwordTile"), which doesn't match
-    # the stored "Nomad::SwordTile" klass, so the tile is never actually
-    # marked used even though the phase resets to mandatory build.
-    assert_includes scenario.usable_tiles(0), "Nomad::SwordTile"
+    # The removal completes the action: the tile is marked used and the phase
+    # resets to mandatory build.
+    assert_not_includes scenario.usable_tiles(0), "SwordTile"
   end
 
   test "cannot be activated when no opponent has a settlement on the board" do
     scenario = GameScenario.new
-    scenario.give_tile(0, "Nomad::SwordTile", from: [ 0, 0 ])
+    scenario.give_tile(0, "SwordTile", from: [ 0, 0 ])
 
-    assert_raises(GameScenario::IllegalMove) { scenario.activate_tile(:"nomad::sword") }
+    assert_raises(GameScenario::IllegalMove) { scenario.activate_tile(:sword) }
   end
 end


### PR DESCRIPTION
The two "known SwordTile bugs" pinned in `sword_tile_test.rb` were **not real production bugs** — they were artifacts of the test fixture granting an unrealistic namespaced klass `"Nomad::SwordTile"`. Real games store the **short** form `"SwordTile"` (it's the `NOMAD_TILE_POOL` entry and the `TILE_CLASSES` key → `Tiles::Nomad::SwordTile`).

## Why neither was real

- **#1 (`buildable_cells` checks `action == "sword"`)**: that check no longer exists — dispatch became polymorphic via `tile_obj.sword_tile?` during the architecture pass.
- **#2 (tile never marked used)**: `remove_settlement` called `mark_tile_used!(current_action_tile_klass.demodulize)`. `mark_tile_used!` matches the klass string exactly, and `demodulize` is a **no-op on short names** — so in a real game (`"SwordTile"`) the tile *is* marked used. It only "failed" against the test's fabricated `"Nomad::SwordTile"`, which `demodulize` shortens to `"SwordTile"` and then can't match the stored namespaced string.

## Changes

- `test/scenarios/tiles/sword_tile_test.rb`: grant `"SwordTile"` / `activate_tile(:sword)` (production form) and assert the tile **is** marked used after the removal (was pinning the opposite as a "known bug").
- `app/services/turn_engine.rb`: strip the 3 dead `.demodulize` calls in `mark_tile_used!` calls. They were no-ops for every production (short-name) klass and actively harmful only for a namespaced klass that never occurs; removing them makes mark-used match the exact stored klass.
- `test/scenarios/tiles/donation_tile_test.rb`: same fixture smell — switched the namespaced `"Nomad::DonationCanyonTile"`/`"Nomad::DonationMountainTile"` grants to the production short forms (`activate_tile(:donationcanyon)`, etc.). Test-only.

## Verification

- `bin/test-all` green (892 unit + 6 system, 0 failures, ~95.3% merged coverage) — confirms stripping `demodulize` broke nothing (it was dead everywhere).
- `bin/rubocop` clean.

All scenario tile fixtures now use the production short klass form, so this class of false "bug" can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)