### PR TITLE
Hex-shaped board cells and terrain icons

### DIFF
--- a/app/assets/images/terrain-icons/canyon.svg
+++ b/app/assets/images/terrain-icons/canyon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <rect x="4" y="30" width="40" height="6" rx="1" fill="white"/>
+  <rect x="8" y="22" width="32" height="6" rx="1" fill="white"/>
+  <rect x="14" y="14" width="20" height="6" rx="1" fill="white"/>
+  <rect x="18" y="8" width="12" height="4" rx="1" fill="white"/>
+</svg>

--- a/app/assets/images/terrain-icons/desert.svg
+++ b/app/assets/images/terrain-icons/desert.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <circle cx="34" cy="12" r="6" fill="white"/>
+  <line x1="34" y1="3" x2="34" y2="5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <line x1="41" y1="5" x2="39.5" y2="6.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <line x1="27" y1="5" x2="28.5" y2="6.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <line x1="43" y1="12" x2="41" y2="12" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <line x1="27" y1="12" x2="25" y2="12" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <path d="M4 38 Q10 24 18 32 Q26 40 34 28 Q40 20 44 26" stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+</svg>

--- a/app/assets/images/terrain-icons/farmland.svg
+++ b/app/assets/images/terrain-icons/farmland.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <!-- plowed field rows -->
+  <path d="M6 34 Q14 30 22 34 Q30 38 42 34" stroke="white" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <path d="M6 27 Q14 23 22 27 Q30 31 42 27" stroke="white" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <path d="M6 20 Q14 16 22 20 Q30 24 42 20" stroke="white" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <!-- wheat stalk -->
+  <line x1="36" y1="38" x2="36" y2="8" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="36" cy="5" rx="2.5" ry="4" fill="white"/>
+  <line x1="36" y1="14" x2="32" y2="10" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="36" y1="18" x2="40" y2="14" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/app/assets/images/terrain-icons/flowers.svg
+++ b/app/assets/images/terrain-icons/flowers.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <circle cx="24" cy="24" r="4" fill="white"/>
+  <ellipse cx="24" cy="13" rx="3.5" ry="6" fill="white"/>
+  <ellipse cx="24" cy="35" rx="3.5" ry="6" fill="white"/>
+  <ellipse cx="13" cy="24" rx="6" ry="3.5" fill="white"/>
+  <ellipse cx="35" cy="24" rx="6" ry="3.5" fill="white"/>
+  <ellipse cx="16.2" cy="16.2" rx="3.5" ry="6" transform="rotate(-45 16.2 16.2)" fill="white"/>
+  <ellipse cx="31.8" cy="31.8" rx="3.5" ry="6" transform="rotate(-45 31.8 31.8)" fill="white"/>
+  <ellipse cx="31.8" cy="16.2" rx="3.5" ry="6" transform="rotate(45 31.8 16.2)" fill="white"/>
+  <ellipse cx="16.2" cy="31.8" rx="3.5" ry="6" transform="rotate(45 16.2 31.8)" fill="white"/>
+</svg>

--- a/app/assets/images/terrain-icons/grass.svg
+++ b/app/assets/images/terrain-icons/grass.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <line x1="24" y1="40" x2="24" y2="16" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="24" cy="12" rx="3" ry="6" fill="white"/>
+  <line x1="16" y1="40" x2="16" y2="20" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="16" cy="16" rx="2.5" ry="5" fill="white"/>
+  <line x1="32" y1="40" x2="32" y2="20" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="32" cy="16" rx="2.5" ry="5" fill="white"/>
+  <line x1="9" y1="40" x2="9" y2="25" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <ellipse cx="9" cy="21" rx="2" ry="4" fill="white"/>
+  <line x1="39" y1="40" x2="39" y2="25" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <ellipse cx="39" cy="21" rx="2" ry="4" fill="white"/>
+</svg>

--- a/app/assets/images/terrain-icons/marshland.svg
+++ b/app/assets/images/terrain-icons/marshland.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <!-- water base -->
+  <path d="M4 40 Q10 35 16 40 Q22 45 28 40 Q34 35 44 40" stroke="white" stroke-width="2" stroke-linecap="round" fill="none"/>
+  <!-- reeds -->
+  <line x1="14" y1="38" x2="14" y2="18" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="14" cy="14" rx="2.5" ry="5" fill="white"/>
+  <line x1="24" y1="38" x2="24" y2="10" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="24" cy="6" rx="2.5" ry="5" fill="white"/>
+  <line x1="34" y1="38" x2="34" y2="16" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="34" cy="12" rx="2.5" ry="5" fill="white"/>
+  <!-- small leaves -->
+  <line x1="14" y1="24" x2="9" y2="20" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="24" y1="20" x2="19" y2="16" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="34" y1="22" x2="39" y2="18" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/app/assets/images/terrain-icons/mountain.svg
+++ b/app/assets/images/terrain-icons/mountain.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <polygon points="28,6 44,38 12,38" fill="white"/>
+  <polygon points="16,14 30,38 2,38" fill="white"/>
+</svg>

