### PR TITLE
Send admin email notification on new user signup

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,6 +26,7 @@ class UsersController < ApplicationController
 
     respond_to do |format|
       if @user.save
+        AdminMailer.new_signup(@user).deliver_later
         format.html { redirect_to unapproved_users_url, notice: "User was successfully created." }
         format.json { render :show, status: :created, location: @user }
       else

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,6 @@
+class AdminMailer < ApplicationMailer
+  def new_signup(user)
+    @user = user
+    mail subject: "New signup: #{user.handle}", to: ENV.fetch("ADMIN_EMAIL")
+  end
+end

--- a/app/views/admin_mailer/new_signup.html.erb
+++ b/app/views/admin_mailer/new_signup.html.erb
@@ -1,0 +1,1 @@
+<p><strong><%= @user.handle %></strong> just signed up with <%= @user.email_address %>.</p>

--- a/app/views/admin_mailer/new_signup.text.erb
+++ b/app/views/admin_mailer/new_signup.text.erb
@@ -1,0 +1,1 @@
+<%= @user.handle %> just signed up with <%= @user.email_address %>.

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -75,6 +75,25 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_content
   end
 
+  test "signup enqueues an admin notification email" do
+    assert_enqueued_emails 1 do
+      post users_url, params: { user: {
+        handle: "Barney",
+        email_address: "brubble@example.com",
+        password: "abc123"
+      } }
+    end
+  end
+
+  test "failed signup does not enqueue an admin notification email" do
+    assert_enqueued_emails 0 do
+      post users_url, params: { user: {
+        handle: "Barney",
+        email_address: "brubble@example.com"
+      } }
+    end
+  end
+
   test "new users are not approved" do
     assert_difference("User.count", 1) do
       post users_url, params: { user: {

--- a/test/mailers/admin_mailer_test.rb
+++ b/test/mailers/admin_mailer_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class AdminMailerTest < ActionMailer::TestCase
+  setup do
+    @user = users(:chris)
+    ENV["ADMIN_EMAIL"] = "admin@example.com"
+  end
+
+  test "new_signup sends to ADMIN_EMAIL" do
+    mail = AdminMailer.new_signup(@user)
+    assert_equal [ "admin@example.com" ], mail.to
+  end
+
+  test "new_signup uses the correct subject" do
+    mail = AdminMailer.new_signup(@user)
+    assert_equal "New signup: #{@user.handle}", mail.subject
+  end
+
+  test "new_signup body contains the user's handle and email address" do
+    mail = AdminMailer.new_signup(@user)
+    assert_match @user.handle, mail.body.encoded
+    assert_match @user.email_address, mail.body.encoded
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `AdminMailer#new_signup` triggered from `UsersController#create` on successful save
- Destination address read from `ADMIN_EMAIL` env var
- Includes mailer tests (to, subject, body) and controller tests (enqueued on success, not enqueued on failure)

## Test plan

- [ ] Set `ADMIN_EMAIL` in production env
- [ ] Sign up a new user and confirm notification email arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)