### PR TITLE
Hamburger menu, resign action, global turn-state-bar

### DIFF
--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -835,7 +835,8 @@ ul li .hex:hover .hex-bg {
 }
 
 #dashboard-link-area {
-    padding-left: 0.75rem;
+    padding-left: 0;
+    position: relative;
 }
 
 #sound-controls {
@@ -1280,4 +1281,59 @@ ul li .hex:hover .hex-bg {
     padding: 2px 4px;
     display: block;
     text-align: center;
+}
+
+/* Hamburger menu */
+
+.hamburger-btn {
+    background: none;
+    border: 1px solid #555;
+    border-radius: 3px;
+    color: inherit;
+    cursor: pointer;
+    font-size: 1.1em;
+    line-height: 1;
+    padding: 0.15em 0.5em;
+    margin-left: 0.75rem;
+}
+
+.hamburger-btn:hover { border-color: #888; }
+
+.hamburger-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: #111;
+    border: 1px solid #444;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    min-width: 200px;
+    z-index: 100;
+}
+
+.hamburger-menu.hidden { display: none; }
+
+.hamburger-menu li { border-bottom: 1px solid #333; }
+.hamburger-menu li:last-child { border-bottom: none; }
+
+.hamburger-menu a,
+.hamburger-menu button {
+    display: block;
+    width: 100%;
+    padding: 0.6em 1em;
+    color: var(--clr-ds-text);
+    text-decoration: none;
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    font-size: 0.9em;
+    box-sizing: border-box;
+}
+
+.hamburger-menu a:hover,
+.hamburger-menu button:hover {
+    background: #222;
+    color: var(--clr-ds-text);
 }

--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -832,6 +832,8 @@ ul li .hex:hover .hex-bg {
     grid-template-columns: auto auto 1fr auto;
     align-items: center;
     height: 2.5rem;
+    position: relative;
+    z-index: 2;
 }
 
 #dashboard-link-area {

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -202,6 +202,13 @@ class GamesController < ApplicationController
     @game.broadcast_game_update
   end
 
+  def resign
+    game = Game.find(params[:id])
+    game_player = game.game_players.find_by(player: Current.user)
+    game_player.update!(resigned_at: Time.current) if game_player && !game_player.resigned?
+    redirect_to dashboard_path
+  end
+
   private
 
   def require_game_playing

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -205,8 +205,20 @@ class GamesController < ApplicationController
   def resign
     game = Game.find(params[:id])
     game_player = game.game_players.find_by(player: Current.user)
-    game_player.update!(resigned_at: Time.current) if game_player && !game_player.resigned?
-    redirect_to dashboard_path
+    if game_player && !game_player.resigned?
+      game_player.update!(resigned_at: Time.current)
+      game.move_count += 1
+      game.moves.create!(
+        order: game.move_count,
+        game_player: game_player,
+        action: "resign",
+        message: "#{game_player.player.handle} resigned",
+        deliberate: true,
+        reversible: false
+      )
+      game.complete!
+    end
+    redirect_to game_path(game)
   end
 
   private

--- a/app/javascript/controllers/menu_controller.js
+++ b/app/javascript/controllers/menu_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+
+  connect() {
+    this._closeHandler = (event) => {
+      if (!this.element.contains(event.target)) this._close()
+    }
+    document.addEventListener("click", this._closeHandler)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this._closeHandler)
+  }
+
+  toggle(event) {
+    event.stopPropagation()
+    this.menuTarget.classList.toggle("hidden")
+  }
+
+  close() { this._close() }
+
+  _close() {
+    this.menuTarget.classList.add("hidden")
+  }
+}

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -191,9 +191,11 @@ class Game < ApplicationRecord
   end
 
   def winners
-    return [] if scores.blank?
-    max_total = scores.values.map { |s| s["total"] }.max
-    game_players.select { |gp| scores[gp.order.to_s]["total"] == max_total }
+    return [] unless state == "completed" && scores.present?
+    eligible = game_players.reject(&:resigned?)
+    return eligible if eligible.length < game_players.length
+    max_total = eligible.map { |gp| scores[gp.order.to_s]["total"] }.max
+    eligible.select { |gp| scores[gp.order.to_s]["total"] == max_total }
   end
 
   def instantiate

