### PR TITLE
One door into the Turn: single click(coordinate) command via polymorphic TurnPhase dispatch

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,8 @@
 class GamesController < ApplicationController
   before_action :require_game_playing, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_meeple, :select_meeple, :activate_fort ]
-  before_action :require_current_player, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_meeple, :select_meeple, :activate_fort ]
+  # ponytail: undo_move intentionally excluded — it was never current-player-gated at baseline.
+  # Whether a non-current player should be able to undo is an open question tracked as a follow-up.
+  before_action :require_current_player, only: [ :action, :select_action, :end_turn, :end_tile_action, :activate_outpost, :remove_meeple, :select_meeple, :activate_fort ]
   after_action :broadcast_game_update, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_meeple, :select_meeple, :activate_fort ]
 
   def new

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,7 @@
 class GamesController < ApplicationController
   before_action :require_game_playing, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_meeple, :select_meeple, :activate_fort ]
   before_action :require_current_player, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_meeple, :select_meeple, :activate_fort ]
+  after_action :broadcast_game_update, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_meeple, :select_meeple, :activate_fort ]
 
   def new
     @game = Game.new
@@ -41,7 +42,6 @@ class GamesController < ApplicationController
       format.html { head :no_content }
       format.turbo_stream { head :no_content }
     end
-    @game.broadcast_game_update
   end
 
   def select_action
@@ -50,7 +50,6 @@ class GamesController < ApplicationController
       format.html { redirect_to @game }
       format.turbo_stream { head :no_content }
     end
-    @game.broadcast_game_update
   end
 
   def end_turn
@@ -61,7 +60,6 @@ class GamesController < ApplicationController
       format.html { redirect_to @game }
       format.turbo_stream { head :no_content }
     end
-    @game.broadcast_game_update
   end
 
   def join
@@ -93,7 +91,6 @@ class GamesController < ApplicationController
       format.turbo_stream { head :no_content }
     end
     @game.broadcast_sound("undo")
-    @game.broadcast_game_update
   end
 
   def end_tile_action
@@ -102,7 +99,6 @@ class GamesController < ApplicationController
       format.html { redirect_to @game }
       format.turbo_stream { head :no_content }
     end
-    @game.broadcast_game_update
   end
 
   def activate_outpost
@@ -111,7 +107,6 @@ class GamesController < ApplicationController
       format.html { redirect_to @game }
       format.turbo_stream { head :no_content }
     end
-    @game.broadcast_game_update
   end
 
   def activate_fort
@@ -120,7 +115,6 @@ class GamesController < ApplicationController
       format.html { head :no_content }
       format.turbo_stream { head :no_content }
     end
-    @game.broadcast_game_update
   end
 
   def remove_meeple
@@ -130,7 +124,6 @@ class GamesController < ApplicationController
       format.html { head :no_content }
       format.turbo_stream { head :no_content }
     end
-    @game.broadcast_game_update
   end
 
   def select_meeple
@@ -140,7 +133,6 @@ class GamesController < ApplicationController
       format.html { head :no_content }
       format.turbo_stream { head :no_content }
     end
-    @game.broadcast_game_update
   end
 
   def resign
@@ -216,6 +208,10 @@ class GamesController < ApplicationController
 
   def require_current_player
     head :no_content unless @game.game_players.find_by(player: Current.user) == @game.current_player
+  end
+
+  def broadcast_game_update
+    @game.broadcast_game_update
   end
 
   def action_params

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,5 +1,6 @@
 class GamesController < ApplicationController
   before_action :require_game_playing, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_meeple, :select_meeple, :activate_fort ]
+  before_action :require_current_player, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_meeple, :select_meeple, :activate_fort ]
 
   def new
     @game = Game.new
@@ -33,8 +34,6 @@ class GamesController < ApplicationController
   # 2. use a tile that I have to build a settlement on the board
   # 3. use a tile that I have to move a piece on the board
   def action
-    return unless @game.game_players.find_by(player: Current.user) == @game.current_player
-
     TurnEngine.new(@game).click(
       Coordinate.new(action_params[:build_row], action_params[:build_col])
     )
@@ -46,8 +45,6 @@ class GamesController < ApplicationController
   end
 
   def select_action
