### PR TITLE
Add player Elo rating system

### DIFF
--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -1179,6 +1179,10 @@ ul li .hex:hover .hex-bg {
     font-size: 1.5rem;
 }
 
+.rating-badge {
+    font-size: 0.8rem;
+}
+
 .first-player-marker {
     margin-left: 0.3rem;
     vertical-align: middle;

--- a/app/helpers/rating_helper.rb
+++ b/app/helpers/rating_helper.rb
@@ -3,4 +3,8 @@ module RatingHelper
     provisional = user.rated_games_count < Rating::CONFIG[:provisional_games]
     "#{user.rating}#{"?" if provisional}"
   end
+
+  def rated_list(game)
+    game.players.map { |player| "#{player.handle} (#{rating_badge(player)})" }.join(", ")
+  end
 end

--- a/app/helpers/rating_helper.rb
+++ b/app/helpers/rating_helper.rb
@@ -1,0 +1,6 @@
+module RatingHelper
+  def rating_badge(user)
+    provisional = user.rated_games_count < Rating::CONFIG[:provisional_games]
+    "#{user.rating}#{"?" if provisional}"
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -185,7 +185,10 @@ class Game < ApplicationRecord
     self.scores = Scoring.new(self).compute
     self.mandatory_count = 0
     self.completed_at = Time.current
-    save!
+    transaction do
+      save!
+      Rating.new(self).apply!
+    end
     chat_messages.create!(body: "Game ended.")
     broadcast_end_game
     broadcast_dashboard_update

--- a/app/models/game_player.rb
+++ b/app/models/game_player.rb
@@ -2,18 +2,20 @@
 #
 # Table name: game_players
 #
-#  id           :bigint           not null, primary key
-#  bonus_scores :jsonb            not null
-#  hand         :json
-#  order        :integer
-#  resigned_at  :datetime
-#  supply       :json
-#  taken_from   :json
-#  tiles        :json
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  game_id      :integer          not null
-#  user_id      :integer          not null
+#  id            :bigint           not null, primary key
+#  bonus_scores  :jsonb            not null
+#  hand          :json
+#  order         :integer
+#  rating_after  :integer
+#  rating_before :integer
+#  resigned_at   :datetime
+#  supply        :json
+#  taken_from    :json
+#  tiles         :json
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  game_id       :integer          not null
+#  user_id       :integer          not null
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@
 #  email_address   :string           not null
 #  handle          :string           not null
 #  password_digest :string           not null
+#  rating          :integer          default(1500), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #
@@ -38,5 +39,9 @@ class User < ApplicationRecord
 
   def completed_games
     games.completed
+  end
+
+  def rated_games_count
+    game_players.where.not(rating_after: nil).count
   end
 end

--- a/app/services/rating.rb
+++ b/app/services/rating.rb
@@ -1,0 +1,73 @@
+class Rating
+  CONFIG = { start: 1500, provisional_k: 40, provisional_games: 10, stable_k: 20 }.freeze
+
+  def initialize(game)
+    @game = game
+  end
+
+  def apply!
+    ActiveRecord::Base.transaction do
+      return if already_rated?
+      ranked = build_ranking
+      deltas = compute_deltas(ranked)
+      apply_deltas!(deltas)
+    end
+  end
+
+  private
+
+  def already_rated?
+    @game.game_players.any? { |gp| gp.rating_after.present? }
+  end
+
+  def build_ranking
+    non_resigned, resigned = @game.game_players.partition { |gp| !gp.resigned? }
+    groups = non_resigned
+      .group_by { |gp| @game.scores[gp.order.to_s]["total"] }
+      .sort_by { |total, _| -total }
+      .map(&:last)
+    groups << resigned if resigned.any?
+    groups
+  end
+
+  def compute_deltas(groups)
+    all = groups.flatten
+    rank_of = {}
+    groups.each_with_index { |group, rank| group.each { |gp| rank_of[gp.id] = rank } }
+    ratings = all.index_with { |gp| gp.player.rating }
+
+    all.each_with_object({}) do |gp, deltas|
+      k = k_factor_for(gp.player)
+      total = all.sum do |opp|
+        next 0 if opp.id == gp.id
+        expected = 1.0 / (1 + 10**((ratings[opp] - ratings[gp]) / 400.0))
+        actual =
+          if rank_of[gp.id] < rank_of[opp.id]
+            1.0
+          elsif rank_of[gp.id] > rank_of[opp.id]
+            0.0
+          else
+            0.5
+          end
+        actual - expected
+      end
+      deltas[gp.id] = (k * total).round
+    end
+  end
+
+  def k_factor_for(user)
+    user.rated_games_count < CONFIG[:provisional_games] ? CONFIG[:provisional_k] : CONFIG[:stable_k]
+  end
+
+  def apply_deltas!(deltas)
+    game_players = @game.game_players.to_a
+    users = User.where(id: game_players.map(&:user_id)).lock.index_by(&:id)
+    game_players.each do |gp|
+      user = users.fetch(gp.user_id)
+      rating_before = user.rating
+      rating_after = rating_before + deltas.fetch(gp.id)
+      gp.update!(rating_before: rating_before, rating_after: rating_after)
+      user.update!(rating: rating_after)
+    end
+  end
+end

--- a/app/views/dashboard/_my_games.html.erb
+++ b/app/views/dashboard/_my_games.html.erb
@@ -11,12 +11,12 @@
       </span>
       <%= link_to game_path(game) do %>
         <span>
-          Game <%= game.id %> with <%= game.player_handles %> &mdash; <%= game.turn_state %>
+          Game <%= game.id %> with <%= rated_list(game) %> &mdash; <%= game.turn_state %>
         </span>
       <% end %>
     <% else %>
       <span>
-        Game <%= game.id %> with <%= game.player_handles %> &mdash; <%= game.turn_state %>
+        Game <%= game.id %> with <%= rated_list(game) %> &mdash; <%= game.turn_state %>
       </span>
     <% end %>
   </div>

--- a/app/views/dashboard/_waiting_games.html.erb
+++ b/app/views/dashboard/_waiting_games.html.erb
@@ -3,7 +3,10 @@
   <table>
     <% games.each do |game| %>
       <tr>
-        <td>Game <%= game.id %> &mdash; <%= game.player_handles %></td>
+        <td>
+          Game <%= game.id %> &mdash;
+          <%= game.players.map { |player| "#{player.handle} (#{rating_badge(player)})" }.join(", ") %>
+        </td>
         <td><%= button_to "Join", join_game_path(game) %></td>
       </tr>
     <% end %>

--- a/app/views/dashboard/_waiting_games.html.erb
+++ b/app/views/dashboard/_waiting_games.html.erb
@@ -3,11 +3,11 @@
   <table>
     <% games.each do |game| %>
       <tr>
-        <td>
-          Game <%= game.id %> &mdash;
-          <%= game.players.map { |player| "#{player.handle} (#{rating_badge(player)})" }.join(", ") %>
-        </td>
         <td><%= button_to "Join", join_game_path(game) %></td>
+        <td>
+          Game <%= game.id %>:
+          <%= rated_list(game) %>
+        </td>
       </tr>
     <% end %>
   </table>

--- a/app/views/games/_end_game_modal.html.erb
+++ b/app/views/games/_end_game_modal.html.erb
@@ -35,6 +35,18 @@
             <td class="score-value"><%= scores[player.order.to_s]["total"] %></td>
           <% end %>
         </tr>
+        <% if players.all?(&:rating_after) %>
+          <tr class="rating-row">
+            <td>Rating</td>
+            <% players.each do |player| %>
+              <% delta = player.rating_after - player.rating_before %>
+              <td class="score-value">
+                <%= player.rating_before %> &rarr; <%= player.rating_after %>
+                (<%= delta >= 0 ? "+" : "" %><%= delta %>)
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   <% end %>

--- a/app/views/games/_game_player.html.erb
+++ b/app/views/games/_game_player.html.erb
@@ -8,7 +8,7 @@
         <% end %>
       <% end %>
       <%= player.player.handle %>
-      <span class="rating-badge"><%= rating_badge(player.player) %></span>
+      <span class="rating-badge">(<%= rating_badge(player.player) %>)</span>
       <% if player.order == 0 %>
         <%= content_tag :span, class: "first-player-marker", title: "First player" do %>
           <%= image_tag "first.svg", alt: "First player" %>

--- a/app/views/games/_game_player.html.erb
+++ b/app/views/games/_game_player.html.erb
@@ -8,6 +8,7 @@
         <% end %>
       <% end %>
       <%= player.player.handle %>
+      <span class="rating-badge"><%= rating_badge(player.player) %></span>
       <% if player.order == 0 %>
         <%= content_tag :span, class: "first-player-marker", title: "First player" do %>
           <%= image_tag "first.svg", alt: "First player" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
       <div id="turn-state-bar" data-controller="menu">
         <div id="dashboard-link-area">
           <button type="button" data-action="click->menu#toggle" class="hamburger-btn" aria-label="Menu">
-            &#9776; <%= Current.user.handle %>
+            &#9776; <%= Current.user.handle %> (<%= rating_badge(Current.user) %>)
           </button>
           <ul class="hamburger-menu hidden" data-menu-target="menu">
             <li><%= link_to "Dashboard", dashboard_path, data: { action: "click->menu#close" } %></li>

--- a/db/migrate/20260701130319_add_rating_to_users.rb
+++ b/db/migrate/20260701130319_add_rating_to_users.rb
@@ -1,0 +1,5 @@
+class AddRatingToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :rating, :integer, null: false, default: 1500
+  end
+end

--- a/db/migrate/20260701130344_add_rating_snapshots_to_game_players.rb
+++ b/db/migrate/20260701130344_add_rating_snapshots_to_game_players.rb
@@ -1,0 +1,6 @@
+class AddRatingSnapshotsToGamePlayers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :game_players, :rating_before, :integer
+    add_column :game_players, :rating_after, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_30_223331) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_130344) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -30,6 +30,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_223331) do
     t.integer "game_id", null: false
     t.json "hand"
     t.integer "order"