--- a/app/assets/images/terrain-icons/timberland.svg
+++ b/app/assets/images/terrain-icons/timberland.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <polygon points="24,4 37,26 11,26" fill="white"/>
+  <polygon points="24,14 39,38 9,38" fill="white"/>
+  <rect x="21" y="38" width="6" height="7" rx="1" fill="white"/>
+</svg>

--- a/app/assets/images/terrain-icons/water.svg
+++ b/app/assets/images/terrain-icons/water.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <path d="M4 16 Q10 10 16 16 Q22 22 28 16 Q34 10 40 16 Q43 19 44 16" stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+  <path d="M4 26 Q10 20 16 26 Q22 32 28 26 Q34 20 40 26 Q43 29 44 26" stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+  <path d="M4 36 Q10 30 16 36 Q22 42 28 36 Q34 30 40 36 Q43 39 44 36" stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+</svg>

--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -93,7 +93,7 @@ section#log {
 #board {
     display: grid;
     grid-template-columns: 10fr 10fr 1fr;
-    height: 60vw;
+    aspect-ratio: 21 / 22;
     margin-left: 5px;
     position: absolute;
     top: 0;

--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -10,7 +10,7 @@
     --clr-p-d: #cccccc;
     --clr-p-e: #aa00aa;
 
-    --fx-hex-transparency: 10%;
+    --fx-hex-transparency: 15%;
     --fx-loc-transparency: 15%;
 }
 
@@ -171,8 +171,8 @@ ul li .hex:hover .hex-bg {
 
 #board .selectable .hex-outline polygon {
     stroke: black;
-    stroke-width: 8;
-    animation: selectable-pulse 2s ease-in-out infinite;
+    stroke-width: 4px;
+    animation: selectable-pulse 2s linear infinite;
 }
 
 @keyframes selectable-pulse {
@@ -181,7 +181,7 @@ ul li .hex:hover .hex-bg {
 }
 
 #board .selectable:hover .hex-bg {
-    filter: drop-shadow(0 0 5px white) drop-shadow(0 0 2px white);
+    filter: drop-shadow(0 0 2px white);
 }
 
 #board .selected {
