### PR TITLE
Fix observer terrain card leak

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -283,6 +283,7 @@ class Game < ApplicationRecord
             game: self,
             player: displayed_player,
             n: viewer == displayed_player ? 0 : 1,
+            is_me: viewer == displayed_player,
             engine: engine,
             scores: scores
           }
@@ -293,6 +294,25 @@ class Game < ApplicationRecord
         target: "end-turn-area",
         partial: "games/end_turn",
         locals: { game: self, engine: engine, my_turn: my_turn }
+      )
+    end
+
+    # public per-player panel - lets observers (non-players) see live updates,
+    # masked exactly like a fresh page load would mask them (never a real hand,
+    # except the current player's, which is publicly displayed per the rules).
+    game_players.each do |displayed_player|
+      broadcast_update_to(
+        "game_player_#{displayed_player.id}",
+        target: "game_player_#{displayed_player.id}",
+        partial: "games/game_player",
+        locals: {
+          game: self,
+          player: displayed_player,
+          n: 1,
+          is_me: false,
+          engine: engine,
+          scores: scores
+        }
       )
     end
 

--- a/app/views/games/_game_player.html.erb
+++ b/app/views/games/_game_player.html.erb
@@ -1,4 +1,4 @@
-<% my_turn = n == 0 && player.id == game.current_player&.id %>
+<% my_turn = is_me && player.id == game.current_player&.id %>
 <div class="player-info-zone">
   <div class="player-header">
     <%= content_tag :div, class: "handle #{' my-turn' if my_turn }" do %>
@@ -33,12 +33,12 @@
         </div>
       </div>
     <% end %>
-    <% if n == 0 && game.id %>
+    <% if is_me && game.id %>
       <%= button_to("Undo", undo_move_game_path(game), class: "undo-btn", disabled: !(my_turn && engine.undo_allowed?)) %>
     <% end %>
   </div>
   <div class="player-stats">
-    <% display_cards = (n == 0 || game.current_player_id == player.id) ? Array(player.hand) : Array(player.hand).map { "Z" } %>
+    <% display_cards = (is_me || game.current_player_id == player.id) ? Array(player.hand) : Array(player.hand).map { "Z" } %>
     <% chosen = (game.current_player_id == player.id) ? game.current_action["chosen_terrain"] : nil %>
     <% display_cards.each do |card| %>
       <% shunned = chosen && card != chosen %>

--- a/app/views/games/_players.html.erb
+++ b/app/views/games/_players.html.erb
@@ -14,20 +14,22 @@
   </div>
   <%# Language note: "player" is a GamePlayer model; "player.player" is a User %>
   <% players = game.game_players.sort_by(&:order) %>
-  <% Rails.logger.debug "CU: #{current_user.inspect}" %>
+  <% viewer_is_player = current_user && players.any? { |p| p.player == current_user } %>
   <% offset = ( current_user ? players.find { |p| p.player == current_user }&.order : nil ) || 0 %>
   <% players.size.times do |n| %>
     <%# Always display current user first %>
     <% index = (n + offset) % players.size %>
     <% player = players[index] %>
-    <% if n == 0 && current_user == player.player %>
+    <% is_me = current_user == player.player %>
+    <% if is_me %>
       <%= turbo_stream_from "game_player_#{player.id}_private" %>
-    <%# else %>
-      <%# = turbo_stream_from "game_player_#{player.id}" %>
+    <% elsif !viewer_is_player %>
+      <%# Observer: no private channel of their own, so subscribe to each player's public panel. %>
+      <%= turbo_stream_from "game_player_#{player.id}" %>
     <% end %>
     <div class="player-area">
       <%= content_tag :div, id: "game_player_#{player.id}" do %>
-        <%= render partial: "games/game_player", locals: { game:, player:, n:, engine:, scores: } %>
+        <%= render partial: "games/game_player", locals: { game:, player:, n:, is_me:, engine:, scores: } %>
       <% end %>
     </div>
   <% end %>

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -78,6 +78,23 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".player-tile.tile-active .tile-container.farm", count: 1
   end
 
+  test "observer viewing a game they're not in only sees the current player's terrain card" do
+    # chris is logged in but is not a player in paula_jules_game.
+    game = games(:paula_jules_game)
+    paula = game_players(:paula_in_paula_jules_game)
+    jules = game_players(:jules_in_paula_jules_game)
+    paula.update!(hand: [ "D" ])
+    jules.update!(hand: [ "M" ])
+    game.update!(current_player: jules)
+
+    get game_url(game)
+
+    # jules is the current player: their card is publicly displayed per the rules.
+    assert_select ".player-card.card-M"
+    # paula is not the current player and chris is not paula: her card must stay hidden.
+    assert_select ".player-card.card-D", count: 0
+  end
+
   test "select_action sets current_action type on the game" do
     game = games(:game2player)
     post select_action_game_url(game), params: { action_type: "paddock" }

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1437,6 +1437,34 @@ class GameTest < ActiveSupport::TestCase
     assert_not_includes chris_panel.to_s, "card-Z"
   end
 
+  test "broadcast_game_update sends observers a masked public player panel per player" do
+    # paula_jules_game: chris is not a player, so chris only ever gets the public per-player channels.
+    game = games(:paula_jules_game)
+    paula = game_players(:paula_in_paula_jules_game)
+    jules = game_players(:jules_in_paula_jules_game)
+    paula.update!(hand: [ "D" ])
+    jules.update!(hand: [ "M" ])
+    game.update!(current_player: jules)
+
+    paula_broadcasts = capture_turbo_stream_broadcasts("game_player_#{paula.id}") do
+      game.broadcast_game_update
+    end
+    jules_broadcasts = capture_turbo_stream_broadcasts("game_player_#{jules.id}") do
+      game.broadcast_game_update
+    end
+
+    paula_panel = paula_broadcasts.find { |broadcast| broadcast.to_s.include?(%(target="game_player_#{paula.id}")) }
+    jules_panel = jules_broadcasts.find { |broadcast| broadcast.to_s.include?(%(target="game_player_#{jules.id}")) }
+
+    assert paula_panel, "expected the public channel to update paula's panel for observers"
+    assert jules_panel, "expected the public channel to update jules's panel for observers"
+    # paula is not the current player: her card must stay masked to observers, even as turns change live.
+    assert_not_includes paula_panel.to_s, "card-D"
+    assert_includes paula_panel.to_s, "card-Z"
+    # jules is the current player: her card is publicly displayed live.
+    assert_includes jules_panel.to_s, "card-M"
+  end
+
   test "broadcast_sound emits a play_sound turbo stream to the game channel" do
     game = games(:game2player)
     broadcasts = capture_turbo_stream_broadcasts("game_#{game.id}") do


### PR DESCRIPTION
## Summary
- Observers (users viewing a game they're not in) could see every player's terrain hand, not just the current player's publicly-displayed card.
- Root cause: views used position `n == 0` as a proxy for "this is the viewer's own panel." For a non-participant, that lookup silently fell back to `0`, exposing the first player's hand. Observers also had no broadcast channel, so live updates never re-masked a hand once the turn moved on.
- Fix: replace the position proxy with an explicit `is_me` identity check, and add a public per-player broadcast channel so observer views stay correctly masked live, not just on initial page load.

## Test plan
- [x] `bin/rails test test/models/game_test.rb test/controllers/games_controller_test.rb` — new regression tests fail before the fix, pass after
- [x] `bin/test-all` — full suite green aside from pre-existing unrelated `MAIL_FROM` env errors in mailer tests (confirmed present on `main` before this change)
- [x] `bin/rubocop` on changed Ruby files — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)