+    t.integer "rating_after"
+    t.integer "rating_before"
     t.datetime "resigned_at"
     t.json "supply"
     t.json "taken_from"
@@ -237,6 +239,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_223331) do
     t.string "email_address", null: false
     t.string "handle", null: false
     t.string "password_digest", null: false
+    t.integer "rating", default: 1500, null: false
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["handle"], name: "index_users_on_handle", unique: true

--- a/docs/adr/0003-elo-player-ratings.md
+++ b/docs/adr/0003-elo-player-ratings.md
@@ -1,0 +1,36 @@
+# ADR 0003: Elo for player ratings
+
+## Status
+
+Accepted.
+
+## Context
+
+kbc had no way for players to gauge skill or self-select balanced opponents. Two goals drive this feature: incite players to finish games and try to win (a win must gain rating, a loss/resignation must cost it), and let players find opponents of similar skill by showing ratings where they choose a table.
+
+The engine is already N-player-agnostic (scoring, turn order, and `Game#winners` all iterate `game_players`); the only hard 2-player assumption is UI glue. Final per-player point totals already exist in `games.scores`. There was no existing rating code.
+
+## Decision
+
+Plain **Elo**, not Glicko-2: Glicko-2 tracks a per-player rating deviation and volatility, which pays off when match frequency is uneven or opponents are unknown; kbc doesn't have that problem yet, and plain Elo's swings can be tuned with a provisional K-factor. Glicko-2 is the named upgrade path if matchmaking mismatches become a real complaint.
+
+Outcome is **binary and unscaled** — a win is a win, a loss is a loss. No margin scoring: final score scales wildly by goal-set/available tiles, so margin-of-victory would be noise, not signal.
+
+**Resignation counts as a normal loss**, no extra penalty. The incentive to finish a game comes from resigning locking in the loss rather than leaving the outcome ambiguous. Ties are a **draw (0.5 each)**, reusing the existing co-winner case.
+
+**Ranking-based pairwise Elo**, not a single aggregate update: for each player, compute an Elo delta against every other player in the game using their relative rank (win/loss/tie), then sum. This handles N=2 today and N>2 later through one code path — no rewrite needed when more-than-2-player games ship. Resigned players are ranked below every non-resigned player (and tie among themselves at the bottom, though a game can only end with one player left unresigned, so that case cannot arise in practice) regardless of their board total — the point is to always rank a resignation as a loss.
+
+**Storage:** `users.rating` holds the current rating; `game_players.rating_before`/`rating_after` snapshot the value at the moment each game was rated, giving history and delta display without a new table. Provisional game count (`User#rated_games_count`) is derived by counting `game_players` with `rating_after` present, rather than a counter column that needs to stay in sync.
+
+**Update timing:** synchronous inside `Game#complete!`, inside the same transaction as saving scores, guarded so a game can only be rated once. Both natural completion and resignation route through `complete!`, so this is the one entry point.
+
+**K-factor:** starts at 1500; **K=40** for a player's first 10 rated games (provisional, lets new ratings move quickly toward true skill), **K=20** after (stable). Tunable via one `Rating::CONFIG` constant. Ratings show a `?` suffix (e.g. `1500?`) while a player is provisional.
+
+**No backfill.** Only games completed after ship are rated; ratings start fresh at 1500 for everyone.
+
+## Consequences
+
+- New `Rating` service (`app/services/rating.rb`) is the only place Elo math lives; `Game#complete!` calls it once, after scores are computed.
+- Ratings are visible on the waiting-tables list (matchmaking), the end-game modal (delta), the in-game player card, and the nav. A leaderboard is deferred — the display need right now is "can I win this / did I gain," not ranking discovery.
+- Abandonment (games that never finish) is out of scope; turn time-limits are the next feature and will define what "abandoned" means before those games can be rated.
+- If N-player games ship, no rating-engine change is required — the pairwise ranking decomposition already generalizes.

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -11,4 +11,12 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     get dashboard_url
     assert_response :success
   end