@@ -211,7 +211,7 @@ ul li .hex:hover .hex-bg {
     translate: -50% -50%;
     z-index: -1;
     padding: 3px;
-    animation: 5s spin linear infinite;
+    animation: 3s spin linear infinite;
 }
 
 @keyframes spin {
@@ -404,6 +404,26 @@ ul li .hex:hover .hex-bg {
 .hex.terrain-w {
     --hex-bg: color-mix(in srgb, royalblue, transparent var(--fx-hex-transparency));
 }
+
+/* Terrain icons */
+.hex .terrain-icon {
+    position: absolute;
+    inset: 0;
+    background-repeat: no-repeat;
+    background-size: 38%;
+    background-position: center 85%;
+    opacity: 0.65;
+    pointer-events: none;
+}
+.hex.terrain-c .terrain-icon { background-image: url("terrain-icons/canyon.svg"); }
+.hex.terrain-d .terrain-icon { background-image: url("terrain-icons/desert.svg"); }
+.hex.terrain-f .terrain-icon { background-image: url("terrain-icons/flowers.svg"); }
+.hex.terrain-g .terrain-icon { background-image: url("terrain-icons/grass.svg"); }
+.hex.terrain-t .terrain-icon { background-image: url("terrain-icons/timberland.svg"); }
+.hex.terrain-m .terrain-icon { background-image: url("terrain-icons/mountain.svg"); }
+.hex.terrain-w .terrain-icon { background-image: url("terrain-icons/water.svg"); }
+.hex.terrain-b .terrain-icon { background-image: url("terrain-icons/marshland.svg"); }
+.hex.terrain-p .terrain-icon { background-image: url("terrain-icons/farmland.svg"); }
 
 /* Special terrains */
 .hex.terrain-l, .hex.terrain-s {
@@ -752,10 +772,10 @@ ul li .hex:hover .hex-bg {
 
 .hex-settlement {
     position: absolute;
-    top: 14%;
-    left: 21%;
-    width: 66%;
-    height: 66%;
+    top: 5%;
+    left: 20%;
+    width: 60%;
+    height: 60%;
 }
 
 .city-hall-settlement {

--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -758,7 +758,8 @@ ul li .hex:hover .hex-bg {
     --angle: 0deg;
     content: "";
     position: absolute;
-    border-radius: 5px;
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+    box-sizing: content-box;
     height: 100%;
     width: 100%;
     background-image: conic-gradient(from var(--angle), #5a3a00, gold, #ffd700, gold, #5a3a00);

--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -32,7 +32,7 @@ body.game-page {
     display: grid;
     grid-template-areas:
         "main players-area game-log";
-    grid-template-columns: 5fr 2fr 2fr;
+    grid-template-columns: 7fr 2fr 2fr;
     grid-template-rows: 1fr;
     flex: 1;
     min-height: 0;
@@ -51,6 +51,7 @@ main {
     overflow: hidden;
     position: relative;
     cursor: grab;
+    container-type: inline-size;
 }
 
 #board-viewport.grabbing {
@@ -93,7 +94,6 @@ section#log {
 #board {
     display: grid;
     grid-template-columns: 10fr 10fr 1fr;
-    aspect-ratio: 21 / 22;
     margin-left: 5px;
     position: absolute;
     top: 0;
@@ -106,26 +106,26 @@ section#log {
 .quadrant {
     display: grid;
     grid-template-columns: repeat(21, 1fr);
-    grid-template-rows: repeat(10, 1fr);
+    grid-template-rows: repeat(10, 3.927cqw);
+    position: relative;
 }
 
 .quadrant.right {
-    margin-left: -14px;
+    margin-left: -24px;
 }
 
 .quadrant.bottom {
-    margin-top: 3px;
+    margin-top: 4px;
 }
 
 .hex, .marker {
     grid-column: span 2;
     position: relative;
+    align-self: start;
 }
 
 .hex {
-    --cell-padding: calc(var(--cell-width) * 2.0 / sqrt(3));
-    position: relative;
-    margin: 0.25px;
+    height: 5.236cqw;
     overflow: visible;
 }
 
@@ -143,7 +143,15 @@ section#log {
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: -1;
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+    pointer-events: none;
+}
+
+.hex > .hex-outline polygon {
+    fill: none;
+    stroke: oklch(from var(--hex-bg, transparent) calc(l * 0.55) c h);
+    stroke-width: 4;
+    vector-effect: non-scaling-stroke;
 }
 
 svg {
@@ -158,8 +166,18 @@ ul li .hex:hover .hex-bg {
 #board .selectable {
     cursor: pointer;
     width: 95%;
-    height: 95%;
     margin: auto;
+}
+
+#board .selectable .hex-outline polygon {
+    stroke: black;
+    stroke-width: 8;
+    animation: selectable-pulse 2s ease-in-out infinite;
+}
+
+@keyframes selectable-pulse {
+    0%, 100%  { stroke-opacity: 0.2; }
+    50%       { stroke-opacity: 1; }
 }
 
 #board .selectable:hover .hex-bg {
@@ -170,9 +188,6 @@ ul li .hex:hover .hex-bg {
     transform: scale(1.25);
     z-index: 10;
     transition: transform 0.1s ease-out;
-}
-
-#board .selected .hex-bg {
     filter: drop-shadow(0 0 3px #f0c040) drop-shadow(0 0 8px rgba(240, 192, 64, 0.8));
 }
 
@@ -277,21 +292,21 @@ ul li .hex:hover .hex-bg {
 
 .tile-counter {
     position: absolute;
-    top: 0;
-    right: 0;
-    width: 48%;
-    height: 48%;
+    top: 0%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 30%;
+    aspect-ratio: 1;
     background: #cc1100;
-    clip-path: polygon(100% 0, 100% 100%, 0 0);
+    border-radius: 50%;
     display: flex;
-    align-items: flex-start;
-    justify-content: flex-end;
-    padding: 4% 6% 0 0;
+    align-items: center;
+    justify-content: center;
     color: white;
     font-size: 0.7rem;
     font-weight: 900;
     line-height: 1;
-    z-index: 2;
+    z-index: 4;
     text-shadow: 0 1px 2px rgba(0,0,0,0.6);
 }
 
@@ -393,7 +408,7 @@ ul li .hex:hover .hex-bg {
 /* Special terrains */
 .hex.terrain-l, .hex.terrain-s {
     width: 95%;
-    height: 95%;
+    height: 4.974cqw;
     margin: auto;
 }
 
@@ -423,8 +438,8 @@ ul li .hex:hover .hex-bg {
 }
 
 .hex .terrain-castlehex {
-    height: inherit;
-    width: inherit;
+    position: absolute;
+    inset: 0;
     background-image: url("silver/castle.svg");
     background-size: 100%;
     background-repeat: no-repeat;
@@ -432,8 +447,8 @@ ul li .hex:hover .hex-bg {
 }
 
 .hex .terrain-nomad {
-    height: inherit;
-    width: inherit;
+    position: absolute;
+    inset: 0;
     background-image: url("silver/nomad.svg");
     background-size: 100%;
     background-repeat: no-repeat;

--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -124,10 +124,17 @@ section#log {
 
 .hex {
     --cell-padding: calc(var(--cell-width) * 2.0 / sqrt(3));
-    border-radius: 15%;
     position: relative;
-    border: 1px solid #0004;
     margin: 0.25px;
+    overflow: visible;
+}
+
+.hex-bg {
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+    position: absolute;
+    inset: 0;
+    background-color: var(--hex-bg, transparent);
+    pointer-events: none;
 }
 
 .hex > .hex-outline {
@@ -144,7 +151,7 @@ svg {
     height: 102%;
 }
 
-ul li .hex:hover {
+ul li .hex:hover .hex-bg {
     background-color: #fd005f;
 }
 
@@ -345,38 +352,38 @@ ul li .hex:hover {
 /* Terrains suitable for building */
 /* canyon */
 .hex.terrain-c {
-    background-color: color-mix(in srgb, #a52a2a, transparent var(--fx-hex-transparency));
+    --hex-bg: color-mix(in srgb, #a52a2a, transparent var(--fx-hex-transparency));
 }
 
 /* desert */
 .hex.terrain-d {
-    background-color: color-mix(in srgb, #ffd700, transparent var(--fx-hex-transparency));
+    --hex-bg: color-mix(in srgb, #ffd700, transparent var(--fx-hex-transparency));
 }
 
 /* flower field */
 .hex.terrain-f {
-    background-color: color-mix(in srgb, darkorchid, transparent var(--fx-hex-transparency));
+    --hex-bg: color-mix(in srgb, darkorchid, transparent var(--fx-hex-transparency));
 }
 
 /* grassland */
 .hex.terrain-g {
-    background-color: color-mix(in srgb, rgb(0,255,5), transparent var(--fx-hex-transparency));
+    --hex-bg: color-mix(in srgb, rgb(0,255,5), transparent var(--fx-hex-transparency));
 }
 
 /* timberland (forest) */
 .hex.terrain-t {
-    background-color: color-mix(in srgb, forestgreen, transparent var(--fx-hex-transparency));
+    --hex-bg: color-mix(in srgb, forestgreen, transparent var(--fx-hex-transparency));
 }
 
 /* Terrains normally not suitable for building */
 /* mountain */
 .hex.terrain-m {
-    background-color: color-mix(in srgb, #444, transparent var(--fx-hex-transparency));
+    --hex-bg: color-mix(in srgb, #444, transparent var(--fx-hex-transparency));
 }
 
 /* water */
 .hex.terrain-w {
-    background-color: color-mix(in srgb, royalblue, transparent var(--fx-hex-transparency));
+    --hex-bg: color-mix(in srgb, royalblue, transparent var(--fx-hex-transparency));
 }
 
 /* Special terrains */
@@ -388,12 +395,12 @@ ul li .hex:hover {
 
 /* location (tiles, nomads) */
 .hex.terrain-l {
-    background-color: color-mix(in srgb, goldenrod, transparent var(--fx-loc-transparency));
+    --hex-bg: color-mix(in srgb, goldenrod, transparent var(--fx-loc-transparency));
 }
 
 /* silver (castle, palace, etc) */
 .hex.terrain-s {
-    background-color: color-mix(in srgb, silver, transparent var(--fx-loc-transparency));
+    --hex-bg: color-mix(in srgb, silver, transparent var(--fx-loc-transparency));
 }
 
 .hex.terrain-s:before, .hex.terrain-l:before {

--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -410,7 +410,8 @@ ul li .hex:hover .hex-bg {
 .hex.terrain-s:before, .hex.terrain-l:before {
     content: "";
     position: absolute;
-    border-radius: 5px;
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+    box-sizing: content-box;
     height: 100%;
     width: 100%;
     background-image: conic-gradient(from var(--angle), black, white, black, white, black);

--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -162,15 +162,18 @@ ul li .hex:hover .hex-bg {
     margin: auto;
 }
 
-#board .selectable:hover {
-    box-shadow: 0 0 10px 5px white;
+#board .selectable:hover .hex-bg {
+    filter: drop-shadow(0 0 5px white) drop-shadow(0 0 2px white);
 }
 
 #board .selected {
     transform: scale(1.25);
-    box-shadow: 0 0 0 2px #f0c040, 0 0 14px 4px rgba(240, 192, 64, 0.7);
     z-index: 10;
-    transition: transform 0.1s ease-out, box-shadow 0.1s ease-out;
+    transition: transform 0.1s ease-out;
+}
+
+#board .selected .hex-bg {
+    filter: drop-shadow(0 0 3px #f0c040) drop-shadow(0 0 8px rgba(240, 192, 64, 0.8));
 }
 
 @property --angle {
@@ -183,7 +186,8 @@ ul li .hex:hover .hex-bg {
     --angle: 0deg;
     content: "";
     position: absolute;
-    border-radius: 5px;
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+    box-sizing: content-box;
     height: 100%;
     width: 100%;
     background-image: conic-gradient(from var(--angle), black, white, black, white, black);

--- a/app/views/games/_quadrant.html.erb
+++ b/app/views/games/_quadrant.html.erb
@@ -22,6 +22,7 @@
           board_col < 10 ? "left" : "right",
           board_row <= 2 ? "top-row" : nil,
           ].compact.join(" ") do %>
+        <div class="hex-bg"></div>
         <% if terrain == "s" && !content.is_a?(Tiles::Tile) %>
           <% silver_kind = quadrant.silver_hex_kind(row, col) %>
           <%= content_tag :div, nil, class: silver_kind == "Nomad" ? "terrain-nomad" : "terrain-castlehex" %>

--- a/app/views/games/_quadrant.html.erb
+++ b/app/views/games/_quadrant.html.erb
@@ -23,6 +23,7 @@
           board_row <= 2 ? "top-row" : nil,
           ].compact.join(" ") do %>
         <div class="hex-bg"></div>
+        <div class="terrain-icon"></div>
         <svg class="hex-outline" viewBox="0 0 100 115.47" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg"><polygon points="50,0 100,28.87 100,86.60 50,115.47 0,86.60 0,28.87"/></svg>
         <% if terrain == "s" && !content.is_a?(Tiles::Tile) %>
           <% silver_kind = quadrant.silver_hex_kind(row, col) %>

--- a/app/views/games/_quadrant.html.erb
+++ b/app/views/games/_quadrant.html.erb
@@ -23,6 +23,7 @@
           board_row <= 2 ? "top-row" : nil,
           ].compact.join(" ") do %>
         <div class="hex-bg"></div>
+        <svg class="hex-outline" viewBox="0 0 100 115.47" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg"><polygon points="50,0 100,28.87 100,86.60 50,115.47 0,86.60 0,28.87"/></svg>
         <% if terrain == "s" && !content.is_a?(Tiles::Tile) %>
           <% silver_kind = quadrant.silver_hex_kind(row, col) %>
           <%= content_tag :div, nil, class: silver_kind == "Nomad" ? "terrain-nomad" : "terrain-castlehex" %>


### PR DESCRIPTION
## Summary

- Replaces square board cells with proper pointy-top hexagons using CSS `clip-path` on a `hex-bg` element, with corrected aspect ratio and interlocking row offsets
- Adds visual polish: hex outlines, selectable pulse animation (conic-gradient spinner), selected-hex glow, counter badge, city hall cluster preview animation, and decorative border on Silver/Location hexes
- Adds small terrain icons (white SVG, bottom-center, 0.65 opacity) to all 7 current terrain types plus stubs for upcoming Marshland and Farmland; implemented via CSS `background-image` so a future high-contrast/colorblind mode needs only a CSS change

## Test plan

- [x] Open a game and confirm all terrain types show their icon at the bottom of each hex
- [x] Confirm icons remain visible when a settlement is placed on the hex
- [x] Confirm Silver and Location hexes show no terrain icon
- [x] Pan and zoom the board; confirm hexes and icons scale correctly
- [x] Confirm selectable hexes pulse and selected hex glows
- [ ] Confirm city hall cluster preview animation shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)