--- a/app/models/game_player.rb
+++ b/app/models/game_player.rb
@@ -6,6 +6,7 @@
 #  bonus_scores :jsonb            not null
 #  hand         :json
 #  order        :integer
+#  resigned_at  :datetime
 #  supply       :json
 #  taken_from   :json
 #  tiles        :json
@@ -219,5 +220,9 @@ class GamePlayer < ApplicationRecord
     updated = tiles.dup
     updated[idx] = updated[idx].merge("used" => false)
     self.tiles = updated
+  end
+
+  def resigned?
+    resigned_at.present?
   end
 end

--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -1,5 +1,11 @@
 <% my_turn = my_player&.id == game.current_player&.id %>
 
+<% content_for :sound_controls do %>
+  <span id="audio-unlock-prompt" title="Click anywhere to enable sounds">&#128265; click for sound</span>
+  <button id="mute-btn" type="button" aria-label="Toggle mute">&#128266;</button>
+  <input id="volume-slider" type="range" min="0" max="1" step="0.01" aria-label="Volume">
+<% end %>
+
 <% content_for :turn_state do %>
   <%= render partial: "games/turn_state", locals: { game:, engine:, my_turn: } %>
 <% end %>

--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -1,20 +1,24 @@
-<div id="turn-state-bar">
-  <div id="dashboard-link-area">
-    <%= link_to "Dashboard", dashboard_path %>
-  </div>
-  <div id="sound-controls">
-    <span id="audio-unlock-prompt" title="Click anywhere to enable sounds">&#128265; click for sound</span>
-    <button id="mute-btn" type="button" aria-label="Toggle mute">&#128266;</button>
-    <input id="volume-slider" type="range" min="0" max="1" step="0.01"
-           aria-label="Volume">
-  </div>
-  <div id="turn-state">
-    <%= render partial: "games/turn_state", locals: { game:, engine:, my_turn: my_player&.id == game.current_player&.id } %>
-  </div>
-  <div id="end-turn-area">
-    <%= render partial: "games/end_turn", locals: { game:, engine:, my_turn: my_player&.id == game.current_player&.id } %>
-  </div>
-</div>
+<% my_turn = my_player&.id == game.current_player&.id %>
+
+<% content_for :turn_state do %>
+  <%= render partial: "games/turn_state", locals: { game:, engine:, my_turn: } %>
+<% end %>
+
+<% content_for :end_turn do %>
+  <%= render partial: "games/end_turn", locals: { game:, engine:, my_turn: } %>
+<% end %>
+
+<% if my_player && !my_player.resigned? %>
+  <% content_for :menu_items do %>
+    <li>
+      <%= link_to "Resign this game", resign_game_path(game),
+          data: { turbo_method: :post,
+                  turbo_confirm: "Are you sure you want to resign? Other players will continue playing.",
+                  action: "click->menu#close" } %>
+    </li>
+  <% end %>
+<% end %>
+
 <div id="game-area">
     <main>
       <%= render partial: "games/scoring", locals: { game: } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,9 +33,7 @@
           </ul>
         </div>
         <div id="sound-controls">
-          <span id="audio-unlock-prompt" title="Click anywhere to enable sounds">&#128265; click for sound</span>
-          <button id="mute-btn" type="button" aria-label="Toggle mute">&#128266;</button>
-          <input id="volume-slider" type="range" min="0" max="1" step="0.01" aria-label="Volume">
+          <%= yield :sound_controls %>
         </div>
         <div id="turn-state">
           <%= yield :turn_state %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,28 @@
   </head>
 
   <%= tag.body(class: content_for?(:body_class) ? yield(:body_class) : "default") do %>