-    current_gp = @game.game_players.find_by(player: Current.user)
-    return unless current_gp == @game.current_player
     TurnEngine.new(@game).select_action(params[:action_type])
     respond_to do |format|
       format.html { redirect_to @game }
@@ -58,9 +55,8 @@ class GamesController < ApplicationController
 
   def end_turn
     Rails.logger.debug("END TURN action")
-    current_gp = @game.game_players.find_by(player: Current.user)
     engine = TurnEngine.new(@game)
-    engine.end_turn if current_gp == @game.current_player && engine.turn_endable?
+    engine.end_turn if engine.turn_endable?
     respond_to do |format|
       format.html { redirect_to @game }
       format.turbo_stream { head :no_content }
@@ -101,8 +97,6 @@ class GamesController < ApplicationController
   end
 
   def end_tile_action
-    current_gp = @game.game_players.find_by(player: Current.user)
-    return unless current_gp == @game.current_player
     TurnEngine.new(@game).end_tile_action
     respond_to do |format|
       format.html { redirect_to @game }
@@ -112,8 +106,6 @@ class GamesController < ApplicationController
   end
 
   def activate_outpost
-    current_gp = @game.game_players.find_by(player: Current.user)
-    return unless current_gp == @game.current_player
     TurnEngine.new(@game).activate_outpost
     respond_to do |format|
       format.html { redirect_to @game }
@@ -123,7 +115,6 @@ class GamesController < ApplicationController
   end
 
   def activate_fort
-    return unless @game.game_players.find_by(player: Current.user) == @game.current_player
     TurnEngine.new(@game).activate_fort_tile
     respond_to do |format|
       format.html { head :no_content }
@@ -133,7 +124,6 @@ class GamesController < ApplicationController
   end
 
   def remove_meeple
-    return unless @game.game_players.find_by(player: Current.user) == @game.current_player
     coord = Coordinate.new(params[:row], params[:col])
     TurnEngine.new(@game).remove_meeple_action(coord.row, coord.col)
     respond_to do |format|
@@ -144,7 +134,6 @@ class GamesController < ApplicationController
   end
 
   def select_meeple
-    return unless @game.game_players.find_by(player: Current.user) == @game.current_player
     coord = Coordinate.new(params[:row], params[:col])
     TurnEngine.new(@game).select_meeple_for_move(coord.row, coord.col)
     respond_to do |format|
@@ -223,6 +212,10 @@ class GamesController < ApplicationController
   def require_game_playing
     @game = Current.user.games.find(params[:id])
     head :no_content unless @game.playing?
+  end
+
+  def require_current_player
+    head :no_content unless @game.game_players.find_by(player: Current.user) == @game.current_player
   end
 
   def action_params

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,5 +1,5 @@
 class GamesController < ApplicationController
-  before_action :require_game_playing, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_settlement, :place_wall, :remove_meeple, :select_meeple, :activate_fort ]
+  before_action :require_game_playing, only: [ :action, :select_action, :end_turn, :undo_move, :end_tile_action, :activate_outpost, :remove_meeple, :select_meeple, :activate_fort ]
 
   def new
     @game = Game.new
@@ -125,30 +125,6 @@ class GamesController < ApplicationController
   def activate_fort
     return unless @game.game_players.find_by(player: Current.user) == @game.current_player
     TurnEngine.new(@game).activate_fort_tile
-    respond_to do |format|
-      format.html { head :no_content }
-      format.turbo_stream { head :no_content }
-    end
-    @game.broadcast_game_update
-  end
-
-  def remove_settlement
-    current_gp = @game.game_players.find_by(player: Current.user)
-    return unless current_gp == @game.current_player
-    coord = Coordinate.new(action_params[:build_row], action_params[:build_col])
-    TurnEngine.new(@game).remove_settlement(coord.row, coord.col)
-    respond_to do |format|
-      format.html { head :no_content }
-      format.turbo_stream { head :no_content }
-    end
-    @game.broadcast_game_update
-  end
-
-  def place_wall
-    current_gp = @game.game_players.find_by(player: Current.user)
-    return unless current_gp == @game.current_player
-    coord = Coordinate.new(action_params[:build_row], action_params[:build_col])
-    TurnEngine.new(@game).place_wall(coord.row, coord.col)
     respond_to do |format|
       format.html { head :no_content }
       format.turbo_stream { head :no_content }

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -35,39 +35,13 @@ class GamesController < ApplicationController
   def action
     return unless @game.game_players.find_by(player: Current.user) == @game.current_player
 
