### PR TITLE
Finish ADR-0001: composite legal-target query behind TurnPhase

### DIFF
--- a/app/models/board_state.rb
+++ b/app/models/board_state.rb
@@ -94,6 +94,17 @@ class BoardState
     empty?(row, col) && !warrior_blocked?(row, col)
   end
 
+  # Every buildable cell (empty, not warrior-blocked) whose terrain is in
+  # `terrains`, row-major. The "anywhere on this terrain" set used by the
+  # Outpost power (ADR-0001's "all buildable terrain cells" primitive).
+  def available_cells_of(terrains)
+    (0..19).flat_map do |row|
+      (0..19).filter_map do |col|
+        [ row, col ] if available_for_building?(row, col) && terrains.include?(terrain_at(row, col))
+      end
+    end
+  end
+
   def move_settlement(from_row, from_col, to_row, to_col)
     cell = @cells.delete([ from_row, from_col ])
     @cells[[ to_row, to_col ]] = cell

--- a/app/models/board_state.rb
+++ b/app/models/board_state.rb
@@ -94,6 +94,23 @@ class BoardState
     empty?(row, col) && !warrior_blocked?(row, col)
   end
 
+  # The "adjacent if possible, else anywhere" build rule (ADR-0001): buildable
+  # cells of `terrain` adjacent to one of player_order's pieces; or, when the
+  # player has no such adjacency, every buildable cell of that terrain. Pass
+  # `excluding` to drop a source cell (a settlement mid-relocation). Shared by
+  # mandatory builds (MandatoryBuildPhase) and the location build tiles
+  # (Tiles::Tile#valid_destinations) so the rule lives in exactly one place.
+  def buildable_cells_for(player_order, terrain, excluding: nil)
+    sources = settlements_for(player_order)
+    sources = sources.reject { |cell| cell == excluding } if excluding
+    adjacent = sources.flat_map do |row, col|
+      neighbors_where(row, col) { |nr, nc| available_for_building?(nr, nc) && terrain_at(nr, nc) == terrain }
+    end.uniq
+    return adjacent unless adjacent.empty?
+
+    available_cells_of([ terrain ])
+  end
+
   # Every buildable cell (empty, not warrior-blocked) whose terrain is in
   # `terrains`, row-major. The "anywhere on this terrain" set used by the
   # Outpost power (ADR-0001's "all buildable terrain cells" primitive).

--- a/app/models/tiles/tile.rb
+++ b/app/models/tiles/tile.rb
@@ -39,22 +39,8 @@ module Tiles
       terrain = build_terrain || hand
       return [] unless terrain
 
-      settlements = board_contents.settlements_for(player_order)
-      settlements = settlements.reject { |r, c| r == from_row && c == from_col } if from_row && from_col
-
-      adjacent = settlements.flat_map do |r, c|
-        board_contents.neighbors_where(r, c) do |nr, nc|
-          board_contents.available_for_building?(nr, nc) && board_contents.terrain_at(nr, nc) == terrain
-        end
-      end.uniq
-
-      return adjacent unless adjacent.empty?
-
-      (0..19).flat_map do |r|
-        (0..19).filter_map do |c|
-          [ r, c ] if board_contents.available_for_building?(r, c) && board_contents.terrain_at(r, c) == terrain
-        end
-      end
+      excluding = (from_row && from_col) ? [ from_row, from_col ] : nil
+      board_contents.buildable_cells_for(player_order, terrain, excluding: excluding)
     end
 
     def selectable_settlements(player_order:, board_contents:, hand: nil, supply: Hash.new(0), budget: nil)

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -109,7 +109,7 @@ class TurnPhase
   # this phase — the cells the UI highlights and every action guard checks
   # (via TurnEngine#legal_targets). Each concrete phase owns its own rule
   # (State pattern); the base has none. `board_contents` is terrain-aware.
-  def legal_targets(board_contents:, player:)
+  def legal_targets(board_contents:, player:, game: nil)
     []
   end
 
@@ -175,7 +175,7 @@ end
 # and the step budget (only ResettlementTile consumes it; other movers ignore
 # it). The including phase supplies tile/from/budget/effective_terrain.
 module TurnPhase::SettlementMoveTargets
-  def legal_targets(board_contents:, player:)
+  def legal_targets(board_contents:, player:, game: nil)
     terrains =
       if tile.uses_played_terrain? && effective_terrain(player).nil?
         player.hand
@@ -315,6 +315,15 @@ class TurnPhase::TileBuildPhase < TurnPhase
 
   def tile_action_endable? = walls_placed.to_i >= 1
 
+  def legal_targets(board_contents:, player:, game: nil)
+    return [] if tile.places_wall? && game.stone_walls <= 0
+    if tile.builds_settlement? && outpost_active?
+      board_contents.available_cells_of(outpost_terrains(player))
+    else
+      played_terrain_targets(board_contents, player)
+    end
+  end
+
   # This phase spans both wall tiles (quarry) and build tiles (village, farm,
   # ...), so it asks its OWN reconstructed tile which one it is.
   # tile_klass_name (not bare klass_name) applies the type-derived fallback:
@@ -381,6 +390,35 @@ class TurnPhase::TileBuildPhase < TurnPhase
     hash["outpost_active"] = true if outpost_active?
     hash
   end
+
+  private
+
+  # Destinations on the tile's terrain: a fixed-terrain tile (Farm/Oasis/...)
+  # ignores the hand; a played-terrain tile (Oracle/Quarry) uses the locked
+  # terrain, or spans both cards of an as-yet-unlocked two-card hand.
+  def played_terrain_targets(board_contents, player)
+    if tile.uses_played_terrain? && effective_terrain(player).nil?
+      player.hand.flat_map do |terrain|
+        tile.valid_destinations(board_contents: board_contents, player_order: player.order, hand: terrain)
+      end.uniq
+    else
+      tile.valid_destinations(
+        board_contents: board_contents, player_order: player.order,
+        hand: effective_terrain(player) || player.hand.first
+      )
+    end
+  end
+
+  # The terrain(s) an Outpost build may target (adjacency waived): a played-
+  # terrain tile with an unlocked two-card hand spans both, otherwise the tile's
+  # fixed build terrain (or the locked/sole hand card).
+  def outpost_terrains(player)
+    if tile.uses_played_terrain? && effective_terrain(player).nil?
+      player.hand
+    else
+      [ tile.build_terrain || effective_terrain(player) || player.hand.first ].compact
+    end
+  end
 end
 
 class TurnPhase::FortPhase < TurnPhase
@@ -406,7 +444,7 @@ class TurnPhase::FortPhase < TurnPhase
     fort_terrain_value
   end
 
-  def legal_targets(board_contents:, player:)
+  def legal_targets(board_contents:, player:, game: nil)
     tile.valid_destinations(
       board_contents: board_contents, player_order: player.order, hand: fort_terrain
     )
@@ -623,7 +661,7 @@ class TurnPhase::MeepleMovementPhase < TurnPhase
   def tile_action_endable? = moves.to_i >= 1
   def accepts_source_selection? = true
 
-  def legal_targets(board_contents:, player:)
+  def legal_targets(board_contents:, player:, game: nil)
     if from
       return [] if budget.to_i <= 0
       src = Coordinate.from_key(from)
@@ -708,7 +746,7 @@ class TurnPhase::TargetedRemovalPhase < TurnPhase
 
   # consume_target is inherited from TurnPhase — its self.class is this class.
 
-  def legal_targets(board_contents:, player:)
+  def legal_targets(board_contents:, player:, game: nil)
     pending_orders.flat_map do |order|
       board_contents.settlements_for(order).reject { |r, c| board_contents.city_hall_at?(r, c) }
     end
@@ -750,7 +788,7 @@ class TurnPhase::MeepleActionPhase < TurnPhase
     klass_value
   end
 
-  def legal_targets(board_contents:, player:)
+  def legal_targets(board_contents:, player:, game: nil)
     tile.valid_destinations(
       board_contents: board_contents, player_order: player.order, supply: player.supply_hash
     )
@@ -793,7 +831,7 @@ class TurnPhase::CityHallPhase < TurnPhase
 
   def city_hall? = true
 
-  def legal_targets(board_contents:, player:)
+  def legal_targets(board_contents:, player:, game: nil)
     tile.valid_destinations(
       board_contents: board_contents, player_order: player.order, supply: player.supply_hash
     )

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -69,6 +69,13 @@ class TurnPhase
     klass_name || "#{type.capitalize}Tile"
   end
 
+  # The tile object backing this phase's action (built from tile_klass_name),
+  # used by legal_targets to delegate to the tile's own valid_destinations /
+  # selectable_settlements. nil for phases with no tile (e.g. mandatory).
+  def tile
+    Tiles::Tile.for_klass(tile_klass_name)&.new(0)
+  end
+
   def chosen_terrain
     serialize["chosen_terrain"]
   end
@@ -97,6 +104,14 @@ class TurnPhase
   # Clicking one of your own pieces starts a transition(SourceSelected) rather
   # than the LegacyPhase fallback. True for the move/resettlement phases.
   def accepts_source_selection? = false
+
+  # The set of board cells (as [row, col]) that are legal action targets in
+  # this phase — the cells the UI highlights and every action guard checks
+  # (via TurnEngine#legal_targets). Each concrete phase owns its own rule
+  # (State pattern); the base has none. `board_contents` is terrain-aware.
+  def legal_targets(board_contents:, player:)
+    []
+  end
 
   # Return a copy of this phase with the outpost power active. Non-build phases
   # fall back to a fresh mandatory build (the engine only activates the outpost
@@ -347,6 +362,12 @@ class TurnPhase::FortPhase < TurnPhase
 
   def fort_terrain
     fort_terrain_value
+  end
+
+  def legal_targets(board_contents:, player:)
+    tile.valid_destinations(
+      board_contents: board_contents, player_order: player.order, hand: fort_terrain
+    )
   end
 
   def click(coordinate, engine)