+    <% if Current.user %>
+      <div id="turn-state-bar" data-controller="menu">
+        <div id="dashboard-link-area">
+          <button type="button" data-action="click->menu#toggle" class="hamburger-btn" aria-label="Menu">&#9776;</button>
+          <ul class="hamburger-menu hidden" data-menu-target="menu">
+            <li><%= link_to "Dashboard", dashboard_path, data: { action: "click->menu#close" } %></li>
+            <%= yield :menu_items %>
+          </ul>
+        </div>
+        <div id="sound-controls">
+          <span id="audio-unlock-prompt" title="Click anywhere to enable sounds">&#128265; click for sound</span>
+          <button id="mute-btn" type="button" aria-label="Toggle mute">&#128266;</button>
+          <input id="volume-slider" type="range" min="0" max="1" step="0.01" aria-label="Volume">
+        </div>
+        <div id="turn-state">
+          <%= yield :turn_state %>
+        </div>
+        <div id="end-turn-area">
+          <%= yield :end_turn %>
+        </div>
+      </div>
+    <% end %>
     <%= yield %>
   <% end %>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,7 @@ Rails.application.routes.draw do
       post :remove_meeple
       post :select_meeple
       post :activate_fort
+      post :resign
     end
   end
 

--- a/db/migrate/20260629191418_add_resigned_at_to_game_players.rb
+++ b/db/migrate/20260629191418_add_resigned_at_to_game_players.rb
@@ -1,0 +1,5 @@
+class AddResignedAtToGamePlayers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :game_players, :resigned_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_13_222737) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_29_191418) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_222737) do
     t.integer "game_id", null: false
     t.json "hand"
     t.integer "order"
+    t.datetime "resigned_at"
     t.json "supply"
     t.json "taken_from"
     t.json "tiles"

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -580,17 +580,20 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".player-tile.tile-active", count: 0
   end
 
-  test "POST resign sets resigned_at on the current user's game_player and redirects to dashboard" do
+  test "POST resign ends the game, logs the resignation, and stays on the game page" do
     game = games(:game2player)
     post resign_game_url(game)
-    assert_redirected_to dashboard_path
+    assert_redirected_to game_path(game)
     assert_not_nil game_players(:chris).reload.resigned_at
+    assert_equal "completed", game.reload.state
+    assert game.moves.exists?(action: "resign")
   end
 
-  test "POST resign redirects to dashboard without error when user is not a player in the game" do
+  test "POST resign does nothing when user is not a player in the game" do
     game = games(:paula_jules_game)
     post resign_game_url(game)
-    assert_redirected_to dashboard_path
+    assert_redirected_to game_path(game)
+    assert_equal "playing", game.reload.state
     assert_nil game_players(:paula_in_paula_jules_game).reload.resigned_at
   end
 end

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -579,6 +579,20 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".player-spinner", count: 0
     assert_select ".player-tile.tile-active", count: 0
   end
+
+  test "POST resign sets resigned_at on the current user's game_player and redirects to dashboard" do
+    game = games(:game2player)
+    post resign_game_url(game)
+    assert_redirected_to dashboard_path
+    assert_not_nil game_players(:chris).reload.resigned_at
+  end
+
+  test "POST resign redirects to dashboard without error when user is not a player in the game" do
+    game = games(:paula_jules_game)
+    post resign_game_url(game)
+    assert_redirected_to dashboard_path
+    assert_nil game_players(:paula_in_paula_jules_game).reload.resigned_at
+  end
 end
 
 class GamesControllerUnauthenticatedTest < ActionDispatch::IntegrationTest

--- a/test/fixtures/game_players.yml
+++ b/test/fixtures/game_players.yml
@@ -7,6 +7,7 @@
 #  bonus_scores :jsonb            not null
 #  hand         :json
 #  order        :integer
+#  resigned_at  :datetime
 #  supply       :json
 #  taken_from   :json
 #  tiles        :json
@@ -81,6 +82,22 @@ chris_in_completed_game:
 paula_in_completed_game:
   player: paula
   game: completed_game
+  supply: <%= { "settlements" => 40 }.to_json %>
+  tiles: <%= [].to_json %>
+  order: 1
+
+paula_in_paula_jules_game:
+  player: paula
+  game: paula_jules_game
+  hand: <%= ["D"].to_json %>
+  supply: <%= { "settlements" => 40 }.to_json %>
+  tiles: <%= [].to_json %>
+  order: 0
+
+jules_in_paula_jules_game:
+  player: jules
+  game: paula_jules_game
+  hand: <%= ["D"].to_json %>
   supply: <%= { "settlements" => 40 }.to_json %>
   tiles: <%= [].to_json %>
   order: 1

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -71,6 +71,19 @@ chris_waiting_game:
   state: "waiting"
   move_count: 0
 
