### PR TITLE
Share active-player board view with all viewers

### DIFF
--- a/app/javascript/gameboard.js
+++ b/app/javascript/gameboard.js
@@ -1,6 +1,8 @@
 function enableClicks() {
   document.querySelector("#board").
     addEventListener("click", function (e) {
+      const myTurnFlag = document.getElementById("my-turn-flag");
+      if (!myTurnFlag || myTurnFlag.dataset.myTurn !== "true") return;
       const hex = e.target.closest(".hex");
       if (!hex || !hex.classList.contains("selectable")) {
         return;
@@ -23,8 +25,8 @@ function unmarkAvailableCells() {
 
 function prepForMove() {
   unmarkAvailableCells();
-  const myTurnFlag = document.getElementById("my-turn-flag");
-  if (!myTurnFlag || myTurnFlag.dataset.myTurn !== "true") return;
+  // All viewers see selectable/selected hexes so observers can follow the
+  // active player's move; clicking is gated to the current player in enableClicks.
   const actionEl = document.getElementById("current-action");
   if (!actionEl) return;
 

--- a/app/views/games/_tiles.html.erb
+++ b/app/views/games/_tiles.html.erb
@@ -28,7 +28,7 @@
         </div>
       <% end %>
     <% else %>
-      <% active = my_turn && !used && game.current_action["type"] == type && marked_active_type != type %>
+      <% active = player.id == game.current_player_id && !used && game.current_action["type"] == type && marked_active_type != type %>
       <% marked_active_type = type if active %>
       <% activatable = my_turn && engine.tile_activatable?(tile) %>
       <% state = active ? "tile-active" : used ? "tile-used" : activatable ? "tile-activatable" : "tile-inactive" %>

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -56,6 +56,19 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".player-tile.tile-used .tile-container.mandatory", count: 0
   end
 
+  test "the current player's active tile shows as tile-active to other players" do
+    # paula_turn_game: paula is the current player; chris (logged in) is watching.
+    game = games(:paula_turn_game)
+    game.update!(current_action: { "type" => "farm" })
+    game_players(:paula_in_paula_turn_game).update!(tiles: [ { "klass" => "FarmTile", "used" => false } ])
+    game_players(:chris_in_paula_turn_game).update!(tiles: [ { "klass" => "FarmTile", "used" => false } ])
+
+    get game_url(game)
+
+    # Only the current player's (paula's) farm tile is active, not the observer's own.
+    assert_select ".player-tile.tile-active .tile-container.farm", count: 1
+  end
+
   test "select_action sets current_action type on the game" do
     game = games(:game2player)
     post select_action_game_url(game), params: { action_type: "paddock" }


### PR DESCRIPTION
## What

When it's not your turn, your board now shows the same selection state the active player sees — so you can follow which tile is selected and which spaces are selectable.

- **Selected tile:** `tile-active` is now keyed on *"this player is the current player"* instead of the viewer's `my_turn`, so the active tile lights up for every viewer (`_tiles.html.erb`).
- **Selectable/selected hexes:** `prepForMove` no longer bails out for observers — the buildable-cell data was already broadcast to all viewers in `_turn_state`, so observers just get the same pulsing hexes (`gameboard.js`).
- **Interaction stays gated:** activate buttons remain behind `my_turn`, and the my-turn guard moved into `enableClicks` so observers *see* selectable hexes but can't click-submit.

## Testing

- TDD controller test (`games_controller_test.rb`): an observer sees the current player's active tile, while their own matching tile stays inactive.
- The JS/hex half was verified in a throwaway browser test (observer sees `.selectable` on another player's turn) and by manual testing; not committed since there's no JS test infra.
- Full suite green: 942 unit + 7 system, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)