@@ -627,6 +648,12 @@ class TurnPhase::TargetedRemovalPhase < TurnPhase
 
   # consume_target is inherited from TurnPhase — its self.class is this class.
 
+  def legal_targets(board_contents:, player:)
+    pending_orders.flat_map do |order|
+      board_contents.settlements_for(order).reject { |r, c| board_contents.city_hall_at?(r, c) }
+    end
+  end
+
   def click(coordinate, engine)
     engine.remove_settlement(coordinate.row, coordinate.col)
   end
@@ -699,6 +726,12 @@ class TurnPhase::CityHallPhase < TurnPhase
   end
 
   def city_hall? = true
+
+  def legal_targets(board_contents:, player:)
+    tile.valid_destinations(
+      board_contents: board_contents, player_order: player.order, supply: player.supply_hash
+    )
+  end
 
   def click(coordinate, engine)
     engine.place_city_hall(coordinate.row, coordinate.col)

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -230,6 +230,16 @@ class TurnPhase::MandatoryBuildPhase < TurnPhase
 
   def mandatory_build? = true
 
+  def legal_targets(board_contents:, player:, game: nil)
+    return [] unless player.settlements_remaining? && game.mandatory_count > 0
+    terrains = effective_terrain(player) ? [ effective_terrain(player) ] : player.hand
+    if outpost_active?
+      board_contents.available_cells_of(terrains)
+    else
+      terrains.flat_map { |terrain| board_contents.buildable_cells_for(player.order, terrain) }.uniq
+    end
+  end
+
   def click(coordinate, engine)
     engine.build_settlement(coordinate.row, coordinate.col)
   end

--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -113,6 +113,13 @@ class TurnPhase
     []
   end
 
+  # The terrain this phase's build is locked to: the chosen terrain if the hand
+  # was already committed, otherwise the sole hand card (a two-card hand stays
+  # unlocked → nil). Shared by the build and settlement-move phases.
+  def effective_terrain(player)
+    chosen_terrain || (player.hand.size == 1 ? player.hand.first : nil)
+  end
+
   # Return a copy of this phase with the outpost power active. Non-build phases
   # fall back to a fresh mandatory build (the engine only activates the outpost
   # during a build action).
@@ -158,6 +165,41 @@ class TurnPhase
 
   def transition(_event, _facts)
     raise InvalidTransition, "#{self.class.name} does not accept that event"
+  end
+end
+
+# Shared legal-targets rule for the settlement movers (paddock/barn via
+# SettlementMovePhase, resettlement via ResettlementPhase): before a source is
+# picked, the selectable settlements; after, that settlement's valid
+# destinations. Both thread the played terrain (a two-card hand widens the set)
+# and the step budget (only ResettlementTile consumes it; other movers ignore
+# it). The including phase supplies tile/from/budget/effective_terrain.
+module TurnPhase::SettlementMoveTargets
+  def legal_targets(board_contents:, player:)
+    terrains =
+      if tile.uses_played_terrain? && effective_terrain(player).nil?
+        player.hand
+      else
+        [ effective_terrain(player) || player.hand.first ]
+      end
+    step_budget = budget.to_i
+
+    if from
+      src = Coordinate.from_key(from)
+      terrains.flat_map do |terrain|
+        tile.valid_destinations(
+          from_row: src.row, from_col: src.col, board_contents: board_contents,
+          player_order: player.order, hand: terrain, budget: step_budget
+        )
+      end.uniq
+    else
+      terrains.flat_map do |terrain|
+        tile.selectable_settlements(
+          player_order: player.order, board_contents: board_contents,
+          hand: terrain, budget: step_budget
+        )
+      end.uniq
+    end
   end
 end
 
@@ -384,6 +426,7 @@ class TurnPhase::FortPhase < TurnPhase
 end
 
 class TurnPhase::SettlementMovePhase < TurnPhase
+  include TurnPhase::SettlementMoveTargets
   attr_reader :action_type, :klass_value, :from_value
 
   def self.from_hash(hash)
@@ -453,6 +496,7 @@ class TurnPhase::SettlementMovePhase < TurnPhase
 end
 
 class TurnPhase::ResettlementPhase < TurnPhase
+  include TurnPhase::SettlementMoveTargets
   attr_reader :budget_value, :moves_value, :from_value
 
   def self.from_hash(hash)
@@ -579,6 +623,22 @@ class TurnPhase::MeepleMovementPhase < TurnPhase
   def tile_action_endable? = moves.to_i >= 1
   def accepts_source_selection? = true
 
+  def legal_targets(board_contents:, player:)
+    if from
+      return [] if budget.to_i <= 0
+      src = Coordinate.from_key(from)
+      destinations = tile.valid_destinations(
+        from_row: src.row, from_col: src.col,
+        board_contents: board_contents, player_order: player.order
+      )
+      board_contents.neighbors(src.row, src.col).select { |cell| destinations.include?(cell) }
+    else
+      tile.valid_destinations(
+        board_contents: board_contents, player_order: player.order, supply: player.supply_hash
+      )
+    end
+  end
+
   def click(coordinate, engine)
     engine.execute_meeple_action(coordinate.row, coordinate.col)
   end