-    Rails.logger.debug("TURN ACTION PARAMS: #{action_params.inspect}")
-
-    coord = Coordinate.new(action_params[:build_row], action_params[:build_col])
-    engine = TurnEngine.new(@game)
-    action_type = @game.current_action["type"]
-    klass_name = @game.current_action["klass"] || "#{action_type.capitalize}Tile"
-    tile_klass = Tiles::Tile.for_klass(klass_name) if action_type != "mandatory"
-    tile_obj = tile_klass&.new(0)
-    if tile_obj&.moves_settlement?
-      if @game.current_action["from"]
-        engine.move_settlement(coord.row, coord.col)
-      else
-        engine.select_settlement(coord.row, coord.col)
-      end
-    elsif tile_obj&.sword_tile?
-      engine.remove_settlement(coord.row, coord.col)
-    elsif tile_obj&.places_wall?
-      engine.place_wall(coord.row, coord.col)
-    elsif tile_obj&.places_meeple?
-      engine.execute_meeple_action(coord.row, coord.col)
-    elsif tile_obj&.places_city_hall?
-      engine.place_city_hall(coord.row, coord.col)
-    elsif tile_obj&.builds_settlement?
-      engine.activate_tile_build(coord.row, coord.col)
-    else
-      engine.build_settlement(coord.row, coord.col)
-    end
+    TurnEngine.new(@game).click(
+      Coordinate.new(action_params[:build_row], action_params[:build_col])
+    )
     respond_to do |format|
       format.html { head :no_content }
       format.turbo_stream { head :no_content }
     end
-    # animate_build_settlement(@game, @game.current_player, coord.row, coord.col)
-    # update all clients
     @game.broadcast_game_update
   end
 

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -61,6 +61,14 @@ class TurnPhase
     serialize["klass"]
   end
 
+  # The tile class name for this phase's action, applying the type-derived
+  # fallback for phases that carry no explicit "klass" (e.g. a quarry action
+  # serializes only its type). Single source of truth for both #click and
+  # TurnEngine#current_action_tile_klass.
+  def tile_klass_name
+    klass_name || "#{type.capitalize}Tile"
+  end
+
   def chosen_terrain
     serialize["chosen_terrain"]
   end
@@ -133,11 +141,8 @@ class TurnPhase
     row = coordinate.row
     col = coordinate.col
     # klass_name alone isn't enough: several phase subclasses only carry a
-    # "klass" key when one was explicitly recorded (e.g. via select_action),
-    # so fall back to the type-derived name exactly as
-    # TurnEngine#current_action_tile_klass does.
-    effective_klass_name = klass_name || "#{type.capitalize}Tile"
-    tile = Tiles::Tile.for_klass(effective_klass_name)&.new(0)
+    # "klass" key when one was explicitly recorded (e.g. via select_action).
+    tile = Tiles::Tile.for_klass(tile_klass_name)&.new(0)
     if tile&.moves_settlement?
       from ? engine.move_settlement(row, col) : engine.select_settlement(row, col)
     elsif tile&.sword_tile?

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -555,6 +555,10 @@ class TurnPhase::MeepleMovementPhase < TurnPhase
   def tile_action_endable? = moves.to_i >= 1
   def accepts_source_selection? = true
 
+  def click(coordinate, engine)
+    engine.execute_meeple_action(coordinate.row, coordinate.col)
+  end
+
   def transition(event, facts)
     case event
     when TurnPhase::Events::SourceSelected
@@ -650,6 +654,10 @@ class TurnPhase::MeepleActionPhase < TurnPhase
 
   def klass_name
     klass_value
+  end
+
+  def click(coordinate, engine)
+    engine.execute_meeple_action(coordinate.row, coordinate.col)
   end
 
   def serialize

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -126,6 +126,35 @@ class TurnPhase
     end
   end
 
