### PR TITLE
Continue enriching the game log for analysis

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -385,8 +385,8 @@ class Game < ApplicationRecord
 
   def log_game_results
     ordered = game_players.order(:order).to_a
-    score_line = ordered.map { |gp| "#{gp.player.handle} #{scores[gp.order.to_s]['total']}" }.join(', ')
-    rating_line = ordered.map { |gp| "#{gp.player.handle} #{gp.rating_before} → #{gp.rating_after}" }.join(', ')
+    score_line = ordered.map { |gp| "#{gp.player.handle} #{scores[gp.order.to_s]['total']}" }.join(", ")
+    rating_line = ordered.map { |gp| "#{gp.player.handle} #{gp.rating_before} → #{gp.rating_after}" }.join(", ")
     self.move_count = (move_count || 0) + 1
     moves.create!(
       order: move_count,

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -190,6 +190,7 @@ class Game < ApplicationRecord
       save!
       Rating.new(self).apply!
     end
+    log_game_results
     chat_messages.create!(body: "Game ended.")
     broadcast_end_game
     broadcast_dashboard_update
@@ -358,7 +359,48 @@ class Game < ApplicationRecord
     board.map.any? { |s| s.location_hexes.any? { |h| h[:k] == "Quarry" } }
   end
 
+  def next_card
+    card = deck.shift
+    shuffle_terrain_deck if deck.size < 1
+    save
+    card
+  end
+
+  def shuffle_terrain_deck
+    discard_count = discard.size
+    self.deck = discard.shuffle
+    self.discard.clear
+    self.move_count = (move_count || 0) + 1
+    moves.build(
+      order: move_count,
+      action: "shuffle_discards",
+      message: "Shuffled #{discard_count} discards into deck",
+      deliberate: false,
+      reversible: false
+    )
+    save
+  end
+
   private
+
+  def log_game_results
+    ordered = game_players.order(:order).to_a
+    score_line = ordered.map { |gp| "#{gp.player.handle} #{scores[gp.order.to_s]['total']}" }.join(', ')
+    rating_line = ordered.map { |gp| "#{gp.player.handle} #{gp.rating_before} → #{gp.rating_after}" }.join(', ')
+    self.move_count = (move_count || 0) + 1
+    moves.create!(
+      order: move_count,
+      action: "game_results",
+      message: "Scores: #{score_line}. Ratings: #{rating_line}",
+      payload: {
+        "scores" => scores,
+        "ratings" => ordered.map { |gp| { "handle" => gp.player.handle, "rating_before" => gp.rating_before, "rating_after" => gp.rating_after } }
+      },
+      deliberate: false,
+      reversible: false
+    )
+    save!
+  end
 
   def select_boards(options = {})
     min = options[:min_board] || 0
@@ -424,12 +466,6 @@ class Game < ApplicationRecord
     shuffle_terrain_deck
   end
 
-  def shuffle_terrain_deck
-    self.deck = discard.shuffle
-    self.discard.clear
-    save
-  end
-
   OPTIONAL_GOALS = %w[ambassadors citizens discoverers families farmers fishermen hermits knights merchants miners shepherds workers].freeze
   # OPTIONAL_GOALS = %w[citizens discoverers farmers fishermen hermits knights merchants miners workers].freeze
   TASKS = %w[advance compass_points fortress home_country place_of_refuge road].freeze
@@ -440,12 +476,32 @@ class Game < ApplicationRecord
     castle_goal = board_has_castles? ? [ "castles" ] : []
     self.goals = castle_goal + OPTIONAL_GOALS.sample(3)
     @board = nil
+    self.move_count = (move_count || 0) + 1
+    moves.build(
+      order: move_count,
+      action: "select_goals",
+      message: "Goals selected: #{goals.join(', ')}",
+      payload: { "goals" => goals },
+      deliberate: false,
+      reversible: false
+    )
     save
   end
 
   def select_tasks
     crossroads_count = boards.count { |id, _| CROSSROADS_BOARD_IDS.include?(id) }
     self.tasks = TASKS.sample(crossroads_count)
+    if tasks.any?
+      self.move_count = (move_count || 0) + 1
+      moves.build(
+        order: move_count,
+        action: "select_tasks",
+        message: "Tasks selected: #{tasks.join(', ')}",
+        payload: { "tasks" => tasks },
+        deliberate: false,
+        reversible: false
+      )
+    end
     save
   end
 
@@ -471,6 +527,14 @@ class Game < ApplicationRecord
   def choose_start_player
     game_players.shuffle.each_with_index { |p, n| p.update(order: n) }
     update(current_player: first_player)
+    self.move_count = (move_count || 0) + 1
+    moves.build(
+      order: move_count,
+      action: "choose_start_player",
+      message: "Player order: #{game_players.order(:order).map { |gp| gp.player.handle }.join(', ')}",
+      deliberate: false,
+      reversible: false
+    )
   end
 
   def overall_location(board, row, col)
@@ -479,12 +543,5 @@ class Game < ApplicationRecord
 
   def first_player
     game_players.where(order: 0).first
-  end
-
-  def next_card
-    card = deck.shift
-    shuffle_terrain_deck if deck.size < 1
-    save
-    card
   end
 end

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -696,8 +696,8 @@ class TurnEngine
     game_player = @game.current_player
     card_discarded = game_player.hand
     @game.discard.push(*game_player.hand)
-    new_cards = [ next_card ]
-    new_cards << next_card if has_crossroads_tile?(game_player)
+    new_cards = [ @game.next_card ]
+    new_cards << @game.next_card if has_crossroads_tile?(game_player)
     game_player.hand = new_cards
     card_drawn = game_player.hand
     reshuffled = @game.discard.empty?
@@ -1211,19 +1211,6 @@ class TurnEngine
     game_player.bonus_scores = (game_player.bonus_scores || {}).merge(
       goal => (game_player.bonus_scores&.dig(goal) || 0) + points
     )
-  end
-
-  def next_card
-    card = @game.deck.shift
-    shuffle_terrain_deck if @game.deck.size < 1
-    @game.save
-    card
-  end
-
-  def shuffle_terrain_deck
-    @game.deck = @game.discard.shuffle
-    @game.discard.clear
-    @game.save
   end
 
   def lock_terrain!(terrain, before)

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -44,6 +44,12 @@ class GameTest < ActiveSupport::TestCase
     # Check that the deck is shuffled and discard is cleared
     assert_equal [], game.discard
     assert_not_equal [ "A" ], game.deck
+
+    move = game.moves.find_by(action: "shuffle_discards")
+    assert_equal "Shuffled 5 discards into deck", move.message # 4 discarded + 1 returned hand card
+    assert_nil move.game_player_id
+    assert_not move.deliberate
+    assert_not move.reversible
   end
 
   # Tile pickup tests
@@ -1146,6 +1152,28 @@ class GameTest < ActiveSupport::TestCase
     assert_equal "Game ended.", system_message.body
   end
 
+  test "complete! logs a system move recording detailed scores and rating changes" do
+    game = new_started_game
+    game.complete!
+    game.reload
+
+    move = game.moves.find_by(action: "game_results")
+    assert_nil move.game_player_id
+    assert_not move.deliberate
+    assert_not move.reversible
+
+    ordered = game.game_players.order(:order).to_a
+    ordered.each do |gp|
+      total = game.scores[gp.order.to_s]["total"]
+      assert_includes move.message, "#{gp.player.handle} #{total}"
+      assert_includes move.message, "#{gp.player.handle} #{gp.rating_before} → #{gp.rating_after}"
+    end
+
+    assert_equal game.scores, move.payload["scores"]
+    expected_ratings = ordered.map { |gp| { "handle" => gp.player.handle, "rating_before" => gp.rating_before, "rating_after" => gp.rating_after } }
+    assert_equal expected_ratings, move.payload["ratings"]
+  end
+
   test "end_turn clears current_player when it completes the game" do
     game = new_started_game
     last_gp = game.game_players.max_by(&:order)
@@ -1264,6 +1292,77 @@ class GameTest < ActiveSupport::TestCase
 
     first = tiles.first
     assert_includes move.message, "[#{first['row']},#{first['col']}] #{first['klass']} x#{first['qty']}"
+    assert_nil move.game_player_id
+    assert_not move.deliberate
+    assert_not move.reversible
+  end
+
+  test "start logs a system move recording the player order" do
+    game = new_started_game
+
+    move = game.moves.find_by(action: "choose_start_player")
+    ordered_handles = game.game_players.order(:order).map { |gp| gp.player.handle }
+    assert_equal "Player order: #{ordered_handles.join(', ')}", move.message
+    assert_nil move.game_player_id
+    assert_not move.deliberate
+    assert_not move.reversible
+  end
+
+  test "select_goals logs a system move recording the selected goals" do
+    game = games(:game2player)
+    game.boards = [ [ 1, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ]
+    game.move_count = 0
+    game.save!
+
+    game.send(:select_goals)
+
+    move = game.moves.find_by(action: "select_goals")
+    assert_equal "Goals selected: #{game.goals.join(', ')}", move.message
+    assert_equal game.goals, move.payload["goals"]
+    assert_nil move.game_player_id
+    assert_not move.deliberate
+    assert_not move.reversible
+  end
+
+  test "select_tasks logs a system move when tasks are assigned" do
+    game = games(:game2player)
+    game.boards = [ [ 12, 0 ], [ 1, 0 ], [ 0, 0 ], [ 4, 0 ] ] # board 12 is a crossroads board
+    game.move_count = 0
+    game.save!
+
+    game.send(:select_tasks)
+
+    assert game.tasks.any?
+    move = game.moves.find_by(action: "select_tasks")
+    assert_equal "Tasks selected: #{game.tasks.join(', ')}", move.message
+    assert_equal game.tasks, move.payload["tasks"]
+    assert_nil move.game_player_id
+    assert_not move.deliberate
+    assert_not move.reversible
+  end
+
+  test "select_tasks logs no move when no tasks are assigned" do
+    game = games(:game2player)
+    game.boards = [ [ 1, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ] # no crossroads boards
+    game.move_count = 0
+    game.save!
+
+    game.send(:select_tasks)
+
+    assert_empty game.tasks
+    assert_nil game.moves.find_by(action: "select_tasks")
+  end
+
+  test "shuffle_terrain_deck logs a system move recording the discard count" do
+    game = games(:game2player)
+    game.discard = %w[C D F G T]
+    game.move_count = 0
+    game.save!
+
+    game.shuffle_terrain_deck
+
+    move = game.moves.find_by(action: "shuffle_discards")
+    assert_equal "Shuffled 5 discards into deck", move.message
     assert_nil move.game_player_id
     assert_not move.deliberate
     assert_not move.reversible


### PR DESCRIPTION
## Summary
Follow-on to #260, logging more of the game lifecycle as system Moves for post-game analysis:
- Player order (`choose_start_player`), goals (`select_goals`, always), and tasks (`select_tasks`, only when any are assigned) each get a Move with a human-readable message and a structured payload.
- Discard reshuffles get a `shuffle_discards` Move (`"Shuffled N discards into deck"`), captured before the discard array is cleared.
- `build` and `pick_up_tile` move messages now include the tile/settlement location.
- `Game#complete!` logs a `game_results` Move with final scores and each player's rating_before/rating_after, covering both normal end-of-game and resignation.

Also deduped `next_card`/`shuffle_terrain_deck`: they existed once on `Game` (game start) and once on `TurnEngine` (a leftover copy from the earlier TurnEngine-extraction refactor, used mid-turn). Both now live only on `Game`; `TurnEngine` delegates via `@game.next_card`.

## Test plan
- [x] `bin/test-all` (full suite, unit + system) green