+
+  test "waiting tables list shows each creator's rating badge" do
+    post session_url, params: { email_address: "chris@example.com", password: "password" }
+
+    get dashboard_url
+
+    assert_select "td", text: /Paula \(1500\?\)/
+  end
 end

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -273,7 +273,7 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
 
     get game_url(game)
 
-    assert_select ".rating-badge", text: "1500?", count: 2
+    assert_select ".rating-badge", text: "(1500?)", count: 2
   end
 
   test "game show renders rating deltas in the end game modal once rated" do

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -268,6 +268,29 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_select "span#current-action[data-type='mandatory']"
   end
 
+  test "game show renders each player's provisional rating badge" do
+    game = games(:game2player)
+
+    get game_url(game)
+
+    assert_select ".rating-badge", text: "1500?", count: 2
+  end
+
+  test "game show renders rating deltas in the end game modal once rated" do
+    game = games(:game2player)
+    game.update!(
+      state: "completed",
+      scores: { "0" => { "total" => 10 }, "1" => { "total" => 5 } }
+    )
+    game_players(:chris).update!(rating_before: 1500, rating_after: 1510)
+    game_players(:paula).update!(rating_before: 1500, rating_after: 1490)
+
+    get game_url(game)
+
+    assert_select "#end-game-modal .rating-row .score-value", text: /1500.*1510.*\+10/
+    assert_select "#end-game-modal .rating-row .score-value", text: /1500.*1490.*-10/
+  end
+
   test "game show renders treasure bonus scores in the end game modal" do
     game = games(:game2player)
     game.update!(

--- a/test/fixtures/game_players.yml
+++ b/test/fixtures/game_players.yml
@@ -3,18 +3,20 @@
 #
 # Table name: game_players
 #
-#  id           :bigint           not null, primary key
-#  bonus_scores :jsonb            not null
-#  hand         :json
-#  order        :integer
-#  resigned_at  :datetime
-#  supply       :json
-#  taken_from   :json
-#  tiles        :json
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  game_id      :integer          not null
-#  user_id      :integer          not null
+#  id            :bigint           not null, primary key
+#  bonus_scores  :jsonb            not null
+#  hand          :json
+#  order         :integer
+#  rating_after  :integer
+#  rating_before :integer
+#  resigned_at   :datetime
+#  supply        :json
+#  taken_from    :json
+#  tiles         :json
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  game_id       :integer          not null
+#  user_id       :integer          not null
 #
 # Indexes
 #

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -9,6 +9,7 @@
 #  email_address   :string           not null
 #  handle          :string           not null
 #  password_digest :string           not null
+#  rating          :integer          default(1500), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #

--- a/test/helpers/rating_helper_test.rb
+++ b/test/helpers/rating_helper_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class RatingHelperTest < ActionView::TestCase
+  test "shows the plain rating once a player has 10+ rated games" do
+    user = users(:chris)
+    user.update!(rating: 1620)
+    user.define_singleton_method(:rated_games_count) { 10 }
+
+    assert_equal "1620", rating_badge(user)
+  end
+
+  test "marks the rating provisional under 10 rated games" do
+    user = users(:chris)
+    user.update!(rating: 1500)
+    user.define_singleton_method(:rated_games_count) { 3 }
+
+    assert_equal "1500?", rating_badge(user)
+  end
+end

--- a/test/models/game_player_test.rb
+++ b/test/models/game_player_test.rb
@@ -2,18 +2,20 @@
 #
 # Table name: game_players
 #
-#  id           :bigint           not null, primary key
-#  bonus_scores :jsonb            not null
-#  hand         :json
-#  order        :integer
-#  resigned_at  :datetime
-#  supply       :json
-#  taken_from   :json
-#  tiles        :json
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  game_id      :integer          not null
-#  user_id      :integer          not null
+#  id            :bigint           not null, primary key
+#  bonus_scores  :jsonb            not null
+#  hand          :json
+#  order         :integer
+#  rating_after  :integer
+#  rating_before :integer
+#  resigned_at   :datetime
+#  supply        :json
+#  taken_from    :json
+#  tiles         :json
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  game_id       :integer          not null
+#  user_id       :integer          not null
 #
 # Indexes
 #

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1113,6 +1113,19 @@ class GameTest < ActiveSupport::TestCase
     assert_not game.chat_open?
   end
 
+  test "complete! rates the game, updating both users' ratings" do
+    game = new_started_game
+    game.complete!
+    game.reload
+
+    chris_gp = game.game_players.find { |gp| gp.player == users(:chris) }
+    paula_gp = game.game_players.find { |gp| gp.player == users(:paula) }
+    assert_not_nil chris_gp.rating_after
+    assert_not_nil paula_gp.rating_after
+    assert_equal chris_gp.rating_after, users(:chris).reload.rating
+    assert_equal paula_gp.rating_after, users(:paula).reload.rating
+  end
+
   test "complete! posts a system chat message" do
     game = new_started_game
     game.complete!

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,6 +7,7 @@
 #  email_address   :string           not null
 #  handle          :string           not null
 #  password_digest :string           not null
+#  rating          :integer          default(1500), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #

--- a/test/services/rating_test.rb
+++ b/test/services/rating_test.rb
@@ -1,0 +1,122 @@
+require "test_helper"
+
+class RatingTest < ActiveSupport::TestCase
+  test "higher-rated winner gains a small amount, loser loses the same amount" do
+    game = games(:game2player)
+    chris = game_players(:chris)
+    paula = game_players(:paula)
+    users(:chris).update!(rating: 1600)
+    users(:paula).update!(rating: 1400)
+    game.update!(scores: { "0" => { "total" => 10 }, "1" => { "total" => 5 } })
+
+    Rating.new(game).apply!
+
+    assert_equal 1610, users(:chris).reload.rating
+    assert_equal 1390, users(:paula).reload.rating
+  end
+
+  test "upset win by the lower-rated player is a big swing" do
+    game = games(:game2player)
+    chris = game_players(:chris)
+    paula = game_players(:paula)
+    users(:chris).update!(rating: 1600)
+    users(:paula).update!(rating: 1400)
+    game.update!(scores: { "0" => { "total" => 5 }, "1" => { "total" => 10 } })
+
+    Rating.new(game).apply!
+
+    assert_equal 1570, users(:chris).reload.rating
+    assert_equal 1430, users(:paula).reload.rating
+  end
+
+  test "a draw converges ratings toward each other" do
+    game = games(:game2player)
+    chris = game_players(:chris)
+    paula = game_players(:paula)
+    users(:chris).update!(rating: 1600)
+    users(:paula).update!(rating: 1400)
+    game.update!(scores: { "0" => { "total" => 10 }, "1" => { "total" => 10 } })
+
+    Rating.new(game).apply!
+
+    assert_equal 1590, users(:chris).reload.rating
+    assert_equal 1410, users(:paula).reload.rating
+  end
+
+  test "a resigned player ranks as a loss regardless of their board total" do
+    game = games(:game2player)
+    chris = game_players(:chris)
+    paula = game_players(:paula)
+    chris.update!(resigned_at: Time.current)
+    game.update!(scores: { "0" => { "total" => 100 }, "1" => { "total" => 1 } })
+
+    Rating.new(game).apply!
+
+    assert_equal 1480, users(:chris).reload.rating
+    assert_equal 1520, users(:paula).reload.rating
+  end
+
+  test "N-player: a mid-rank finish nets between beating everyone and losing to everyone" do
+    game = Game.create!(state: "completed")
+    first = GamePlayer.create!(game: game, player: users(:chris), order: 0)
+    second = GamePlayer.create!(game: game, player: users(:paula), order: 1)
+    third = GamePlayer.create!(game: game, player: users(:jules), order: 2)
+    game.update!(scores: {
+      "0" => { "total" => 30 },
+      "1" => { "total" => 20 },
+      "2" => { "total" => 10 }
+    })
+
+    Rating.new(game).apply!
+
+    assert_equal 1540, users(:chris).reload.rating
+    assert_equal 1500, users(:paula).reload.rating
+    assert_equal 1460, users(:jules).reload.rating
+  end
+
+  test "applying twice does not double-rate the game" do
+    game = games(:game2player)
+    game.update!(scores: { "0" => { "total" => 10 }, "1" => { "total" => 5 } })
+
+    Rating.new(game).apply!
+    chris_rating_after_first = users(:chris).reload.rating
+    Rating.new(game).apply!
+
+    assert_equal chris_rating_after_first, users(:chris).reload.rating
+  end
+
+  test "writes rating_before/rating_after snapshots and syncs users.rating" do
+    game = games(:game2player)
+    chris = game_players(:chris)
+    game.update!(scores: { "0" => { "total" => 10 }, "1" => { "total" => 5 } })
+
+    Rating.new(game).apply!
+    chris.reload
+
+    assert_equal 1500, chris.rating_before
+    assert_equal chris.rating_after, users(:chris).reload.rating
+  end
+
+  test "K-factor drops from 40 to 20 once a player has 10 rated games" do
+    veteran = users(:jules)
+    10.times do |n|
+      filler = Game.create!(state: "completed")
+      GamePlayer.create!(game: filler, player: veteran, order: 0, rating_after: 1500)
+      GamePlayer.create!(game: filler, player: users(:paula), order: 1, rating_after: 1500)
+    end
+    assert_equal 10, veteran.rated_games_count
+
+    game = games(:game2player)
+    chris = game_players(:chris)
+    game.game_players.destroy(game_players(:paula))
+    veteran_gp = GamePlayer.create!(game: game, player: veteran, order: 1)
+    game.update!(scores: { "0" => { "total" => 10 }, "1" => { "total" => 5 } })
+
+    Rating.new(game).apply!
+
+    # equal ratings (1500 vs 1500), chris (provisional, K=40) wins: +20
+    # veteran (stable, K=20) loses: -10
+    assert_equal 1520, users(:chris).reload.rating
+    assert_equal 1490, veteran.reload.rating
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a plain-Elo player rating system: `users.rating` (default 1500) plus `game_players.rating_before`/`rating_after` snapshots per rated game.
- New `Rating` service applies a ranking-based pairwise Elo update synchronously inside `Game#complete!` (natural end and resignation both route through it), so wins/losses — including resignations — always move a rating. N-player-general from day one, provisional K=40 for a player's first 10 rated games, K=20 after.
- Ratings surface on the waiting-tables list (matchmaking), the end-game modal (before → after delta), the in-game player card, and the nav — with a `?` suffix while provisional.
- ADR-0003 documents the Elo/N-player/no-margin/resignation-as-loss decisions and names Glicko-2 as the upgrade path if matchmaking mismatches become a real complaint.

## Test plan
- [x] `Rating` service unit tests: higher/lower-rated wins, draw, resignation-as-loss, N-player mid-rank, idempotency guard, snapshot writes, provisional/stable K-factor
- [x] `RatingHelper#rating_badge` unit tests
- [x] `Game#complete!` rates both players and syncs `users.rating`
- [x] Controller tests for rating badge on game page, end-game modal delta, and waiting-tables badge
- [x] Full suite (`bin/rails test` + `bin/rails test:system`): 0 failures (pre-existing unrelated `MAIL_FROM` env errors excluded)