### PR TITLE
Show drawn card indicator when Fort tile is active

### DIFF
--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -1324,6 +1324,42 @@ ul li .hex:hover .hex-bg {
     position: relative;
 }
 
+.fort-drawn {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    margin-left: 6px;
+}
+
+.fort-drawn-label {
+    font-size: 9px;
+    line-height: 1;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: gold;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+.fort-drawn .player-card {
+    transform-origin: center;
+    /* deal-in flip, then a settling golden pulse */
+    animation:
+        fort-card-deal 0.55s cubic-bezier(0.2, 0.9, 0.3, 1.25) both,
+        fort-card-glow 1.8s ease-in-out 0.55s infinite;
+}
+
+@keyframes fort-card-deal {
+    0%   { opacity: 0; transform: perspective(500px) translateY(-34px) rotateY(90deg) scale(0.75); }
+    55%  { opacity: 1; transform: perspective(500px) translateY(4px) rotateY(-12deg) scale(1.08); }
+    100% { opacity: 1; transform: perspective(500px) translateY(0) rotateY(0) scale(1); }
+}
+
+@keyframes fort-card-glow {
+    0%, 100% { box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5), 0 0 4px 1px rgba(255, 215, 0, 0.45); }
+    50%      { box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5), 0 0 11px 3px rgba(255, 215, 0, 0.9); }
+}
+
 .meeple-popup {
     position: absolute;
     z-index: 100;

--- a/app/views/games/_game_player.html.erb
+++ b/app/views/games/_game_player.html.erb
@@ -44,6 +44,13 @@
       <% shunned = chosen && card != chosen %>
       <%= content_tag :span, card, title: Boards::Board::TERRAIN_NAMES[card], class: "player-card card-#{card}#{" card-shunned" if shunned}" %>
     <% end %>
+    <% fort_terrain = (game.current_player_id == player.id) ? game.current_action["fort_terrain"] : nil %>
+    <% if fort_terrain %>
+      <span class="fort-drawn" title="Fort drew <%= Boards::Board::TERRAIN_NAMES[fort_terrain] %>">
+        <span class="fort-drawn-label">Fort drew</span>
+        <%= content_tag :span, fort_terrain, class: "player-card card-#{fort_terrain}" %>
+      </span>
+    <% end %>
     <div class="supply-display">
       <div class="supply-settlements">
         <%= content_tag :span, player.supply["settlements"], class: "settlement-count" %>

--- a/test/system/fort_tile_test.rb
+++ b/test/system/fort_tile_test.rb
@@ -34,5 +34,6 @@ class FortTileSystemTest < ApplicationSystemTestCase
 
     assert_selector "#current-action[data-type='fort']", visible: false
     assert_text "Chris drew a Desert card"
+    assert_selector ".fort-drawn .player-card.card-D"
   end
 end


### PR DESCRIPTION
## What

When a player activates a Fort tile, a terrain card is drawn (and discarded) to determine where they build. This adds a **visual indicator of that drawn card** in the active player's hand row.

- A **"Fort drew"** label + terrain card chip appears while the Fort phase is active, reading `current_action["fort_terrain"]` and reusing the existing `.player-card card-#{terrain}` visual.
- **Flourish:** the chip flips in with a 3D "deal" animation, then settles into an infinite golden glow so it stays legible during the build.

Complements the three existing indicators (turn state, game log entry, selectable hexes on the map) with a direct, always-visible card.

## Testing

TDD — added a system-test assertion (`test/system/fort_tile_test.rb`) that the drawn-card chip renders with the correct terrain after activation. Animation itself isn't assertable; the test pins the element + terrain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)