+paula_jules_game:
+  boards: []
+  board_contents: {}
+  deck: []
+  discard: []
+  goals: []
+  current_player: paula_in_paula_jules_game
+  mandatory_count: 0
+  state: "playing"
+  move_count: 0
+  current_action:
+    type: "mandatory"
+
 completed_game:
   boards: []
   board_contents: {}

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -29,6 +29,12 @@ paula:
   approved: true
   password_digest: <%= password_digest %>
 
+jules:
+  handle: "Jules"
+  email_address: jules@example.com
+  approved: true
+  password_digest: <%= password_digest %>
+
 exemplar:
   handle: "Exemplar"
   email_address: exemplar@example.com

--- a/test/models/game_player_test.rb
+++ b/test/models/game_player_test.rb
@@ -6,6 +6,7 @@
 #  bonus_scores :jsonb            not null
 #  hand         :json
 #  order        :integer
+#  resigned_at  :datetime
 #  supply       :json
 #  taken_from   :json
 #  tiles        :json

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -942,6 +942,7 @@ class GameTest < ActiveSupport::TestCase
       chris.order.to_s => { "total" => 10 },
       paula.order.to_s => { "total" => 6 }
     }
+    game.state = "completed"
     game.save
 
     assert_equal [ chris ], game.winners
@@ -955,6 +956,7 @@ class GameTest < ActiveSupport::TestCase
       chris.order.to_s => { "total" => 8 },
       paula.order.to_s => { "total" => 8 }
     }
+    game.state = "completed"
     game.save
 
     assert_equal [ chris, paula ].map(&:id).sort, game.winners.map(&:id).sort
@@ -963,6 +965,33 @@ class GameTest < ActiveSupport::TestCase
   test "winners returns empty when scores are not yet stored" do
     game = games(:game2player)
     assert_empty game.winners
+  end
+
+  test "winners returns empty when game is not completed even if scores are present" do
+    game = games(:game2player)
+    chris = game_players(:chris)
+    paula = game_players(:paula)
+    game.scores = {
+      chris.order.to_s => { "total" => 10 },
+      paula.order.to_s => { "total" => 6 }
+    }
+    game.save
+    assert_empty game.winners
+  end
+
+  test "winners returns the non-resigned player even if they have a lower score" do
+    game = games(:game2player)
+    chris = game_players(:chris)
+    paula = game_players(:paula)
+    game.scores = {
+      chris.order.to_s => { "total" => 10 },
+      paula.order.to_s => { "total" => 6 }
+    }
+    game.state = "completed"
+    game.save
+    chris.update!(resigned_at: Time.current)
+
+    assert_equal [ paula ], game.winners
   end
 
   # ── Live scores ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Moves `#turn-state-bar` to the global layout, visible on every logged-in page (empty center/right slots on non-game pages via `content_for`)
- Replaces the Dashboard link with a ☰ hamburger menu (Stimulus `menu_controller`) containing Dashboard and a Resign item (game pages only, active players only)
- Adds `resigned_at` to `game_players` and a `resign` action: stamps the timestamp, writes a deliberate move to the game log, calls `game.complete!` (ends the game, computes scores, broadcasts the end-game modal), and stays on the game page
- Updates `Game#winners` to require `state == "completed"` and exclude resigned players from contention
- Adds Jules as an approved user fixture and `paula_jules_game` for testing non-player resign behaviour

## Test plan

- [x] Run `bin/test-all` — 906 tests, 0 failures
- [x] Visit dashboard — hamburger bar appears, clicking ☰ shows only Dashboard
- [x] Open a game as a player — turn state and end-turn button populate; ☰ shows Dashboard + Resign
- [x] Click Resign — confirmation dialog appears; confirm → end-game modal shown, game marked completed, log entry visible
- [x] Re-open game — Resign item absent from menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)