+  # Interpret a board-cell click for this phase and drive the engine (State
+  # pattern: phase = State, engine = Context). Base class reproduces the legacy
+  # tile-predicate dispatch; concrete phases override with their own meaning.
+  def click(coordinate, engine)
+    row = coordinate.row
+    col = coordinate.col
+    # klass_name alone isn't enough: several phase subclasses only carry a
+    # "klass" key when one was explicitly recorded (e.g. via select_action),
+    # so fall back to the type-derived name exactly as
+    # TurnEngine#current_action_tile_klass does.
+    effective_klass_name = klass_name || "#{type.capitalize}Tile"
+    tile = Tiles::Tile.for_klass(effective_klass_name)&.new(0)
+    if tile&.moves_settlement?
+      from ? engine.move_settlement(row, col) : engine.select_settlement(row, col)
+    elsif tile&.sword_tile?
+      engine.remove_settlement(row, col)
+    elsif tile&.places_wall?
+      engine.place_wall(row, col)
+    elsif tile&.places_meeple?
+      engine.execute_meeple_action(row, col)
+    elsif tile&.places_city_hall?
+      engine.place_city_hall(row, col)
+    elsif tile&.builds_settlement?
+      engine.activate_tile_build(row, col)
+    else
+      engine.build_settlement(row, col)
+    end
+  end
+
   def transition(_event, _facts)
     raise InvalidTransition, "#{self.class.name} does not accept that event"
   end

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -364,6 +364,10 @@ class TurnPhase::FortPhase < TurnPhase
     fort_terrain_value
   end
 