@@ -688,6 +748,12 @@ class TurnPhase::MeepleActionPhase < TurnPhase
 
   def klass_name
     klass_value
+  end
+
+  def legal_targets(board_contents:, player:)
+    tile.valid_destinations(
+      board_contents: board_contents, player_order: player.order, supply: player.supply_hash
+    )
   end
 
   def click(coordinate, engine)

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -786,22 +786,7 @@ class TurnEngine
           if tile_obj.sword_tile?
             current_phase.legal_targets(board_contents: @game.board_contents, player: player)
           elsif tile_obj.places_meeple?
-            if current_phase.from
-              from = Coordinate.from_key(current_phase.from)
-              if current_phase.budget.to_i <= 0
-                []
-              else
-                @game.board_contents.neighbors(from.row, from.col).select do |row, col|
-                  meeple_step_available?(from, row, col, tile_obj)
-                end
-              end
-            else
-              tile_obj.valid_destinations(
-                board_contents: @game.board_contents,
-                player_order: player.order,
-                supply: player.supply_hash
-              )
-            end
+            current_phase.legal_targets(board_contents: @game.board_contents, player: player)
           elsif tile_obj.places_wall?
             if @game.stone_walls <= 0
               []
@@ -816,33 +801,7 @@ class TurnEngine
               )
             end
           elsif tile_obj.moves_settlement?
-            # budget only gates ResettlementTile; every other mover accepts and
-            # ignores it, so it can be passed uniformly without special-casing.
-            hand_arg = effective_terrain(player) || player.hand.first
-            budget = current_phase.budget.to_i
-            if current_phase.from
-              from = Coordinate.from_key(current_phase.from)
-              if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
-                player.hand.flat_map { |t|
-                  tile_obj.valid_destinations(from_row: from.row, from_col: from.col, board_contents: @game.board_contents, player_order: player.order, hand: t, budget:)
-                }.uniq
-              else
-                tile_obj.valid_destinations(
-                  from_row: from.row, from_col: from.col,
-                  board_contents: @game.board_contents, player_order: player.order, hand: hand_arg, budget:
-                )
-              end
-            else
-              if tile_obj.uses_played_terrain? && effective_terrain(player).nil?
-                player.hand.flat_map { |t|
-                  tile_obj.selectable_settlements(player_order: player.order, board_contents: @game.board_contents, hand: t, budget:)
-                }.uniq
-              else
-                tile_obj.selectable_settlements(
-                  player_order: player.order, board_contents: @game.board_contents, hand: hand_arg, budget:
-                )
-              end
-            end
+            current_phase.legal_targets(board_contents: @game.board_contents, player: player)
           elsif tile_obj.places_city_hall?
             current_phase.legal_targets(board_contents: @game.board_contents, player: player)
           else
@@ -1282,14 +1241,6 @@ class TurnEngine
   # One move step is legal when a hop remains this turn and the destination is
   # among the piece's adjacent single-step destinations (the tile owns the
   # terrain rule via valid_destinations).
