### PR TITLE
Enrich the game log for detailed game analysis

### DIFF
--- a/app/assets/stylesheets/game_board.css
+++ b/app/assets/stylesheets/game_board.css
@@ -149,7 +149,7 @@ section#log-chat {
     &.c { background-color: oklch(from var(--clr-p-c) l c h / 30%); }
     &.d { background-color: oklch(from var(--clr-p-d) l c h / 30%); }
     &.e { background-color: oklch(from var(--clr-p-e) l c h / 30%); }
-    &.system { opacity: 0.7; font-style: italic; }
+    &.system { background-color: oklch(from gray l c h / 30%); opacity: 0.7; font-style: italic; }
 }
 
 .chat-message .handle {

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -10,6 +10,7 @@ class GamesController < ApplicationController
     @game.add_player(Current.user)
     respond_to do |format|
       if @game.save
+        log_table_opened
         @game.broadcast_dashboard_update
         format.html { redirect_to dashboard_path, notice: "Game created" }
         format.json { render :show, status: :created, location: @game }
@@ -106,6 +107,7 @@ class GamesController < ApplicationController
       Rails.logger.error "ERROR saving game: #{@game.errors.inspect}"
       return
     end
+    log_table_joined
     # MVP: 2 players every game, so just start it now
     @game.start
     @game.broadcast_game_update
@@ -222,6 +224,42 @@ class GamesController < ApplicationController
   end
 
   private
+
+  def log_table_opened
+    game_player = @game.game_players.find_by(player: Current.user)
+    @game.move_count = (@game.move_count || 0) + 1
+    @game.moves.create!(
+      order: @game.move_count,
+      game_player: game_player,
+      action: "open_table",
+      message: "#{game_player.player.handle} opened the table",
+      deliberate: true,
+      reversible: false
+    )
+    @game.move_count += 1
+    @game.moves.create!(
+      order: @game.move_count,
+      action: "game_options",
+      message: "Game options: None available",
+      deliberate: true,
+      reversible: false
+    )
+    @game.save!
+  end
+
+  def log_table_joined
+    game_player = @game.game_players.find_by(player: Current.user)
+    @game.move_count = (@game.move_count || 0) + 1
+    @game.moves.create!(
+      order: @game.move_count,
+      game_player: game_player,
+      action: "join_table",
+      message: "#{game_player.player.handle} joined the table",
+      deliberate: true,
+      reversible: false
+    )
+    @game.save!
+  end
 
   def require_game_playing
     @game = Current.user.games.find(params[:id])

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -94,10 +94,11 @@ class Game < ApplicationRecord
     else
       Rails.logger.debug "FORCING start of game #{id} in state #{state}"
       reset_players
+      self.moves.destroy_all
     end
-    self.moves.destroy_all
     self.state = "playing"
-    self.move_count = 0
+    self.move_count = (move_count || 0) + 1
+    moves.build(order: move_count, action: "start_game", message: "Game started.", deliberate: false, reversible: false)
     self.mandatory_count = MANDATORY_COUNT
     select_boards(options)
     populate_boards(options)
@@ -366,17 +367,29 @@ class Game < ApplicationRecord
     while options[:include_boards] && !options[:include_boards].all? { |b| boards.any? { |bid, _| bid == b } }
       self.boards = (min..max).to_a.sample(4).map { |id| [ id, rand(2) ] }
     end
+    self.move_count += 1
+    moves.build(
+      order: move_count,
+      action: "select_boards",
+      message: "Boards selected: #{boards.inspect}",
+      payload: { "boards" => boards },
+      deliberate: false,
+      reversible: false
+    )
     save
   end
 
   def populate_boards(options = {})
     state = BoardState.new
     instantiate
+    placements = []
     @board.map.each_with_index do |board, i|
       board.location_hexes.each do |loc|
         # MVP (and base game) always have 2 tiles per location
         row, col = overall_location(i, loc[:r], loc[:c])
-        state.place_tile(row, col, "#{loc[:k]}Tile", 2)
+        klass = "#{loc[:k]}Tile"
+        state.place_tile(row, col, klass, 2)
+        placements << { row:, col:, klass:, qty: 2 }
       end
     end
     nomad_pool = Boards::Board::NOMAD_TILE_POOL.shuffle
@@ -387,12 +400,23 @@ class Game < ApplicationRecord
       board_section.silver_hexes.select { |h| h[:k] == "Nomad" }.each do |nomad_hex|
         row, col = overall_location(i, nomad_hex[:r], nomad_hex[:c])
         klass = nomad_pool.shift
-        state.place_tile(row, col, klass, 1) if klass
+        next unless klass
+        state.place_tile(row, col, klass, 1)
+        placements << { row:, col:, klass:, qty: 1 }
       end
     end
     self.board_contents = state
     @board = nil # board was created before tiles were placed; reset so next instantiate is fresh
     Rails.logger.debug("CONTENT AT START: #{self.board_contents}")
+    self.move_count = (move_count || 0) + 1
+    moves.build(
+      order: move_count,
+      action: "populate_boards",
+      message: "Tiles placed: #{placements.map { |p| "[#{p[:row]},#{p[:col]}] #{p[:klass]} x#{p[:qty]}" }.join(', ')}",
+      payload: { "tiles" => placements },
+      deliberate: false,
+      reversible: false
+    )
   end
 
   def initialize_terrain_deck

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -15,7 +15,7 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  game_id         :bigint           not null
-#  game_player_id  :bigint           not null
+#  game_player_id  :bigint
 #
 # Indexes
 #
@@ -43,7 +43,7 @@ class Move < ApplicationRecord
   }.freeze
 
   belongs_to :game
-  belongs_to :game_player
+  belongs_to :game_player, optional: true
 
   after_create_commit :broadcast_sound
 

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -990,7 +990,7 @@ class TurnEngine
       from: "supply",
       to: "[#{row}, #{col}]",
       payload: payload,
-      message: "#{game_player.player.handle} built a settlement on #{Boards::Board::TERRAIN_NAMES[terrain]}"
+      message: "#{game_player.player.handle} built a settlement on #{Boards::Board::TERRAIN_NAMES[terrain]} at [#{row}, #{col}]"
     )
     @game.board_contents_will_change!
     @game.board_contents.place_settlement(row, col, game_player.order)