+  def click(coordinate, engine)
+    engine.activate_tile_build(coordinate.row, coordinate.col)
+  end
+
   def serialize
     {
       "type" => "fort",

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -697,6 +697,10 @@ class TurnPhase::CityHallPhase < TurnPhase
 
   def city_hall? = true
 
+  def click(coordinate, engine)
+    engine.place_city_hall(coordinate.row, coordinate.col)
+  end
+
   def serialize
     {
       "type" => action_type,

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -273,6 +273,20 @@ class TurnPhase::TileBuildPhase < TurnPhase
 
   def tile_action_endable? = walls_placed.to_i >= 1
 
+  # This phase spans both wall tiles (quarry) and build tiles (village, farm,
+  # ...), so it asks its OWN reconstructed tile which one it is.
+  # tile_klass_name (not bare klass_name) applies the type-derived fallback:
+  # a quarry action serializes no "klass" key, so bare klass_name is nil and
+  # would misroute to activate_tile_build.
+  def click(coordinate, engine)
+    tile = Tiles::Tile.for_klass(tile_klass_name)&.new(0)
+    if tile&.places_wall?
+      engine.place_wall(coordinate.row, coordinate.col)
+    else
+      engine.activate_tile_build(coordinate.row, coordinate.col)
+    end
+  end
+
   def with_outpost_active
     self.class.new(
       action_type: action_type,

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -624,6 +624,10 @@ class TurnPhase::TargetedRemovalPhase < TurnPhase
 
   # consume_target is inherited from TurnPhase — its self.class is this class.
 
+  def click(coordinate, engine)
+    engine.remove_settlement(coordinate.row, coordinate.col)
+  end
+
   def serialize
     {
       "type" => action_type,

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -192,6 +192,10 @@ class TurnPhase::MandatoryBuildPhase < TurnPhase
 
   def mandatory_build? = true
 
+  def click(coordinate, engine)
+    engine.build_settlement(coordinate.row, coordinate.col)
+  end
+
   def with_outpost_active
     self.class.new(chosen_terrain: chosen_terrain, builds: builds, outpost_active: true)
   end

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -135,29 +135,10 @@ class TurnPhase
   end
 
   # Interpret a board-cell click for this phase and drive the engine (State
-  # pattern: phase = State, engine = Context). Base class reproduces the legacy
-  # tile-predicate dispatch; concrete phases override with their own meaning.
-  def click(coordinate, engine)
-    row = coordinate.row
-    col = coordinate.col
-    # klass_name alone isn't enough: several phase subclasses only carry a
-    # "klass" key when one was explicitly recorded (e.g. via select_action).
-    tile = Tiles::Tile.for_klass(tile_klass_name)&.new(0)
-    if tile&.moves_settlement?
-      from ? engine.move_settlement(row, col) : engine.select_settlement(row, col)
-    elsif tile&.sword_tile?
-      engine.remove_settlement(row, col)
-    elsif tile&.places_wall?
-      engine.place_wall(row, col)
-    elsif tile&.places_meeple?
-      engine.execute_meeple_action(row, col)
-    elsif tile&.places_city_hall?
-      engine.place_city_hall(row, col)
-    elsif tile&.builds_settlement?
-      engine.activate_tile_build(row, col)
-    else
-      engine.build_settlement(row, col)
-    end
+  # pattern: phase = State, engine = Context). Every concrete phase overrides
+  # this with its own meaning; the base class never accepts a click directly.
+  def click(_coordinate, _engine)
+    raise InvalidTransition, "#{self.class.name} does not accept a board click"
   end
 
   def transition(_event, _facts)
@@ -768,6 +749,31 @@ class TurnPhase::LegacyPhase < TurnPhase
 
   def moves
     data["moves"]
+  end
+
+  # The honest catch-all: reproduces the legacy tile-predicate dispatch for
+  # phases that didn't resolve to a dedicated TurnPhase subclass.
+  def click(coordinate, engine)
+    row = coordinate.row
+    col = coordinate.col
+    # tile_klass_name applies the type-derived fallback (Task 2 fix) so phases
+    # carrying no serialized "klass" still resolve their tile.
+    tile = Tiles::Tile.for_klass(tile_klass_name)&.new(0)
+    if tile&.moves_settlement?
+      from ? engine.move_settlement(row, col) : engine.select_settlement(row, col)
+    elsif tile&.sword_tile?
+      engine.remove_settlement(row, col)
+    elsif tile&.places_wall?
+      engine.place_wall(row, col)
+    elsif tile&.places_meeple?
+      engine.execute_meeple_action(row, col)
+    elsif tile&.places_city_hall?
+      engine.place_city_hall(row, col)
+    elsif tile&.builds_settlement?
+      engine.activate_tile_build(row, col)
+    else
+      engine.build_settlement(row, col)
+    end
   end
 
   def serialize

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -390,6 +390,14 @@ class TurnPhase::SettlementMovePhase < TurnPhase
 
   def accepts_source_selection? = true
 
+  def click(coordinate, engine)
+    if from
+      engine.move_settlement(coordinate.row, coordinate.col)
+    else
+      engine.select_settlement(coordinate.row, coordinate.col)
+    end
+  end
+
   def transition(event, facts)
     case event
     when TurnPhase::Events::SourceSelected
@@ -446,6 +454,14 @@ class TurnPhase::ResettlementPhase < TurnPhase
 
   def klass_name
     "ResettlementTile"
+  end
+
+  def click(coordinate, engine)
+    if from
+      engine.move_settlement(coordinate.row, coordinate.col)
+    else
+      engine.select_settlement(coordinate.row, coordinate.col)
+    end
   end
 
   def budget

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -4,27 +4,7 @@ class TurnEngine
   end
 
   def click(coordinate)
-    row = coordinate.row
-    col = coordinate.col
-    action_type = @game.current_action["type"]
-    klass_name = @game.current_action["klass"] || "#{action_type.capitalize}Tile"
-    tile_klass = Tiles::Tile.for_klass(klass_name) if action_type != "mandatory"
-    tile_obj = tile_klass&.new(0)
-    if tile_obj&.moves_settlement?
-      @game.current_action["from"] ? move_settlement(row, col) : select_settlement(row, col)
-    elsif tile_obj&.sword_tile?
-      remove_settlement(row, col)
-    elsif tile_obj&.places_wall?
-      place_wall(row, col)
-    elsif tile_obj&.places_meeple?
-      execute_meeple_action(row, col)
-    elsif tile_obj&.places_city_hall?
-      place_city_hall(row, col)
-    elsif tile_obj&.builds_settlement?
-      activate_tile_build(row, col)
-    else
-      build_settlement(row, col)
-    end
+    @game.turn_phase.click(coordinate, self)
   end
 
   def available_list(active_player, terrain)

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -3,6 +3,30 @@ class TurnEngine
     @game = game
   end
 
+  def click(coordinate)
+    row = coordinate.row
+    col = coordinate.col
+    action_type = @game.current_action["type"]
+    klass_name = @game.current_action["klass"] || "#{action_type.capitalize}Tile"
+    tile_klass = Tiles::Tile.for_klass(klass_name) if action_type != "mandatory"
+    tile_obj = tile_klass&.new(0)
+    if tile_obj&.moves_settlement?
+      @game.current_action["from"] ? move_settlement(row, col) : select_settlement(row, col)
+    elsif tile_obj&.sword_tile?
+      remove_settlement(row, col)
+    elsif tile_obj&.places_wall?
+      place_wall(row, col)
+    elsif tile_obj&.places_meeple?
+      execute_meeple_action(row, col)
+    elsif tile_obj&.places_city_hall?
+      place_city_hall(row, col)
+    elsif tile_obj&.builds_settlement?
+      activate_tile_build(row, col)
+    else
+      build_settlement(row, col)
+    end
+  end
+
   def available_list(active_player, terrain)
     return nil unless @game.playing?
     available = Array.new(20) { Array.new(20, false) }

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -992,11 +992,8 @@ class TurnEngine
   end
 
   # Returns the tile klass name (without "Tiles::" prefix) for the current action.
-  # Uses "klass" from current_action if present (stored by select_action),
-  # otherwise falls back to the capitalize convention for existing tiles.
   def current_action_tile_klass
-    phase = @game.turn_phase
-    phase.klass_name || "#{phase.type.capitalize}Tile"
+    @game.turn_phase.tile_klass_name
   end
 
   # Derives the tile klass name from the action type string.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,8 +79,6 @@ Rails.application.routes.draw do
       post :select_action
       post :end_tile_action
       post :activate_outpost
-      post :remove_settlement
-      post :place_wall
       post :remove_meeple
       post :select_meeple
       post :activate_fort

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -206,7 +206,9 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     game.save
     post session_url, params: { email_address: "paula@example.com", password: "password" }
 
-    post action_game_url(game), params: { build_row: 3, build_col: 6 }
+    assert_no_difference -> { game.reload.move_count.to_i } do
+      post action_game_url(game), params: { build_row: 3, build_col: 6 }
+    end
 
     assert game.reload.board_contents.empty?(3, 6)
   end

--- a/test/models/turn_phase_click_test.rb
+++ b/test/models/turn_phase_click_test.rb
@@ -74,4 +74,25 @@ class TurnPhaseClickTest < ActiveSupport::TestCase
     phase.click(coord(10, 10), engine)
     assert_equal [ [ :place_city_hall, 10, 10 ] ], engine.sent
   end
+
+  test "TileBuildPhase#click places a wall for a wall tile" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::TileBuildPhase.new(action_type: "quarry", klass_name: "QuarryTile", walls_placed: 0)
+    phase.click(coord(3, 6), engine)
+    assert_equal [ [ :place_wall, 3, 6 ] ], engine.sent
+  end
+
+  test "TileBuildPhase#click activates a tile build for a build tile" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::TileBuildPhase.new(action_type: "village", klass_name: "VillageTile")
+    phase.click(coord(3, 6), engine)
+    assert_equal [ [ :activate_tile_build, 3, 6 ] ], engine.sent
+  end
+
+  test "TileBuildPhase#click places a wall for a klass-less quarry action" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::TileBuildPhase.new(action_type: "quarry", klass_name: nil, walls_placed: 0)
+    phase.click(coord(3, 6), engine)
+    assert_equal [ [ :place_wall, 3, 6 ] ], engine.sent
+  end
 end

--- a/test/models/turn_phase_click_test.rb
+++ b/test/models/turn_phase_click_test.rb
@@ -46,4 +46,18 @@ class TurnPhaseClickTest < ActiveSupport::TestCase
     phase.click(coord(6, 7), engine)
     assert_equal [ [ :move_settlement, 6, 7 ] ], engine.sent
   end
+
+  test "MeepleActionPhase#click tells the engine to execute_meeple_action" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::MeepleActionPhase.new(action_type: "barracks", klass_name: "BarracksTile")
+    phase.click(coord(2, 3), engine)
+    assert_equal [ [ :execute_meeple_action, 2, 3 ] ], engine.sent
+  end
+
+  test "MeepleMovementPhase#click tells the engine to execute_meeple_action" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::MeepleMovementPhase.new(action_type: "wagon", klass_name: "WagonTile")
+    phase.click(coord(2, 3), engine)
+    assert_equal [ [ :execute_meeple_action, 2, 3 ] ], engine.sent
+  end
 end

--- a/test/models/turn_phase_click_test.rb
+++ b/test/models/turn_phase_click_test.rb
@@ -18,4 +18,32 @@ class TurnPhaseClickTest < ActiveSupport::TestCase
     TurnPhase::MandatoryBuildPhase.new.click(coord(3, 6), engine)
     assert_equal [ [ :build_settlement, 3, 6 ] ], engine.sent
   end
+
+  test "SettlementMovePhase#click selects the source when no from is set" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::SettlementMovePhase.new(action_type: "paddock", klass_name: "PaddockTile")
+    phase.click(coord(4, 5), engine)
+    assert_equal [ [ :select_settlement, 4, 5 ] ], engine.sent
+  end
+
+  test "SettlementMovePhase#click moves to the destination once from is set" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::SettlementMovePhase.new(action_type: "paddock", klass_name: "PaddockTile", from: "[4, 5]")
+    phase.click(coord(6, 7), engine)
+    assert_equal [ [ :move_settlement, 6, 7 ] ], engine.sent
+  end
+
+  test "ResettlementPhase#click selects the source when no from is set" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::ResettlementPhase.new(budget: 5, moves: 0)
+    phase.click(coord(4, 5), engine)
+    assert_equal [ [ :select_settlement, 4, 5 ] ], engine.sent
+  end
+
+  test "ResettlementPhase#click moves to the destination once from is set" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::ResettlementPhase.new(budget: 5, moves: 0, from: "[4, 5]")
+    phase.click(coord(6, 7), engine)
+    assert_equal [ [ :move_settlement, 6, 7 ] ], engine.sent
+  end
 end

--- a/test/models/turn_phase_click_test.rb
+++ b/test/models/turn_phase_click_test.rb
@@ -102,4 +102,17 @@ class TurnPhaseClickTest < ActiveSupport::TestCase
     phase.click(coord(5, 5), engine)
     assert_equal [ [ :activate_tile_build, 5, 5 ] ], engine.sent
   end
+
+  test "base TurnPhase#click rejects clicks (every concrete phase overrides it)" do
+    base = TurnPhase.allocate # bare base instance, no subclass behavior
+    assert_raises(TurnPhase::InvalidTransition) do
+      base.click(coord(0, 0), RecordingEngine.new)
+    end
+  end
+
+  test "LegacyPhase#click builds a settlement for unknown mandatory-shaped data" do
+    engine = RecordingEngine.new
+    TurnPhase::LegacyPhase.new({ "type" => "mandatory" }).click(coord(1, 1), engine)
+    assert_equal [ [ :build_settlement, 1, 1 ] ], engine.sent
+  end
 end

--- a/test/models/turn_phase_click_test.rb
+++ b/test/models/turn_phase_click_test.rb
@@ -60,4 +60,11 @@ class TurnPhaseClickTest < ActiveSupport::TestCase
     phase.click(coord(2, 3), engine)
     assert_equal [ [ :execute_meeple_action, 2, 3 ] ], engine.sent
   end
+
+  test "TargetedRemovalPhase#click tells the engine to remove_settlement" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::TargetedRemovalPhase.new(action_type: "sword", klass_name: "SwordTile", pending_orders: [ 1 ])
+    phase.click(coord(8, 9), engine)
+    assert_equal [ [ :remove_settlement, 8, 9 ] ], engine.sent
+  end
 end

--- a/test/models/turn_phase_click_test.rb
+++ b/test/models/turn_phase_click_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class TurnPhaseClickTest < ActiveSupport::TestCase
+  # Records outgoing engine messages so a phase's click can be tested in
+  # isolation, without a Game. Asserts the command the phase SENDS, per the
+  # State-pattern design (behavior itself is pinned by test/scenarios).
+  class RecordingEngine
+    attr_reader :sent
+    def initialize = @sent = []
+    def method_missing(name, *args) = @sent << [ name, *args ]
+    def respond_to_missing?(*) = true
+  end
+
+  def coord(row, col) = Coordinate.new(row, col)
+
+  test "MandatoryBuildPhase#click tells the engine to build_settlement" do
+    engine = RecordingEngine.new
+    TurnPhase::MandatoryBuildPhase.new.click(coord(3, 6), engine)
+    assert_equal [ [ :build_settlement, 3, 6 ] ], engine.sent
+  end
+end

--- a/test/models/turn_phase_click_test.rb
+++ b/test/models/turn_phase_click_test.rb
@@ -95,4 +95,11 @@ class TurnPhaseClickTest < ActiveSupport::TestCase
     phase.click(coord(3, 6), engine)
     assert_equal [ [ :place_wall, 3, 6 ] ], engine.sent
   end
+
+  test "FortPhase#click tells the engine to activate_tile_build" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::FortPhase.new(fort_terrain: "G")
+    phase.click(coord(5, 5), engine)
+    assert_equal [ [ :activate_tile_build, 5, 5 ] ], engine.sent
+  end
 end

--- a/test/models/turn_phase_click_test.rb
+++ b/test/models/turn_phase_click_test.rb
@@ -67,4 +67,11 @@ class TurnPhaseClickTest < ActiveSupport::TestCase
     phase.click(coord(8, 9), engine)
     assert_equal [ [ :remove_settlement, 8, 9 ] ], engine.sent
   end
+
+  test "CityHallPhase#click tells the engine to place_city_hall" do
+    engine = RecordingEngine.new
+    phase = TurnPhase::CityHallPhase.new(action_type: "cityhall", klass_name: "CityHallTile")
+    phase.click(coord(10, 10), engine)
+    assert_equal [ [ :place_city_hall, 10, 10 ] ], engine.sent
+  end
 end


### PR DESCRIPTION
## One door into the Turn

Collapses `GamesController#action`'s tile-predicate dispatch into a single `TurnEngine#click(coordinate)` command that the active `TurnPhase` interprets **polymorphically** (State pattern: phase = State, engine = Context). The web layer no longer reasons about tiles.

### Why
`#action` used to instantiate a tile, probe ~6 capability predicates, and read `current_action["from"]` to pick among ~7 engine mutators — a leaky seam where the controller knew tile semantics. Now the controller just passes a `Coordinate` to `engine.click`, and each Sub-phase knows what a click means for it. Adding a tile action becomes a **domain-only change**.

### How — incremental per-phase strangler (anti-big-bang)
The prior Turn-stack rewrite (PR #217) was reverted for cutting over big-bang. This one strangles one phase at a time, green at every commit:

1. Move `#action`'s dispatch verbatim into `TurnEngine#click` (decision leaves the web layer).
2. Move it onto base `TurnPhase#click`; `engine.click` delegates.
3–9. Override `click` on each concrete phase (move/resettle, meeple, removal, city-hall, tile-build, fort, mandatory), base conditional left intact and shadowed.
10. Base `#click` raises; `LegacyPhase` owns the probe — dispatch fully polymorphic.
11. Controller cleanup: `require_current_player` before_action, `broadcast_game_update` after_action, delete the dead `remove_settlement`/`place_wall` actions + routes.

Plus `TurnPhase#tile_klass_name` extracted to dedup the type-derived fallback shared with `TurnEngine#current_action_tile_klass`.

### Behavior preservation
Behavior-neutral by construction. The `#action` endpoint and `build_row`/`build_col` params are unchanged (no `gameboard.js`/system-test changes). Existing controller tests + the `test/scenarios/` net pin equivalence; per-phase unit tests assert the outgoing engine message via a recording double. **Full suite: 1045 unit + 14 system tests, 0 failures.** A final whole-branch review traced every tile through both the phase-selection and click-dispatch paths and confirmed equivalence.

### Follow-up (not in this PR)
`undo_move` was never current-player-gated at baseline; it's deliberately **excluded** from `require_current_player` here to keep this refactor behavior-preserving. Whether a non-current player should be able to undo is a separate, untested decision worth a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