-  def meeple_step_available?(from_coord, row, col, tile_obj)
-    @game.turn_phase.budget.to_i > 0 &&
-      tile_obj.valid_destinations(
-        from_row: from_coord.row, from_col: from_coord.col,
-        board_contents: @game.board_contents,
-        player_order: @game.current_player.order
-      ).include?([ row, col ])
-  end
 
   def place_warrior(row, col, game_player, tile_klass:)
     record_move(

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -7,33 +7,15 @@ class TurnEngine
     @game.turn_phase.click(coordinate, self)
   end
 
+  # A 20x20 boolean grid of the cells legal for a mandatory-style build of
+  # `terrain` (used for 2-card terrain disambiguation and view highlighting).
+  # A grid view of BoardState#buildable_cells_for — the adjacent-if-possible
+  # rule lives there, not here.
   def available_list(active_player, terrain)
     return nil unless @game.playing?
-    available = Array.new(20) { Array.new(20, false) }
-
-    any = false
-    20.times do |row|
-      20.times do |col|
-        if @game.board_contents.player_at(row, col) == active_player
-          @game.board_contents.neighbors(row, col).each do |nr, nc|
-            if @game.board_contents.empty?(nr, nc) && @game.board_contents.terrain_at(nr, nc) == terrain &&
-               !@game.board_contents.warrior_blocked?(nr, nc)
-              any = available[nr][nc] = true
-            end
-          end
-        end
-      end
-    end
-    return available if any
-
-    20.times do |row|
-      20.times do |col|
-        if @game.board_contents.terrain_at(row, col) == terrain && !@game.board_contents.warrior_blocked?(row, col)
-          available[row][col] = true if @game.board_contents.empty?(row, col)
-        end
-      end
-    end
-    available
+    grid = Array.new(20) { Array.new(20, false) }
+    @game.board_contents.buildable_cells_for(active_player, terrain).each { |row, col| grid[row][col] = true }
+    grid
   end
 
   def build_settlement(row, col)
@@ -748,46 +730,16 @@ class TurnEngine
     end
   end
 
+  # The cells the current player may legally target right now, owned by the
+  # active sub-phase (State pattern). Recomputed each call (no memo): a derived
+  # view of mutable game state that the guards read mid-action, so caching
+  # across a mutation would be unsafe.
   def buildable_cells
     return [] unless @game.playing?
-    # Recomputed each call (no memo): it is a derived view of mutable game state,
-    # and the guards now read it mid-action, so caching across a mutation is unsafe.
-    begin
-      @game.instantiate
-      player = @game.current_player
-      current_phase = @game.turn_phase
-      action = current_phase.type
-
-      if action == "mandatory"
-        if player.settlements_remaining? && @game.mandatory_count > 0
-          if current_phase.outpost_active?
-            terrains = effective_terrain(player) ? [ effective_terrain(player) ] : player.hand
-            (0..19).flat_map do |r|
-              (0..19).filter_map do |c|
-                [ r, c ] if @game.board_contents.available_for_building?(r, c) &&
-                  terrains.include?(@game.board_contents.terrain_at(r, c))
-              end
-            end
-          else
-            terrains = effective_terrain(player) ? [ effective_terrain(player) ] : player.hand
-            terrains.flat_map { |t|
-              list = available_list(player.order, t)
-              (0..19).flat_map { |r| (0..19).filter_map { |c| [ r, c ] if list[r][c] } }
-            }.uniq
-          end
-        else
-          []
-        end
-      else
-        klass = current_action_tile_klass
-        tile = player.find_unused_tile(klass)
-        if tile
-          current_phase.legal_targets(board_contents: @game.board_contents, player: player, game: @game)
-        else
-          []
-        end
-      end
-    end
+    @game.instantiate
+    @game.turn_phase.legal_targets(
+      board_contents: @game.board_contents, player: @game.current_player, game: @game
+    )
   end
 
   # Canonical set of hexes the current player may legally click right now, for

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -782,52 +782,7 @@ class TurnEngine
         klass = current_action_tile_klass
         tile = player.find_unused_tile(klass)
         if tile
-          tile_obj = Tiles::Tile.from_hash(tile)
-          if tile_obj.sword_tile?
-            current_phase.legal_targets(board_contents: @game.board_contents, player: player)
-          elsif tile_obj.places_meeple?
-            current_phase.legal_targets(board_contents: @game.board_contents, player: player)
-          elsif tile_obj.places_wall?
-            if @game.stone_walls <= 0
-              []
-            elsif tile_obj.uses_played_terrain? && effective_terrain(player).nil?
-              player.hand.flat_map { |t|
-                tile_obj.valid_destinations(board_contents: @game.board_contents, player_order: player.order, hand: t)
-              }.uniq
-            else
-              tile_obj.valid_destinations(
-                board_contents: @game.board_contents,
-                player_order: player.order, hand: effective_terrain(player) || player.hand.first
-              )
-            end
-          elsif tile_obj.moves_settlement?
-            current_phase.legal_targets(board_contents: @game.board_contents, player: player)
-          elsif tile_obj.places_city_hall?
-            current_phase.legal_targets(board_contents: @game.board_contents, player: player)
-          else
-            if tile_obj.builds_settlement? && current_phase.outpost_active?
-              terrains = outpost_build_terrains(tile_obj, current_phase, player)
-              (0..19).flat_map do |r|
-                (0..19).filter_map do |c|
-                  [ r, c ] if @game.board_contents.available_for_building?(r, c) &&
-                    terrains.include?(@game.board_contents.terrain_at(r, c))
-                end
-              end
-            elsif tile_obj.fort_tile?
-              current_phase.legal_targets(board_contents: @game.board_contents, player: player)
-            elsif tile_obj.uses_played_terrain? && effective_terrain(player).nil?
-              player.hand.flat_map { |t|
-                tile_obj.valid_destinations(
-                  board_contents: @game.board_contents, player_order: player.order, hand: t
-                )
-              }.uniq
-            else
-              hand = effective_terrain(player) || player.hand.first
-              tile_obj.valid_destinations(
-                board_contents: @game.board_contents, player_order: player.order, hand: hand
-              )
-            end
-          end
+          current_phase.legal_targets(board_contents: @game.board_contents, player: player, game: @game)
         else
           []
         end
@@ -932,15 +887,6 @@ class TurnEngine
     klass&.new(0)&.builds_settlement? || false
   end
 
-  def outpost_build_terrains(tile_obj, current_phase, game_player)
-    if tile_obj.fort_tile?
-      [ current_phase.fort_terrain ].compact
-    elsif tile_obj.uses_played_terrain? && effective_terrain(game_player).nil?
-      game_player.hand
-    else
-      [ tile_obj.build_terrain || effective_terrain(game_player) || game_player.hand.first ].compact
-    end
-  end
 
   # Returns the tile klass name (without "Tiles::" prefix) for the current action.
   def current_action_tile_klass

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -784,10 +784,7 @@ class TurnEngine
         if tile
           tile_obj = Tiles::Tile.from_hash(tile)
           if tile_obj.sword_tile?
-            pending_orders = current_phase.pending_orders
-            pending_orders.flat_map { |order|
-              @game.board_contents.settlements_for(order).reject { |r, c| @game.board_contents.city_hall_at?(r, c) }
-            }
+            current_phase.legal_targets(board_contents: @game.board_contents, player: player)
           elsif tile_obj.places_meeple?
             if current_phase.from
               from = Coordinate.from_key(current_phase.from)
@@ -847,9 +844,7 @@ class TurnEngine
               end
             end
           elsif tile_obj.places_city_hall?
-            tile_obj.valid_destinations(
-              board_contents: @game.board_contents, player_order: player.order, supply: player.supply_hash
-            )
+            current_phase.legal_targets(board_contents: @game.board_contents, player: player)
           else
             if tile_obj.builds_settlement? && current_phase.outpost_active?
               terrains = outpost_build_terrains(tile_obj, current_phase, player)
@@ -860,10 +855,7 @@ class TurnEngine
                 end
               end
             elsif tile_obj.fort_tile?
-              hand = current_phase.fort_terrain
-              tile_obj.valid_destinations(
-                board_contents: @game.board_contents, player_order: player.order, hand: hand
-              )
+              current_phase.legal_targets(board_contents: @game.board_contents, player: player)
             elsif tile_obj.uses_played_terrain? && effective_terrain(player).nil?
               player.hand.flat_map { |t|
                 tile_obj.valid_destinations(

--- a/test/models/turn_phase_legal_targets_test.rb
+++ b/test/models/turn_phase_legal_targets_test.rb
@@ -53,6 +53,62 @@ class TurnPhaseLegalTargetsTest < ActiveSupport::TestCase
     targets.each { |r, c| assert_equal "D", board.terrain_at(r, c) }
   end
 
+  test "SettlementMovePhase without a source lists the movable settlements; with one, its destinations" do
+    game, player = playing_game(hand: [ "G" ])
+    board = with_terrain(game.board_contents, game.instantiate)
+    board.place_settlement(5, 6, player.order)
+    tile = Tiles::Location::PaddockTile.new(0)
+
+    unsourced = TurnPhase::SettlementMovePhase.new(action_type: "paddock", klass_name: "PaddockTile")
+    assert_equal tile.selectable_settlements(player_order: player.order, board_contents: board, hand: "G", budget: 0),
+      unsourced.legal_targets(board_contents: board, player: player)
+    assert_includes unsourced.legal_targets(board_contents: board, player: player), [ 5, 6 ]
+
+    sourced = TurnPhase::SettlementMovePhase.new(action_type: "paddock", klass_name: "PaddockTile", from: "[5, 6]")
+    assert_equal tile.valid_destinations(from_row: 5, from_col: 6, board_contents: board, player_order: player.order, hand: "G", budget: 0),
+      sourced.legal_targets(board_contents: board, player: player)
+  end
+
+  test "ResettlementPhase gates its destinations by the remaining step budget" do
+    game, player = playing_game(hand: [ "G" ])
+    board = with_terrain(game.board_contents, game.instantiate)
+    board.place_settlement(5, 6, player.order)
+    tile = Tiles::Nomad::ResettlementTile.new(0)
+
+    phase = TurnPhase::ResettlementPhase.new(budget: 4, moves: 0, from: "[5, 6]")
+    assert_equal tile.valid_destinations(from_row: 5, from_col: 6, board_contents: board, player_order: player.order, hand: "G", budget: 4),
+      phase.legal_targets(board_contents: board, player: player)
+  end
+
+  test "MeepleActionPhase delegates to the tile's valid destinations (barracks placement)" do
+    game, player = playing_game(hand: [ "G" ])
+    player.add_warriors!(2)
+    player.save!
+    board = with_terrain(game.board_contents, game.instantiate)
+    board.place_settlement(1, 1, player.order)
+    tile = Tiles::Tile.for_klass("BarracksTile").new(0)
+    phase = TurnPhase::MeepleActionPhase.new(action_type: "barracks", klass_name: "BarracksTile")
+
+    expected = tile.valid_destinations(board_contents: board, player_order: player.order, supply: player.supply_hash)
+    assert_equal expected, phase.legal_targets(board_contents: board, player: player)
+    assert expected.any?
+  end
+
+  test "MeepleMovementPhase offers placement before a source and nothing once the budget is spent" do
+    game, player = playing_game(hand: [ "G" ])
+    player.add_wagons!(1)
+    player.save!
+    board = with_terrain(game.board_contents, game.instantiate)
+    tile = Tiles::Tile.for_klass("WagonTile").new(0)
+
+    unsourced = TurnPhase::MeepleMovementPhase.new(action_type: "wagon", klass_name: "WagonTile")
+    assert_equal tile.valid_destinations(board_contents: board, player_order: player.order, supply: player.supply_hash),
+      unsourced.legal_targets(board_contents: board, player: player)
+
+    spent = TurnPhase::MeepleMovementPhase.new(action_type: "wagon", klass_name: "WagonTile", from: "[3, 3]", budget: 0, moves: 3)
+    assert_empty spent.legal_targets(board_contents: board, player: player)
+  end
+
   private
 
   # A minimal playing game on the scenario's fixed board, with a clean board.

--- a/test/models/turn_phase_legal_targets_test.rb
+++ b/test/models/turn_phase_legal_targets_test.rb
@@ -109,6 +109,38 @@ class TurnPhaseLegalTargetsTest < ActiveSupport::TestCase
     assert_empty spent.legal_targets(board_contents: board, player: player)
   end
 
+  test "TileBuildPhase (quarry) has no wall targets when stone walls are exhausted" do
+    game, player = playing_game(hand: [ "G" ])
+    game.update!(stone_walls: 0)
+    board = with_terrain(game.board_contents, game.instantiate)
+    board.place_settlement(5, 6, player.order)
+    phase = TurnPhase::TileBuildPhase.new(action_type: "quarry", klass_name: "QuarryTile")
+
+    assert_empty phase.legal_targets(board_contents: board, player: player, game: game)
+  end
+
+  test "TileBuildPhase (build tile) targets the tile's terrain" do
+    game, player = playing_game(hand: [ "G" ])
+    board = with_terrain(game.board_contents, game.instantiate)
+    tile = Tiles::Tile.for_klass("OasisTile").new(0) # builds on Desert
+    phase = TurnPhase::TileBuildPhase.new(action_type: "oasis", klass_name: "OasisTile")
+
+    targets = phase.legal_targets(board_contents: board, player: player, game: game)
+    assert_equal tile.valid_destinations(board_contents: board, player_order: player.order, hand: "G"), targets
+    assert targets.any?
+  end
+
+  test "TileBuildPhase with outpost active spans the whole build terrain, adjacency waived" do
+    game, player = playing_game(hand: [ "D" ])
+    board = with_terrain(game.board_contents, game.instantiate)
+    phase = TurnPhase::TileBuildPhase.new(action_type: "oasis", klass_name: "OasisTile", outpost_active: true)
+
+    targets = phase.legal_targets(board_contents: board, player: player, game: game)
+
+    assert_equal board.available_cells_of([ "D" ]).to_set, targets.to_set
+    assert targets.any?
+  end
+
   private
 
   # A minimal playing game on the scenario's fixed board, with a clean board.

--- a/test/models/turn_phase_legal_targets_test.rb
+++ b/test/models/turn_phase_legal_targets_test.rb
@@ -141,6 +141,30 @@ class TurnPhaseLegalTargetsTest < ActiveSupport::TestCase
     assert targets.any?
   end
 
+  test "MandatoryBuildPhase uses the adjacent-else-anywhere rule, and none once mandatory is done" do
+    game, player = playing_game(hand: [ "G" ])
+    board = with_terrain(game.board_contents, game.instantiate)
+    phase = TurnPhase::MandatoryBuildPhase.new
+
+    assert_equal board.buildable_cells_for(player.order, "G"),
+      phase.legal_targets(board_contents: board, player: player, game: game)
+
+    game.update!(mandatory_count: 0)
+    assert_empty phase.legal_targets(board_contents: board, player: player, game: game)
+  end
+
+  test "MandatoryBuildPhase with a two-card hand spans both terrains" do
+    game, player = playing_game(hand: %w[G D])
+    board = with_terrain(game.board_contents, game.instantiate)
+    phase = TurnPhase::MandatoryBuildPhase.new
+
+    targets = phase.legal_targets(board_contents: board, player: player, game: game)
+    terrains = targets.map { |cell| board.terrain_at(*cell) }.uniq
+
+    assert_includes terrains, "G"
+    assert_includes terrains, "D"
+  end
+
   private
 
   # A minimal playing game on the scenario's fixed board, with a clean board.

--- a/test/models/turn_phase_legal_targets_test.rb
+++ b/test/models/turn_phase_legal_targets_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+# Unit tests for each phase's legal_targets — the composite "legal targets for
+# the active sub-phase" query (ADR-0001), owned by the phase (State pattern)
+# rather than a conditional in TurnEngine. Scenario/tile tests cover the
+# end-to-end parity; these pin each phase's rule in isolation.
+class TurnPhaseLegalTargetsTest < ActiveSupport::TestCase
+  test "base TurnPhase has no legal targets" do
+    assert_equal [], TurnPhase.new.legal_targets(board_contents: BoardState.new, player: nil)
+  end
+
+  test "TargetedRemovalPhase targets the pending opponents' settlements, excluding city hall hexes" do
+    board = BoardState.new
+    board.place_settlement(5, 5, 1)
+    board.place_settlement(6, 6, 1)
+    board.place_settlement(8, 8, 2) # a non-targeted player's settlement
+    board.place_city_hall_hex(5, 7, 1)
+    phase = TurnPhase::TargetedRemovalPhase.new(
+      action_type: "sword", klass_name: "SwordTile", pending_orders: [ 1 ]
+    )
+
+    targets = phase.legal_targets(board_contents: board, player: nil)
+
+    assert_includes targets, [ 5, 5 ]
+    assert_includes targets, [ 6, 6 ]
+    assert_not_includes targets, [ 8, 8 ], "only pending opponents are targetable"
+    assert_not_includes targets, [ 5, 7 ], "city hall hexes are not removable"
+  end
+
+  test "CityHallPhase delegates to the tile's valid destinations" do
+    game, player = playing_game(hand: [ "G" ])
+    player.add_city_halls!(1)
+    player.save!
+    board = with_terrain(game.board_contents, game.instantiate)
+    board.place_settlement(1, 3, player.order)
+    phase = TurnPhase::CityHallPhase.new(action_type: "cityhall", klass_name: "CityHallTile")
+
+    expected = Tiles::Location::CityHallTile.new(0).valid_destinations(
+      board_contents: board, player_order: player.order, supply: player.supply_hash
+    )
+    assert_equal expected, phase.legal_targets(board_contents: board, player: player)
+    assert expected.any?, "fixed board should offer a city hall cluster next to the settlement"
+  end
+
+  test "FortPhase targets empty hexes of the drawn fort terrain" do
+    game, player = playing_game(hand: [ "G" ])
+    board = with_terrain(game.board_contents, game.instantiate)
+    phase = TurnPhase::FortPhase.new(fort_terrain: "D")
+
+    targets = phase.legal_targets(board_contents: board, player: player)
+
+    assert targets.any?
+    targets.each { |r, c| assert_equal "D", board.terrain_at(r, c) }
+  end
+
+  private
+
+  # A minimal playing game on the scenario's fixed board, with a clean board.
+  def playing_game(hand:)
+    game = Game.create!(
+      state: "playing", boards: [ [ 1, 0 ], [ 5, 0 ], [ 0, 0 ], [ 4, 0 ] ],
+      board_contents: BoardState.new, deck: %w[T G C D F], discard: [],
+      mandatory_count: Game::MANDATORY_COUNT, move_count: 0,
+      current_action: { "type" => "mandatory" }
+    )
+    user = User.create!(handle: "lt#{game.id}", email_address: "lt#{game.id}@example.com", password: "password", approved: true)
+    player = GamePlayer.create!(game: game, player: user, order: 0, hand: hand,
+      supply: { "settlements" => Game::SETTLEMENTS_PER_PLAYER }, tiles: [])
+    game.update!(current_player: player)
+    [ game, player ]
+  end
+end


### PR DESCRIPTION
Architecture-review candidate #2. Finishes ADR-0001's composite legal-target
query: consolidate "legal targets for the active sub-phase" behind the phase
(State pattern) instead of a ~110-line conditional in `TurnEngine`.

## Why

Candidate #1 established the single seam (`legal_targets` = `buildable_cells.to_set`,
shared by every action guard and the view), but its *implementation* stayed a
~110-line `if/elsif` change-magnet in `TurnEngine`, dispatching on phase type
then tile predicate — the classic "case on type" the State pattern exists to
remove. ADR-0001 put the query *primitives* in `BoardState`; this finishes the
*composites*.

## What

`TurnEngine#buildable_cells`: **~110 lines → 6**, a single
`@game.turn_phase.legal_targets(...)` delegation.

- Each `TurnPhase` subclass now owns `legal_targets(board_contents:, player:, game:)`.
  The two-axis conditional dissolves into polymorphism; tiles stay adapters
  (`valid_destinations`/`selectable_settlements`), `BoardState` supplies primitives.
- `game:` is optional — only MandatoryBuildPhase (`mandatory_count`) and
  TileBuildPhase (`stone_walls`) read a game-level resource.
- Shared logic finds its home: `effective_terrain` on the base; the two
  settlement movers share a `SettlementMoveTargets` concern; a base `tile`
  helper builds the backing tile. Retired `meeple_step_available?` and
  `outpost_build_terrains`.
- **Rule unification:** the "adjacent if possible, else anywhere" build rule,
  previously duplicated across `available_list` and `Tiles::Tile#valid_destinations`,
  now lives once in **`BoardState#buildable_cells_for`**. Mandatory builds and the
  location build tiles both route through it; `available_list` becomes a thin grid
  adapter. Added `BoardState#available_cells_of` (ADR's "all buildable terrain cells").

## Testing

New `test/models/turn_phase_legal_targets_test.rb` pins each phase's rule in
isolation; the scenario/tile suites give end-to-end parity across every strangler
step. Full unit/integration/scenario suite green: **981 runs, 0 failures**;
rubocop clean. (The browser system suite has pre-existing shared-login/rate-limit
flakiness unrelated to this change — different tests fail on different runs, none
touching legal-target code.)

Migrated one phase per commit, suite green between each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3gU8hDYRQBjjjNh6v68ZE