### PR TITLE
ci: fix broken CI (postgres service, MAIL_FROM, brakeman false positives)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
         env:
           RAILS_ENV: test
           DB_HOST: localhost
+          MAIL_FROM: test@example.com
         run: bin/rails db:test:prepare test test:system
 
       - name: Keep screenshots from failed system tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    # services:
-    #  redis:
-    #    image: redis
-    #    ports:
-    #      - 6379:6379
-    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git pkg-config google-chrome-stable
@@ -78,7 +81,7 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
-          # REDIS_URL: redis://localhost:6379/0
+          DB_HOST: localhost
         run: bin/rails db:test:prepare test test:system
 
       - name: Keep screenshots from failed system tests

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,304 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "b9330dadeffdaab3d869917999d414d3d0d2f032806531ce432312995ea0c80c",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/games/_quadrant.html.erb",
+      "line": 48,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Tiles::Tile.description",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "games/_board",
+          "line": 1,
+          "file": "app/views/games/_board.html.erb",
+          "rendered": {
+            "name": "games/_quadrant",
+            "file": "app/views/games/_quadrant.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "games/_quadrant"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        79
+      ],
+      "note": "False positive: description strings are built from hardcoded class names and DESCRIPTION constants (see Tiles::Tile#description), not user input. The <br> tags are intentionally rendered unescaped."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "d631a515636967e29ae958bff584a9aaf0b8ff4a2fef78f56c26c879a67d5e78",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/games/_tiles.html.erb",
+      "line": 21,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Tiles::Tile.for_klass(tile[\"klass\"]).new(0).description",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "games/_game",
+          "line": 38,
+          "file": "app/views/games/_game.html.erb",
+          "rendered": {
+            "name": "games/_players",
+            "file": "app/views/games/_players.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "games/_players",
+          "line": 30,
+          "file": "app/views/games/_players.html.erb",
+          "rendered": {
+            "name": "games/_game_player",
+            "file": "app/views/games/_game_player.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "games/_game_player",
+          "line": 72,
+          "file": "app/views/games/_game_player.html.erb",
+          "rendered": {
+            "name": "games/_tiles",
+            "file": "app/views/games/_tiles.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "games/_tiles"
+      },
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        79
+      ],
+      "note": "False positive: description strings are built from hardcoded class names and DESCRIPTION constants (see Tiles::Tile#description), not user input. The <br> tags are intentionally rendered unescaped."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "d631a515636967e29ae958bff584a9aaf0b8ff4a2fef78f56c26c879a67d5e78",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/games/_tiles.html.erb",
+      "line": 27,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Tiles::Tile.for_klass(tile[\"klass\"]).new(0).description",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "games/_game",
+          "line": 38,
+          "file": "app/views/games/_game.html.erb",
+          "rendered": {
+            "name": "games/_players",
+            "file": "app/views/games/_players.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "games/_players",
+          "line": 30,
+          "file": "app/views/games/_players.html.erb",
+          "rendered": {
+            "name": "games/_game_player",
+            "file": "app/views/games/_game_player.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "games/_game_player",
+          "line": 72,
+          "file": "app/views/games/_game_player.html.erb",
+          "rendered": {
+            "name": "games/_tiles",
+            "file": "app/views/games/_tiles.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "games/_tiles"
+      },
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        79
+      ],
+      "note": "False positive: description strings are built from hardcoded class names and DESCRIPTION constants (see Tiles::Tile#description), not user input. The <br> tags are intentionally rendered unescaped."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "d631a515636967e29ae958bff584a9aaf0b8ff4a2fef78f56c26c879a67d5e78",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/games/_tiles.html.erb",
+      "line": 42,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Tiles::Tile.for_klass(tile[\"klass\"]).new(0).description",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "games/_game",
+          "line": 38,
+          "file": "app/views/games/_game.html.erb",
+          "rendered": {
+            "name": "games/_players",
+            "file": "app/views/games/_players.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "games/_players",
+          "line": 30,
+          "file": "app/views/games/_players.html.erb",
+          "rendered": {
+            "name": "games/_game_player",
+            "file": "app/views/games/_game_player.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "games/_game_player",
+          "line": 72,
+          "file": "app/views/games/_game_player.html.erb",
+          "rendered": {
+            "name": "games/_tiles",
+            "file": "app/views/games/_tiles.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "games/_tiles"
+      },
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        79
+      ],
+      "note": "False positive: description strings are built from hardcoded class names and DESCRIPTION constants (see Tiles::Tile#description), not user input. The <br> tags are intentionally rendered unescaped."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "d631a515636967e29ae958bff584a9aaf0b8ff4a2fef78f56c26c879a67d5e78",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/games/_tiles.html.erb",
+      "line": 55,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Tiles::Tile.for_klass(tile[\"klass\"]).new(0).description",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "games/_game",
+          "line": 38,
+          "file": "app/views/games/_game.html.erb",
+          "rendered": {
+            "name": "games/_players",
+            "file": "app/views/games/_players.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "games/_players",
+          "line": 30,
+          "file": "app/views/games/_players.html.erb",
+          "rendered": {
+            "name": "games/_game_player",
+            "file": "app/views/games/_game_player.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "games/_game_player",
+          "line": 72,
+          "file": "app/views/games/_game_player.html.erb",
+          "rendered": {
+            "name": "games/_tiles",
+            "file": "app/views/games/_tiles.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "games/_tiles"
+      },
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        79
+      ],
+      "note": "False positive: description strings are built from hardcoded class names and DESCRIPTION constants (see Tiles::Tile#description), not user input. The <br> tags are intentionally rendered unescaped."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "d631a515636967e29ae958bff584a9aaf0b8ff4a2fef78f56c26c879a67d5e78",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/games/_tiles.html.erb",
+      "line": 61,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Tiles::Tile.for_klass(tile[\"klass\"]).new(0).description",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "games/_game",
+          "line": 38,
+          "file": "app/views/games/_game.html.erb",
+          "rendered": {
+            "name": "games/_players",
+            "file": "app/views/games/_players.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "games/_players",
+          "line": 30,
+          "file": "app/views/games/_players.html.erb",
+          "rendered": {
+            "name": "games/_game_player",
+            "file": "app/views/games/_game_player.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "games/_game_player",
+          "line": 72,
+          "file": "app/views/games/_game_player.html.erb",
+          "rendered": {
+            "name": "games/_tiles",
+            "file": "app/views/games/_tiles.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "games/_tiles"
+      },
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        79
+      ],
+      "note": "False positive: description strings are built from hardcoded class names and DESCRIPTION constants (see Tiles::Tile#description), not user input. The <br> tags are intentionally rendered unescaped."
+    }
+  ],
+  "updated": "2026-07-03 14:21:22 +0000",
+  "brakeman_version": "8.0.5"
+}


### PR DESCRIPTION
The CI workflow has been silently broken for months (GitHub Actions was disabled repo-wide, and even before that every run failed):
- test job had no postgres service, so db:test:prepare/test/test:system always failed with ConnectionNotEstablished
- test job never set MAIL_FROM, so app boot failed in test env
- brakeman flagged 6 false-positive XSS warnings on Tile#description (hardcoded content, no user input)

Re-enabled Actions, fixed all three, and set up branch protection requiring lint/scan_js/scan_ruby/test to pass before merging to main.