@@ -1110,7 +1110,7 @@ class TurnEngine
       from: tile[:key],
       to: "player_#{game_player.order}",
       payload: { "klass" => tile[:klass], "qty_before" => qty_before },
-      message: "#{game_player.player.handle} picked up #{/\A[AEIOU]/.match?(tile[:klass]) ? "an" : "a"} #{tile[:klass].delete_suffix("Tile")} tile"
+      message: "#{game_player.player.handle} picked up #{/\A[AEIOU]/.match?(tile[:klass]) ? "an" : "a"} #{tile[:klass].delete_suffix("Tile")} tile at #{tile[:key]}"
     )
     @game.board_contents_will_change!
     @game.board_contents.decrement_tile(*Coordinate.from_key(tile[:key]))

--- a/app/views/games/_log.html.erb
+++ b/app/views/games/_log.html.erb
@@ -1,7 +1,7 @@
 <h1>Game Log</h1>
 <% game.moves.includes(:game_player).order(created_at: :desc).each do |move| %>
   <% next if move.message.blank? %>
-  <div class="move <%= 'abcde'.chars[move.game_player.order] %>">
+  <div class="move <%= move.game_player ? 'abcde'.chars[move.game_player.order] : 'system' %>">
     <%= move.message %>
   </div>
 <% end %>

--- a/db/migrate/20260703151655_change_game_player_id_null_on_moves.rb
+++ b/db/migrate/20260703151655_change_game_player_id_null_on_moves.rb
@@ -1,0 +1,5 @@
+class ChangeGamePlayerIdNullOnMoves < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :moves, :game_player_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_01_130344) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_151655) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -70,7 +70,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_01_130344) do
     t.boolean "deliberate"
     t.string "from"
     t.bigint "game_id", null: false
-    t.bigint "game_player_id", null: false
+    t.bigint "game_player_id"
     t.string "message"
     t.integer "order"
     t.jsonb "payload"

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -56,6 +56,15 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".player-tile.tile-used .tile-container.mandatory", count: 0
   end
 
+  test "game show renders a system log entry (no game_player) as a system move" do
+    game = games(:game2player)
+    game.moves.create!(game_player: nil, action: "end_game", message: "Game ended.", order: 1)
+
+    get game_url(game)
+
+    assert_select ".move.system", text: "Game ended."
+  end
+
   test "the current player's active tile shows as tile-active to other players" do
     # paula_turn_game: paula is the current player; chris (logged in) is watching.
     game = games(:paula_turn_game)
@@ -360,6 +369,23 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to dashboard_path
   end
 
+  test "POST create logs the table opening and game options as deliberate, irreversible moves" do
+    post games_url
+    game = Game.last
+
+    opened = game.moves.find_by(action: "open_table")
+    assert_equal "Chris opened the table", opened.message
+    assert_equal game.game_players.find_by(player: users(:chris)), opened.game_player
+    assert opened.deliberate
+    assert_not opened.reversible
+
+    options = game.moves.find_by(action: "game_options")
+    assert_equal "Game options: None available", options.message
+    assert_nil options.game_player_id
+    assert options.deliberate
+    assert_not options.reversible
+  end
+
   test "POST action with mandatory current_action dispatches build_settlement" do
     game = games(:game2player)
     chris = game_players(:chris)
@@ -432,6 +458,20 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     post join_game_url(game)
 
     assert_redirected_to game_path(game)
+  end
+
+  test "POST join logs the joining player as a deliberate, irreversible move" do
+    game = Game.create!(state: "waiting")
+    game.add_player(users(:chris))
+
+    post session_url, params: { email_address: "paula@example.com", password: "password" }
+    post join_game_url(game)
+
+    joined = game.reload.moves.find_by(action: "join_table")
+    assert_equal "Paula joined the table", joined.message
+    assert_equal game.game_players.find_by(player: users(:paula)), joined.game_player
+    assert joined.deliberate
+    assert_not joined.reversible
   end
 
   test "POST undo_move redirects to the game" do

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -864,6 +864,15 @@ class GameTest < ActiveSupport::TestCase
     assert_match(/picked up an Oasis tile/, pickup_move.message)
   end
 
+  test "pick_up_tile message includes the tile's location" do
+    game = game_with_tile_at_2_7(qty: 2)
+
+    engine(game).build_settlement(1, 7)
+
+    pickup_move = game.moves.find_by(action: "pick_up_tile")
+    assert_includes pickup_move.message, "[2, 7]"
+  end
+
   test "forfeit_tile stores tile klass in payload" do
     game = games(:game2player)
     chris = game_players(:chris)
@@ -1217,6 +1226,47 @@ class GameTest < ActiveSupport::TestCase
   test "start randomizes board selection across games" do
     boards_seen = 10.times.map { new_started_game.boards.map(&:first) }
     assert boards_seen.uniq.size > 1, "expected varied board selection, got always #{boards_seen.first}"
+  end
+
+  test "start logs a system move (no game_player) recording the game started" do
+    game = new_started_game
+
+    move = game.moves.find_by(action: "start_game")
+    assert_equal "Game started.", move.message
+    assert_nil move.game_player_id
+    assert_not move.deliberate
+    assert_not move.reversible
+  end
+
+  test "start logs a system move recording the selected boards" do
+    game = new_started_game
+
+    move = game.moves.find_by(action: "select_boards")
+    assert_equal "Boards selected: #{game.boards.inspect}", move.message
+    assert_equal game.boards, move.payload["boards"]
+    assert_nil move.game_player_id
+    assert_not move.deliberate
+    assert_not move.reversible
+  end
+
+  test "start logs a single system move recording every tile placement" do
+    game = new_started_game
+
+    move = game.moves.find_by(action: "populate_boards")
+    tiles = move.payload["tiles"]
+    assert tiles.size > 0
+    tiles.each do |t|
+      assert t.key?("row")
+      assert t.key?("col")
+      assert t.key?("klass")
+      assert t.key?("qty")
+    end
+
+    first = tiles.first
+    assert_includes move.message, "[#{first['row']},#{first['col']}] #{first['klass']} x#{first['qty']}"
+    assert_nil move.game_player_id
+    assert_not move.deliberate
+    assert_not move.reversible
   end
 
   test "broadcast_game_update broadcasts dashboard update to participants" do

--- a/test/models/move_test.rb
+++ b/test/models/move_test.rb
@@ -15,7 +15,7 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  game_id         :bigint           not null
-#  game_player_id  :bigint           not null
+#  game_player_id  :bigint
 #
 # Indexes
 #
@@ -109,6 +109,12 @@ class MoveTest < ActiveSupport::TestCase
     assert_no_turbo_stream_broadcasts("game_#{game.id}") do
       game.moves.create!(game_player: gp, action: "score_goal", order: 2)
     end
+  end
+
+  test "a system move (no game_player) can be created" do
+    game = games(:game2player)
+    move = game.moves.create!(game_player: nil, action: "end_game", order: 1)
+    assert_nil move.game_player_id
   end
 
   test "creating a Move with a malicious select_action payload does not broadcast" do

--- a/test/services/turn_engine_test.rb
+++ b/test/services/turn_engine_test.rb
@@ -21,6 +21,17 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_equal 39, @game.current_player.supply["settlements"]
   end
 
+  test "build_settlement logs the location in the move message" do
+    force_hand("G")
+    spot = empty_hexes_of("G", 1).first
+
+    @engine.build_settlement(*spot)
+    @game.reload
+
+    move = @game.moves.find_by(action: "build")
+    assert_includes move.message, "[#{spot[0]}, #{spot[1]}]"
+  end
+
   test "mandatory builds gate turn_endable?" do
     force_hand("G")
 
@@ -65,13 +76,14 @@ class TurnEngineTest < ActiveSupport::TestCase
     assert_equal 39, player.reload.supply["settlements"]
     assert @engine.undo_allowed?
 
-    @engine.undo_last_move
+    assert_difference("@game.moves.count", -1) do
+      @engine.undo_last_move
+    end
     @game.reload
 
     assert_equal 3, @game.mandatory_count
     assert_equal 40, player.reload.supply["settlements"]
     assert @game.board_contents.empty?(*spot)
-    assert_equal 0, @game.moves.count
   end
 
   test "building adjacent to a tile location picks it up and decrements qty" do
@@ -324,11 +336,12 @@ class TurnEngineTest < ActiveSupport::TestCase
     @engine.select_action("paddock")
     assert_equal "paddock", @game.reload.current_action["type"]
 
-    @engine.undo_last_move
+    assert_difference("@game.moves.count", -1) do
+      @engine.undo_last_move
+    end
     @game.reload
 
     assert_equal "mandatory", @game.current_action["type"]
-    assert_equal 0, @game.moves.count
   end
 
   test "select_action for paddock preserves klass" do
@@ -511,11 +524,12 @@ class TurnEngineTest < ActiveSupport::TestCase
     @engine.select_settlement(5, 5)
     assert_equal "[5, 5]", @game.reload.current_action["from"]
 
-    @engine.undo_last_move
+    assert_difference("@game.moves.count", -1) do
+      @engine.undo_last_move
+    end
     @game.reload
 
     assert_nil @game.current_action["from"]
-    assert_equal 0, @game.moves.count
   end
 
   test "end_turn creates an end_game move when the last player ends and game is ending" do
@@ -1421,13 +1435,14 @@ class TurnEngineTest < ActiveSupport::TestCase
       { "klass" => "OutpostTile", "from" => "[3, 3]", "used" => false }
     ])
 
-    @engine.activate_outpost
+    assert_difference("@game.moves.count", 1) do
+      @engine.activate_outpost
+    end
     @game.reload
 
     assert @game.current_action["outpost_active"]
     outpost = @game.current_player.tiles.find { |t| t["klass"] == "OutpostTile" }
     assert outpost["used"]
-    assert_equal 1, @game.moves.count
     assert_equal "activate_outpost", @game.moves.last.action
   end
 
@@ -1523,13 +1538,14 @@ class TurnEngineTest < ActiveSupport::TestCase
     @game.reload
     assert @game.current_action["outpost_active"]
 
-    @engine.undo_last_move
+    assert_difference("@game.moves.count", -1) do
+      @engine.undo_last_move
+    end
     @game.reload
 
     assert_nil @game.current_action["outpost_active"]
     outpost = @game.current_player.tiles.find { |t| t["klass"] == "OutpostTile" }
     assert_equal false, outpost["used"]
-    assert_equal 0, @game.moves.count
   end
 
   test "undo of an Outpost build restores the active Outpost build state" do
@@ -2094,18 +2110,17 @@ class TurnEngineTest < ActiveSupport::TestCase
       { "klass" => "FortTile", "from" => "[3, 3]", "used" => false }
     ])
 
-    @engine.activate_fort_tile
+    assert_difference("@game.moves.count", 2) do
+      @engine.activate_fort_tile
+    end
     @game.reload
 
-    moves = @game.moves.order(:order)
-    assert_equal 2, moves.count
+    fort_move, draw_move = @game.moves.order(:order).last(2)
 
-    fort_move = moves.first
     assert_equal "activate_fort", fort_move.action
     assert fort_move.deliberate
     assert_not fort_move.reversible
 
-    draw_move = moves.last
     assert_equal "draw_fort_card", draw_move.action
     assert_not draw_move.deliberate
     assert_not draw_move.reversible
@@ -2162,10 +2177,12 @@ class TurnEngineTest < ActiveSupport::TestCase
     ])
     @game.update!(current_action: { "type" => "fort", "klass" => "FortTile", "fort_terrain" => "G" })
 
-    result = @engine.activate_fort_tile
+    result = nil
+    assert_no_difference("@game.moves.count") do
+      result = @engine.activate_fort_tile
+    end
 
     assert_equal "Not available", result
-    assert_equal 0, @game.reload.moves.count
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `moves.game_player_id` is now nullable, so system-authored log entries (no player) can exist — mirrors the existing `ChatMessage` pattern.
- New Move entries capture pregame/setup events for post-game analysis: table opened, player joined, game started, boards selected, and every tile placement (collected into one Move with a structured `payload["tiles"]`).
- `build` and `pick_up_tile` move messages now include the location.
- Fixed `Game#start` unconditionally calling `moves.destroy_all` on every start (even the normal 2nd-player-joins path), which was wiping the new pregame log entries the instant a game started. Now only the force-restart path wipes history.

## Test plan
- [x] `bin/test-all` (full suite, unit + system) green