### PR TITLE
Add Announcements feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 /coverage
 
 # AI config and notes
+/.claude/*
 .codex
 AGENTS.md
 CLAUDE.md

--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -1,0 +1,440 @@
+/*
+ * Default Trix editor styles. See Action Text overwrites below.
+*/
+
+trix-editor {
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  margin: 0;
+  padding: 0.4em 0.6em;
+  min-height: 5em;
+  outline: none; }
+
+trix-toolbar * {
+  box-sizing: border-box; }
+
+trix-toolbar .trix-button-row {
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  overflow-x: auto; }
+
+trix-toolbar .trix-button-group {
+  display: flex;
+  margin-bottom: 10px;
+  border: 1px solid #bbb;
+  border-top-color: #ccc;
+  border-bottom-color: #888;
+  border-radius: 3px; }
+  trix-toolbar .trix-button-group:not(:first-child) {
+    margin-left: 1.5vw; }
+    @media (max-width: 768px) {
+      trix-toolbar .trix-button-group:not(:first-child) {
+        margin-left: 0; } }
+
+trix-toolbar .trix-button-group-spacer {
+  flex-grow: 1; }
+  @media (max-width: 768px) {
+    trix-toolbar .trix-button-group-spacer {
+      display: none; } }
+
+trix-toolbar .trix-button {
+  position: relative;
+  float: left;
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.75em;
+  font-weight: 600;
+  white-space: nowrap;
+  padding: 0 0.5em;
+  margin: 0;
+  outline: none;
+  border: none;
+  border-bottom: 1px solid #ddd;
+  border-radius: 0;
+  background: transparent; }
+  trix-toolbar .trix-button:not(:first-child) {
+    border-left: 1px solid #ccc; }
+  trix-toolbar .trix-button.trix-active {
+    background: #cbeefa;
+    color: black; }
+  trix-toolbar .trix-button:not(:disabled) {
+    cursor: pointer; }
+  trix-toolbar .trix-button:disabled {
+    color: rgba(0, 0, 0, 0.125); }
+  @media (max-width: 768px) {
+    trix-toolbar .trix-button {
+      letter-spacing: -0.01em;
+      padding: 0 0.3em; } }
+
+trix-toolbar .trix-button--icon {
+  font-size: inherit;
+  width: 2.6em;
+  height: 1.6em;
+  max-width: calc(0.8em + 4vw);
+  text-indent: -9999px; }
+  @media (max-width: 768px) {
+    trix-toolbar .trix-button--icon {
+      height: 2em;
+      max-width: calc(0.8em + 3.5vw); } }
+  trix-toolbar .trix-button--icon::before {
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    opacity: 0.6;
+    content: "";
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain; }
+    @media (max-width: 768px) {
+      trix-toolbar .trix-button--icon::before {
+        right: 6%;
+        left: 6%; } }
+  trix-toolbar .trix-button--icon.trix-active::before {
+    opacity: 1; }
+  trix-toolbar .trix-button--icon:disabled::before {
+    opacity: 0.125; }
+
+trix-toolbar .trix-button--icon-attach::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M10.5%2018V7.5c0-2.25%203-2.25%203%200V18c0%204.125-6%204.125-6%200V7.5c0-6.375%209-6.375%209%200V18%22%20stroke%3D%22%23000%22%20stroke-width%3D%222%22%20stroke-miterlimit%3D%2210%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E");
+  top: 8%;
+  bottom: 4%; }
+
+trix-toolbar .trix-button--icon-bold::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M6.522%2019.242a.5.5%200%200%201-.5-.5V5.35a.5.5%200%200%201%20.5-.5h5.783c1.347%200%202.46.345%203.24.982.783.64%201.216%201.562%201.216%202.683%200%201.13-.587%202.129-1.476%202.71a.35.35%200%200%200%20.049.613c1.259.56%202.101%201.742%202.101%203.22%200%201.282-.483%202.334-1.363%203.063-.876.726-2.132%201.12-3.66%201.12h-5.89ZM9.27%207.347v3.362h1.97c.766%200%201.347-.17%201.733-.464.38-.291.587-.716.587-1.27%200-.53-.183-.928-.513-1.198-.334-.273-.838-.43-1.505-.43H9.27Zm0%205.606v3.791h2.389c.832%200%201.448-.177%201.853-.497.399-.315.614-.786.614-1.423%200-.62-.22-1.077-.63-1.385-.418-.313-1.053-.486-1.905-.486H9.27Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-italic::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M9%205h6.5v2h-2.23l-2.31%2010H13v2H6v-2h2.461l2.306-10H9V5Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-link::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M18.948%205.258a4.337%204.337%200%200%200-6.108%200L11.217%206.87a.993.993%200%200%200%200%201.41c.392.39%201.027.39%201.418%200l1.623-1.613a2.323%202.323%200%200%201%203.271%200%202.29%202.29%200%200%201%200%203.251l-2.393%202.38a3.021%203.021%200%200%201-4.255%200l-.05-.049a1.007%201.007%200%200%200-1.418%200%20.993.993%200%200%200%200%201.41l.05.049a5.036%205.036%200%200%200%207.091%200l2.394-2.38a4.275%204.275%200%200%200%200-6.072Zm-13.683%2013.6a4.337%204.337%200%200%200%206.108%200l1.262-1.255a.993.993%200%200%200%200-1.41%201.007%201.007%200%200%200-1.418%200L9.954%2017.45a2.323%202.323%200%200%201-3.27%200%202.29%202.29%200%200%201%200-3.251l2.344-2.331a2.579%202.579%200%200%201%203.631%200c.392.39%201.027.39%201.419%200a.993.993%200%200%200%200-1.41%204.593%204.593%200%200%200-6.468%200l-2.345%202.33a4.275%204.275%200%200%200%200%206.072Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-strike::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M6%2014.986c.088%202.647%202.246%204.258%205.635%204.258%203.496%200%205.713-1.728%205.713-4.463%200-.275-.02-.536-.062-.781h-3.461c.398.293.573.654.573%201.123%200%201.035-1.074%201.787-2.646%201.787-1.563%200-2.773-.762-2.91-1.924H6ZM6.432%2010h3.763c-.632-.314-.914-.715-.914-1.273%200-1.045.977-1.739%202.432-1.739%201.475%200%202.52.723%202.617%201.914h2.764c-.05-2.548-2.11-4.238-5.39-4.238-3.145%200-5.392%201.719-5.392%204.316%200%20.363.04.703.12%201.02ZM4%2011a1%201%200%201%200%200%202h15a1%201%200%201%200%200-2H4Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-quote::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M4.581%208.471c.44-.5%201.056-.834%201.758-.995C8.074%207.17%209.201%207.822%2010%208.752c1.354%201.578%201.33%203.555.394%205.277-.941%201.731-2.788%203.163-4.988%203.56a.622.622%200%200%201-.653-.317c-.113-.205-.121-.49.16-.764.294-.286.567-.566.791-.835.222-.266.413-.54.524-.815.113-.28.156-.597.026-.908-.128-.303-.39-.524-.72-.69a3.02%203.02%200%200%201-1.674-2.7c0-.905.283-1.59.72-2.088Zm9.419%200c.44-.5%201.055-.834%201.758-.995%201.734-.306%202.862.346%203.66%201.276%201.355%201.578%201.33%203.555.395%205.277-.941%201.731-2.789%203.163-4.988%203.56a.622.622%200%200%201-.653-.317c-.113-.205-.122-.49.16-.764.294-.286.567-.566.791-.835.222-.266.412-.54.523-.815.114-.28.157-.597.026-.908-.127-.303-.39-.524-.72-.69a3.02%203.02%200%200%201-1.672-2.701c0-.905.283-1.59.72-2.088Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-heading-1::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M21.5%207.5v-3h-12v3H14v13h3v-13h4.5ZM9%2013.5h3.5v-3h-10v3H6v7h3v-7Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-code::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M3.293%2011.293a1%201%200%200%200%200%201.414l4%204a1%201%200%201%200%201.414-1.414L5.414%2012l3.293-3.293a1%201%200%200%200-1.414-1.414l-4%204Zm13.414%205.414%204-4a1%201%200%200%200%200-1.414l-4-4a1%201%200%201%200-1.414%201.414L18.586%2012l-3.293%203.293a1%201%200%200%200%201.414%201.414Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-bullet-list::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M5%207.5a1.5%201.5%200%201%200%200-3%201.5%201.5%200%200%200%200%203ZM8%206a1%201%200%200%201%201-1h11a1%201%200%201%201%200%202H9a1%201%200%200%201-1-1Zm1%205a1%201%200%201%200%200%202h11a1%201%200%201%200%200-2H9Zm0%206a1%201%200%201%200%200%202h11a1%201%200%201%200%200-2H9Zm-2.5-5a1.5%201.5%200%201%201-3%200%201.5%201.5%200%200%201%203%200ZM5%2019.5a1.5%201.5%200%201%200%200-3%201.5%201.5%200%200%200%200%203Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-number-list::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M3%204h2v4H4V5H3V4Zm5%202a1%201%200%200%201%201-1h11a1%201%200%201%201%200%202H9a1%201%200%200%201-1-1Zm1%205a1%201%200%201%200%200%202h11a1%201%200%201%200%200-2H9Zm0%206a1%201%200%201%200%200%202h11a1%201%200%201%200%200-2H9Zm-3.5-7H6v1l-1.5%202H6v1H3v-1l1.667-2H3v-1h2.5ZM3%2017v-1h3v4H3v-1h2v-.5H4v-1h1V17H3Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-undo::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M3%2014a1%201%200%200%200%201%201h6a1%201%200%201%200%200-2H6.257c2.247-2.764%205.151-3.668%207.579-3.264%202.589.432%204.739%202.356%205.174%205.405a1%201%200%200%200%201.98-.283c-.564-3.95-3.415-6.526-6.825-7.095C11.084%207.25%207.63%208.377%205%2011.39V8a1%201%200%200%200-2%200v6Zm2-1Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-redo::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M21%2014a1%201%200%200%201-1%201h-6a1%201%200%201%201%200-2h3.743c-2.247-2.764-5.151-3.668-7.579-3.264-2.589.432-4.739%202.356-5.174%205.405a1%201%200%200%201-1.98-.283c.564-3.95%203.415-6.526%206.826-7.095%203.08-.513%206.534.614%209.164%203.626V8a1%201%200%201%201%202%200v6Zm-2-1Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-decrease-nesting-level::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M5%206a1%201%200%200%201%201-1h12a1%201%200%201%201%200%202H6a1%201%200%200%201-1-1Zm4%205a1%201%200%201%200%200%202h9a1%201%200%201%200%200-2H9Zm-3%206a1%201%200%201%200%200%202h12a1%201%200%201%200%200-2H6Zm-3.707-5.707a1%201%200%200%200%200%201.414l2%202a1%201%200%201%200%201.414-1.414L4.414%2012l1.293-1.293a1%201%200%200%200-1.414-1.414l-2%202Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-increase-nesting-level::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M5%206a1%201%200%200%201%201-1h12a1%201%200%201%201%200%202H6a1%201%200%200%201-1-1Zm4%205a1%201%200%201%200%200%202h9a1%201%200%201%200%200-2H9Zm-3%206a1%201%200%201%200%200%202h12a1%201%200%201%200%200-2H6Zm-2.293-2.293%202-2a1%201%200%200%200%200-1.414l-2-2a1%201%200%201%200-1.414%201.414L3.586%2012l-1.293%201.293a1%201%200%201%200%201.414%201.414Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-dialogs {
+  position: relative; }
+
+trix-toolbar .trix-dialog {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  font-size: 0.75em;
+  padding: 15px 10px;
+  background: #fff;
+  box-shadow: 0 0.3em 1em #ccc;
+  border-top: 2px solid #888;
+  border-radius: 5px;
+  z-index: 5; }
+
+trix-toolbar .trix-input--dialog {
+  font-size: inherit;
+  font-weight: normal;
+  padding: 0.5em 0.8em;
+  margin: 0 10px 0 0;
+  border-radius: 3px;
+  border: 1px solid #bbb;
+  background-color: #fff;
+  box-shadow: none;
+  outline: none;
+  -webkit-appearance: none;
+  -moz-appearance: none; }
+  trix-toolbar .trix-input--dialog.validate:invalid {
+    box-shadow: #F00 0px 0px 1.5px 1px; }
+
+trix-toolbar .trix-button--dialog {
+  font-size: inherit;
+  padding: 0.5em;
+  border-bottom: none; }
+
+trix-toolbar .trix-dialog--link {
+  max-width: 600px; }
+
+trix-toolbar .trix-dialog__link-fields {
+  display: flex;
+  align-items: baseline; }
+  trix-toolbar .trix-dialog__link-fields .trix-input {
+    flex: 1; }
+  trix-toolbar .trix-dialog__link-fields .trix-button-group {
+    flex: 0 0 content;
+    margin: 0; }
+
+trix-editor [data-trix-mutable]:not(.attachment__caption-editor) {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none; }
+
+trix-editor [data-trix-mutable]::-moz-selection,
+trix-editor [data-trix-cursor-target]::-moz-selection, trix-editor [data-trix-mutable] ::-moz-selection {
+  background: none; }
+
+trix-editor [data-trix-mutable]::selection,
+trix-editor [data-trix-cursor-target]::selection, trix-editor [data-trix-mutable] ::selection {
+  background: none; }
+
+trix-editor .attachment__caption-editor:focus[data-trix-mutable]::-moz-selection {
+  background: highlight; }
+
+trix-editor .attachment__caption-editor:focus[data-trix-mutable]::selection {
+  background: highlight; }
+
+trix-editor [data-trix-mutable].attachment.attachment--file {
+  box-shadow: 0 0 0 2px highlight;
+  border-color: transparent; }
+
+trix-editor [data-trix-mutable].attachment img {
+  box-shadow: 0 0 0 2px highlight; }
+
+trix-editor .attachment {
+  position: relative; }
+  trix-editor .attachment:hover {
+    cursor: default; }
+
+trix-editor .attachment--preview .attachment__caption:hover {
+  cursor: text; }
+
+trix-editor .attachment__progress {
+  position: absolute;
+  z-index: 1;
+  height: 20px;
+  top: calc(50% - 10px);
+  left: 5%;
+  width: 90%;
+  opacity: 0.9;
+  transition: opacity 200ms ease-in; }
+  trix-editor .attachment__progress[value="100"] {
+    opacity: 0; }
+
+trix-editor .attachment__caption-editor {
+  display: inline-block;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+  color: inherit;
+  text-align: center;
+  vertical-align: top;
+  border: none;
+  outline: none;
+  -webkit-appearance: none;
+  -moz-appearance: none; }
+
+trix-editor .attachment__toolbar {
+  position: absolute;
+  z-index: 1;
+  top: -0.9em;
+  left: 0;
+  width: 100%;
+  text-align: center; }
+
+trix-editor .trix-button-group {
+  display: inline-flex; }
+
+trix-editor .trix-button {
+  position: relative;
+  float: left;
+  color: #666;
+  white-space: nowrap;
+  font-size: 80%;
+  padding: 0 0.8em;
+  margin: 0;
+  outline: none;
+  border: none;
+  border-radius: 0;
+  background: transparent; }
+  trix-editor .trix-button:not(:first-child) {
+    border-left: 1px solid #ccc; }
+  trix-editor .trix-button.trix-active {
+    background: #cbeefa; }
+  trix-editor .trix-button:not(:disabled) {
+    cursor: pointer; }
+
+trix-editor .trix-button--remove {
+  text-indent: -9999px;
+  display: inline-block;
+  padding: 0;
+  outline: none;
+  width: 1.8em;
+  height: 1.8em;
+  line-height: 1.8em;
+  border-radius: 50%;
+  background-color: #fff;
+  border: 2px solid highlight;
+  box-shadow: 1px 1px 6px rgba(0, 0, 0, 0.25); }
+  trix-editor .trix-button--remove::before {
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    opacity: 0.7;
+    content: "";
+    background-image: url("data:image/svg+xml,%3Csvg%20height%3D%2224%22%20width%3D%2224%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M19%206.41%2017.59%205%2012%2010.59%206.41%205%205%206.41%2010.59%2012%205%2017.59%206.41%2019%2012%2013.41%2017.59%2019%2019%2017.59%2013.41%2012z%22%2F%3E%3Cpath%20d%3D%22M0%200h24v24H0z%22%20fill%3D%22none%22%2F%3E%3C%2Fsvg%3E");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 90%; }
+  trix-editor .trix-button--remove:hover {
+    border-color: #333; }
+    trix-editor .trix-button--remove:hover::before {
+      opacity: 1; }
+
+trix-editor .attachment__metadata-container {
+  position: relative; }
+
+trix-editor .attachment__metadata {
+  position: absolute;
+  left: 50%;
+  top: 2em;
+  transform: translate(-50%, 0);
+  max-width: 90%;
+  padding: 0.1em 0.6em;
+  font-size: 0.8em;
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-radius: 3px; }
+  trix-editor .attachment__metadata .attachment__name {
+    display: inline-block;
+    max-width: 100%;
+    vertical-align: bottom;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap; }
+  trix-editor .attachment__metadata .attachment__size {
+    margin-left: 0.2em;
+    white-space: nowrap; }
+
+.trix-content {
+  line-height: 1.5;
+  overflow-wrap: break-word;
+  word-break: break-word; }
+  .trix-content * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0; }
+  .trix-content h1 {
+    font-size: 1.2em;
+    line-height: 1.2; }
+  .trix-content blockquote {
+    border: 0 solid #ccc;
+    border-left-width: 0.3em;
+    margin-left: 0.3em;
+    padding-left: 0.6em; }
+  .trix-content [dir=rtl] blockquote,
+  .trix-content blockquote[dir=rtl] {
+    border-width: 0;
+    border-right-width: 0.3em;
+    margin-right: 0.3em;
+    padding-right: 0.6em; }
+  .trix-content li {
+    margin-left: 1em; }
+  .trix-content [dir=rtl] li {
+    margin-right: 1em; }
+  .trix-content pre {
+    display: inline-block;
+    width: 100%;
+    vertical-align: top;
+    font-family: monospace;
+    font-size: 0.9em;
+    padding: 0.5em;
+    white-space: pre;
+    background-color: #eee;
+    overflow-x: auto; }
+  .trix-content img {
+    max-width: 100%;
+    height: auto; }
+  .trix-content .attachment {
+    display: inline-block;
+    position: relative;
+    max-width: 100%; }
+    .trix-content .attachment a {
+      color: inherit;
+      text-decoration: none; }
+      .trix-content .attachment a:hover, .trix-content .attachment a:visited:hover {
+        color: inherit; }
+  .trix-content .attachment__caption {
+    text-align: center; }
+    .trix-content .attachment__caption .attachment__name + .attachment__size::before {
+      content: ' \2022 '; }
+  .trix-content .attachment--preview {
+    width: 100%;
+    text-align: center; }
+    .trix-content .attachment--preview .attachment__caption {
+      color: #666;
+      font-size: 0.9em;
+      line-height: 1.2; }
+  .trix-content .attachment--file {
+    color: #333;
+    line-height: 1;
+    margin: 0 2px 2px 2px;
+    padding: 0.4em 1em;
+    border: 1px solid #bbb;
+    border-radius: 5px; }
+  .trix-content .attachment-gallery {
+    display: flex;
+    flex-wrap: wrap;
+    position: relative; }
+    .trix-content .attachment-gallery .attachment {
+      flex: 1 0 33%;
+      padding: 0 0.5em;
+      max-width: 33%; }
+    .trix-content .attachment-gallery.attachment-gallery--2 .attachment, .trix-content .attachment-gallery.attachment-gallery--4 .attachment {
+      flex-basis: 50%;
+      max-width: 50%; }
+
+/*
+ * We need to override trix.css’s image gallery styles to accommodate the
+ * <action-text-attachment> element we wrap around attachments. Otherwise,
+ * images in galleries will be squished by the max-width: 33%; rule.
+*/
+.trix-content .attachment-gallery > action-text-attachment,
+.trix-content .attachment-gallery > .attachment {
+  flex: 1 0 33%;
+  padding: 0 0.5em;
+  max-width: 33%;
+}
+
+.trix-content .attachment-gallery.attachment-gallery--2 > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--2 > .attachment, .trix-content .attachment-gallery.attachment-gallery--4 > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--4 > .attachment {
+  flex-basis: 50%;
+  max-width: 50%;
+}
+
+.trix-content action-text-attachment .attachment {
+  padding: 0 !important;
+  max-width: 100% !important;
+}

--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -438,3 +438,8 @@ trix-editor .attachment__metadata {
   padding: 0 !important;
   max-width: 100% !important;
 }
+
+/* Uploads are disabled (no Active Storage service in production); hide Trix's file-attach control. */
+trix-toolbar .trix-button-group--file-tools {
+  display: none;
+}

--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -371,7 +371,7 @@ trix-editor .attachment__metadata {
     font-size: 0.9em;
     padding: 0.5em;
     white-space: pre;
-    background-color: #eee;
+    background-color: #030;
     overflow-x: auto; }
   .trix-content img {
     max-width: 100%;

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,7 +1,5 @@
 class Admin::AnnouncementsController < Admin::BaseController
-  # ponytail: toggle_pin omitted here (Task 5 owns the action); raise_on_missing_callback_actions
-  # errors if it's listed in :only before the action method exists.
-  before_action :set_announcement, only: %i[ edit update destroy ]
+  before_action :set_announcement, only: %i[ edit update destroy toggle_pin ]
 
   def index
     @announcements = Announcement.order(pinned: :desc, created_at: :desc)
@@ -33,6 +31,11 @@ class Admin::AnnouncementsController < Admin::BaseController
   def destroy
     @announcement.destroy!
     redirect_to admin_announcements_path, notice: "Announcement deleted.", status: :see_other
+  end
+
+  def toggle_pin
+    @announcement.update!(pinned: !@announcement.pinned?)
+    redirect_to admin_announcements_path
   end
 
   private

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,0 +1,46 @@
+class Admin::AnnouncementsController < Admin::BaseController
+  # ponytail: toggle_pin omitted here (Task 5 owns the action); raise_on_missing_callback_actions
+  # errors if it's listed in :only before the action method exists.
+  before_action :set_announcement, only: %i[ edit update destroy ]
+
+  def index
+    @announcements = Announcement.order(pinned: :desc, created_at: :desc)
+  end
+
+  def new
+    @announcement = Announcement.new
+  end
+
+  def create
+    @announcement = Announcement.new(announcement_params)
+    if @announcement.save
+      redirect_to admin_announcements_path, notice: "Announcement created."
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @announcement.update(announcement_params)
+      redirect_to admin_announcements_path, notice: "Announcement updated."
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    @announcement.destroy!
+    redirect_to admin_announcements_path, notice: "Announcement deleted.", status: :see_other
+  end
+
+  private
+    def set_announcement
+      @announcement = Announcement.find(params.expect(:id))
+    end
+
+    def announcement_params
+      params.expect(announcement: [ :title, :body, :pinned ])
+    end
+end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,8 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_admin
+
+  private
+    def require_admin
+      head :forbidden unless Current.user&.admin?
+    end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,6 @@
+class Admin::DashboardController < Admin::BaseController
+  def index
+    @announcements = Announcement.order(created_at: :desc).limit(2)
+    @users = User.order(:handle)
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,10 @@
+class Admin::UsersController < Admin::BaseController
+  def update
+    @user = User.find(params.expect(:id))
+    @user.update!(approved: params.expect(user: :approved))
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to admin_path }
+    end
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,7 @@
 class Admin::UsersController < Admin::BaseController
   def update
     @user = User.find(params.expect(:id))
-    @user.update!(approved: params.expect(user: :approved))
+    @user.update!(approved: params.expect(user: :approved).require(:approved))
     respond_to do |format|
       format.turbo_stream
       format.html { redirect_to admin_path }

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,6 +1,6 @@
 class AnnouncementsController < ApplicationController
   def index
-    @offset = params[:offset].to_i
+    @offset = [ params[:offset].to_i, 0 ].max
     @unpinned = Announcement.unpinned.offset(@offset).limit(Announcement::PAGE_SIZE)
     @more = Announcement.unpinned.offset(@offset + Announcement::PAGE_SIZE).exists?
 

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,0 +1,13 @@
+class AnnouncementsController < ApplicationController
+  def index
+    @offset = params[:offset].to_i
+    @unpinned = Announcement.unpinned.offset(@offset).limit(Announcement::PAGE_SIZE)
+    @more = Announcement.unpinned.offset(@offset + Announcement::PAGE_SIZE).exists?
+
+    if params[:offset]
+      render partial: "page", locals: { announcements: @unpinned, offset: @offset, more: @more }
+    else
+      @pinned = Announcement.pinned
+    end
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,5 +3,7 @@ class DashboardController < ApplicationController
     @my_games = Current.user.my_games.includes(game_players: :player)
     @waiting_games = Current.user.waiting_games.includes(game_players: :player)
     @completed_games = Current.user.completed_games.includes(game_players: :player)
+    @pinned_announcements = Announcement.pinned
+    @latest_unpinned = Announcement.unpinned.first
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -38,3 +38,6 @@ function fancy_dance() {
 
 document.addEventListener('turbo:before-render', stop_fancy_dance);
 document.addEventListener('turbo:load', fancy_dance);
+
+import "trix"
+import "@rails/actiontext"

--- a/app/javascript/controllers/auto_submit_controller.js
+++ b/app/javascript/controllers/auto_submit_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Submits the closest form as soon as the input changes.
+export default class extends Controller {
+  submit() {
+    this.element.requestSubmit()
+  }
+}

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id         :bigint           not null, primary key
+#  pinned     :boolean          default(FALSE), not null
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_announcements_on_pinned_and_created_at  (pinned,created_at)
+#
+class Announcement < ApplicationRecord
+  PAGE_SIZE = 5
+
+  has_rich_text :body
+
+  validates :title, presence: true
+
+  scope :pinned,   -> { where(pinned: true).order(created_at: :desc) }
+  scope :unpinned, -> { where(pinned: false).order(created_at: :desc) }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@
 # Table name: users
 #
 #  id              :bigint           not null, primary key
+#  admin           :boolean          default(FALSE), not null
 #  approved        :boolean          default(FALSE)
 #  email_address   :string           not null
 #  handle          :string           not null

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/admin/announcements/_form.html.erb
+++ b/app/views/admin/announcements/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with model: [ :admin, announcement ] do |form| %>
+  <% if announcement.errors.any? %>
+    <div class="flash-alert"><%= announcement.errors.full_messages.to_sentence %></div>
+  <% end %>
+  <div><%= form.label :title %><%= form.text_field :title %></div>
+  <div><%= form.label :body %><%= form.rich_text_area :body %></div>
+  <div><%= form.label :pinned %><%= form.check_box :pinned %></div>
+  <div><%= form.submit %></div>
+<% end %>

--- a/app/views/admin/announcements/edit.html.erb
+++ b/app/views/admin/announcements/edit.html.erb
@@ -1,0 +1,5 @@
+<div class="dashboard-box">
+  <h1>Edit announcement</h1>
+  <%= render "form", announcement: @announcement %>
+  <%= link_to "Back", admin_announcements_path %>
+</div>

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -9,7 +9,12 @@
         <strong><%= announcement.title %></strong>
         <%= "(pinned)" if announcement.pinned? %>
         <%= link_to "Edit", edit_admin_announcement_path(announcement) %>
-        <%= button_to "Delete", admin_announcement_path(announcement), method: :delete, data: { turbo_confirm: "Delete this announcement?" } %>
+        <span class="pin-toggle">
+          <%= button_to (announcement.pinned? ? "unpin" : "pin"), toggle_pin_admin_announcement_path(announcement), method: :patch %>
+        </span>
+        <span class="delete-toggle">
+          <%= button_to "Delete", admin_announcement_path(announcement), method: :delete, data: { turbo_confirm: "Delete this announcement?" } %>
+        </span>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -1,0 +1,16 @@
+<div class="dashboard-box">
+  <h1>Announcements</h1>
+  <%= link_to "New announcement", new_admin_announcement_path %>
+  <%= link_to "Admin", admin_path %>
+
+  <div class="dashboard-section">
+    <% @announcements.each do |announcement| %>
+      <div id="<%= dom_id(announcement) %>">
+        <strong><%= announcement.title %></strong>
+        <%= "(pinned)" if announcement.pinned? %>
+        <%= link_to "Edit", edit_admin_announcement_path(announcement) %>
+        <%= button_to "Delete", admin_announcement_path(announcement), method: :delete, data: { turbo_confirm: "Delete this announcement?" } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/announcements/new.html.erb
+++ b/app/views/admin/announcements/new.html.erb
@@ -1,0 +1,5 @@
+<div class="dashboard-box">
+  <h1>New announcement</h1>
+  <%= render "form", announcement: @announcement %>
+  <%= link_to "Back", admin_announcements_path %>
+</div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -15,4 +15,9 @@
     <% end %>
     <%= link_to "Manage announcements", admin_announcements_path %>
   </div>
+
+  <div class="dashboard-section">
+    <h2>Users</h2>
+    <%= render partial: "admin/users/user", collection: @users, as: :user %>
+  </div>
 </div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,18 @@
+<div class="dashboard-box">
+  <h1>Admin</h1>
+  <%= link_to "Dashboard", dashboard_path %>
+
+  <div class="dashboard-section">
+    <h2>Latest announcements</h2>
+    <% if @announcements.any? %>
+      <ul>
+        <% @announcements.each do |announcement| %>
+          <li><%= link_to announcement.title, edit_admin_announcement_path(announcement) %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p>No announcements yet.</p>
+    <% end %>
+    <%= link_to "Manage announcements", admin_announcements_path %>
+  </div>
+</div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -18,6 +18,18 @@
 
   <div class="dashboard-section">
     <h2>Users</h2>
-    <%= render partial: "admin/users/user", collection: @users, as: :user %>
+    <table>
+      <thead>
+        <tr>
+          <th>Approved</th>
+          <th>Created At</th>
+          <th>Email Address</th>
+          <th>Handle</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: "admin/users/user", collection: @users, as: :user %>
+      </tbody>
+    </table>
   </div>
 </div>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,0 +1,11 @@
+<div id="<%= dom_id(user) %>" class="admin-user-row">
+  <%= form_with model: user, url: admin_user_path(user), method: :patch,
+        data: { controller: "auto-submit" } do |form| %>
+    <label>
+      <%= form.check_box :approved,
+            id: "approved_#{user.id}",
+            data: { action: "change->auto-submit#submit" } %>
+      <%= user.handle %>
+    </label>
+  <% end %>
+</div>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,11 +1,15 @@
 <div id="<%= dom_id(user) %>" class="admin-user-row">
-  <%= form_with model: user, url: admin_user_path(user), method: :patch,
-        data: { controller: "auto-submit" } do |form| %>
-    <label>
-      <%= form.check_box :approved,
-            id: "approved_#{user.id}",
-            data: { action: "change->auto-submit#submit" } %>
-      <%= user.handle %>
-    </label>
-  <% end %>
+  <tr>
+    <td>
+      <%= form_with model: user, url: admin_user_path(user), method: :patch,
+            data: { controller: "auto-submit" } do |form| %>
+        <%= form.check_box :approved,
+              id: "approved_#{user.id}",
+              data: { action: "change->auto-submit#submit" } %>
+      <% end %>
+    </td>
+    <td><%= user.created_at.strftime("%Y-%m-%d") %></td>
+    <td><%= user.email_address %></td>
+    <td><%= user.handle %></td>
+  </tr>
 </div>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,15 +1,13 @@
-<div id="<%= dom_id(user) %>" class="admin-user-row">
-  <tr>
-    <td>
-      <%= form_with model: user, url: admin_user_path(user), method: :patch,
-            data: { controller: "auto-submit" } do |form| %>
-        <%= form.check_box :approved,
-              id: "approved_#{user.id}",
-              data: { action: "change->auto-submit#submit" } %>
-      <% end %>
-    </td>
-    <td><%= user.created_at.strftime("%Y-%m-%d") %></td>
-    <td><%= user.email_address %></td>
-    <td><%= user.handle %></td>
-  </tr>
-</div>
+<tr id="<%= dom_id(user) %>" class="admin-user-row">
+  <td>
+    <%= form_with model: user, url: admin_user_path(user), method: :patch,
+          data: { controller: "auto-submit" } do |form| %>
+      <%= form.check_box :approved,
+            id: "approved_#{user.id}",
+            data: { action: "change->auto-submit#submit" } %>
+    <% end %>
+  </td>
+  <td><%= user.created_at.strftime("%Y-%m-%d") %></td>
+  <td><%= user.email_address %></td>
+  <td><%= user.handle %></td>
+</tr>

--- a/app/views/admin/users/update.turbo_stream.erb
+++ b/app/views/admin/users/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@user) do %>
+  <%= render "admin/users/user", user: @user %>
+<% end %>

--- a/app/views/announcements/_announcement.html.erb
+++ b/app/views/announcements/_announcement.html.erb
@@ -1,0 +1,4 @@
+<div class="dashboard-section announcement">
+  <h2><%= announcement.title %></h2>
+  <div class="announcement-body"><%= announcement.body %></div>
+</div>

--- a/app/views/announcements/_page.html.erb
+++ b/app/views/announcements/_page.html.erb
@@ -1,0 +1,8 @@
+<%= turbo_frame_tag "announcements_page_#{offset}" do %>
+  <%= render partial: "announcement", collection: announcements, as: :announcement %>
+  <% if more %>
+    <%= turbo_frame_tag "announcements_page_#{offset + Announcement::PAGE_SIZE}",
+          src: announcements_path(offset: offset + Announcement::PAGE_SIZE),
+          loading: :lazy %>
+  <% end %>
+<% end %>

--- a/app/views/announcements/index.html.erb
+++ b/app/views/announcements/index.html.erb
@@ -1,0 +1,7 @@
+<div class="dashboard-box">
+  <h1>Announcements</h1>
+  <%= link_to "Dashboard", dashboard_path %>
+
+  <%= render partial: "announcement", collection: @pinned, as: :announcement %>
+  <%= render "page", announcements: @unpinned, offset: 0, more: @more %>
+</div>

--- a/app/views/dashboard/_announcements.html.erb
+++ b/app/views/dashboard/_announcements.html.erb
@@ -1,4 +1,4 @@
-<div id="dashboard-announcements" class="dashboard-section">
+<div id="dashboard-announcements">
   <h2>Announcements</h2>
   <%= render partial: "announcements/announcement", collection: pinned, as: :announcement %>
   <% if latest_unpinned %>

--- a/app/views/dashboard/_announcements.html.erb
+++ b/app/views/dashboard/_announcements.html.erb
@@ -1,0 +1,8 @@
+<div id="dashboard-announcements" class="dashboard-section">
+  <h2>Announcements</h2>
+  <%= render partial: "announcements/announcement", collection: pinned, as: :announcement %>
+  <% if latest_unpinned %>
+    <%= render "announcements/announcement", announcement: latest_unpinned %>
+  <% end %>
+  <%= link_to "All announcements", announcements_path %>
+</div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -9,6 +9,8 @@
   <div id="logout_btn"><%= button_to "Log out", session_path, method: :delete, data: { turbo: false } %></div>
   <%= link_to "Credits", credits_path %>
 
+  <%= render "announcements", pinned: @pinned_announcements, latest_unpinned: @latest_unpinned %>
+
   <div id="dashboard-my-games" class="dashboard-section">
     <%= render "dashboard/my_games", games: @my_games %>
   </div>

--- a/app/views/layouts/action_text/contents/_content.html.erb
+++ b/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,0 +1,3 @@
+<div class="trix-content">
+  <%= yield -%>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,9 @@
           </button>
           <ul class="hamburger-menu hidden" data-menu-target="menu">
             <li><%= link_to "Dashboard", dashboard_path, data: { action: "click->menu#close" } %></li>
+            <% if Current.user.admin? %>
+              <li><%= link_to "Admin", admin_path, data: { action: "click->menu#close" } %></li>
+            <% end %>
             <%= yield :menu_items %>
             <hr>
             <div id="logout_btn"><%= button_to "Log out", session_path, method: :delete, data: { turbo: false } %></div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ require "rails/test_unit/railtie"
 # unused:
 # require "active_storage/engine"
 # require "action_mailbox/engine"
-# require "action_text/engine"
+require "action_text/engine"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  # config.active_storage.service = :local
+  config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,6 +22,9 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.cache_store = :null_store
 
+  # Store uploaded files on the local file system in a temporary directory.
+  config.active_storage.service = :test
+
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,5 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "@rails/actioncable", to: "@rails--actioncable.js" # @8.1.300
+pin "trix"
+pin "@rails/actiontext", to: "actiontext.esm.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,17 @@ Rails.application.routes.draw do
   get "dashboard", to: "dashboard#index"
   get "credits", to: "credits#index"
 
+  get "admin", to: "admin/dashboard#index"
+
+  namespace :admin do
+    resources :announcements do
+      member { patch :toggle_pin }
+    end
+    resources :users, only: [ :update ]
+  end
+
+  resources :announcements, only: [ :index ]
+
   get "hidden/icons", to: "hidden#icons"
 
   resource :session

--- a/db/migrate/20260713170659_add_admin_to_users.rb
+++ b/db/migrate/20260713170659_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260713171036_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260713171036_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/migrate/20260713171037_create_action_text_tables.action_text.rb
+++ b/db/migrate/20260713171037_create_action_text_tables.action_text.rb
@@ -1,0 +1,26 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :action_text_rich_texts, id: primary_key_type do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/migrate/20260713171057_create_announcements.rb
+++ b/db/migrate/20260713171057_create_announcements.rb
@@ -1,0 +1,10 @@
+class CreateAnnouncements < ActiveRecord::Migration[8.1]
+  def change
+    create_table :announcements do |t|
+      t.string :title, null: false
+      t.boolean :pinned, null: false, default: false
+      t.timestamps
+    end
+    add_index :announcements, [ :pinned, :created_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,55 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_13_170659) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_171057) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "announcements", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "pinned", default: false, null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["pinned", "created_at"], name: "index_announcements_on_pinned_and_created_at"
+  end
 
   create_table "chat_messages", force: :cascade do |t|
     t.string "body", null: false
@@ -251,6 +297,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_170659) do
     t.index ["handle"], name: "index_users_on_handle", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "chat_messages", "game_players"
   add_foreign_key "chat_messages", "games"
   add_foreign_key "game_players", "games"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_06_145430) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_170659) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -238,6 +238,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_145430) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.boolean "admin", default: false, null: false
     t.boolean "approved", default: false
     t.datetime "created_at", null: false
     t.string "email_address", null: false

--- a/test/controllers/announcements_controller_test.rb
+++ b/test/controllers/announcements_controller_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class AnnouncementsControllerTest < ActionDispatch::IntegrationTest
+  test "index succeeds with a normal request" do
+    post session_url, params: { email_address: "paula@example.com", password: "password" }
+
+    get announcements_url
+
+    assert_response :success
+  end
+
+  test "index clamps a negative offset instead of raising" do
+    post session_url, params: { email_address: "paula@example.com", password: "password" }
+
+    get announcements_url(offset: -1)
+
+    assert_response :success
+  end
+end

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -1,0 +1,4 @@
+# one:
+#   record: name_of_fixture (ClassOfFixture)
+#   name: content
+#   body: <p>In a <i>million</i> stars!</p>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -5,6 +5,7 @@
 # Table name: users
 #
 #  id              :bigint           not null, primary key
+#  admin           :boolean          default(FALSE), not null
 #  approved        :boolean          default(FALSE)
 #  email_address   :string           not null
 #  handle          :string           not null
@@ -23,6 +24,7 @@ chris:
   handle: "Chris"
   email_address: chris@example.com
   approved: true
+  admin: true
   password_digest: <%= password_digest %>
 
 paula:

--- a/test/integration/admin_authorization_test.rb
+++ b/test/integration/admin_authorization_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class AdminAuthorizationTest < ActionDispatch::IntegrationTest
+  def sign_in_as(user)
+    post session_url, params: { email_address: user.email_address, password: "password" }
+  end
+
+  test "non-admin is forbidden from the admin page" do
+    sign_in_as(users(:paula))
+    get admin_url
+    assert_response :forbidden
+  end
+
+  test "admin can reach the admin page" do
+    sign_in_as(users(:chris))
+    get admin_url
+    assert_response :success
+  end
+end

--- a/test/integration/admin_authorization_test.rb
+++ b/test/integration/admin_authorization_test.rb
@@ -16,4 +16,12 @@ class AdminAuthorizationTest < ActionDispatch::IntegrationTest
     get admin_url
     assert_response :success
   end
+
+  test "non-admin cannot create an announcement" do
+    sign_in_as(users(:paula))
+    assert_no_difference -> { Announcement.count } do
+      post admin_announcements_url, params: { announcement: { title: "x", body: "y" } }
+    end
+    assert_response :forbidden
+  end
 end

--- a/test/models/announcement_test.rb
+++ b/test/models/announcement_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id         :bigint           not null, primary key
+#  pinned     :boolean          default(FALSE), not null
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_announcements_on_pinned_and_created_at  (pinned,created_at)
+#
+class AnnouncementTest < ActiveSupport::TestCase
+  test "requires a title" do
+    a = Announcement.new(body: "hi")
+    assert_not a.valid?
+    assert_includes a.errors[:title], "can't be blank"
+  end
+
+  test "pinned scope returns only pinned, newest first" do
+    old = Announcement.create!(title: "old", body: "x", pinned: true, created_at: 2.days.ago)
+    new = Announcement.create!(title: "new", body: "x", pinned: true, created_at: 1.day.ago)
+    Announcement.create!(title: "plain", body: "x", pinned: false)
+    assert_equal [ new, old ], Announcement.pinned.to_a
+  end
+
+  test "unpinned scope returns only unpinned, newest first" do
+    Announcement.create!(title: "pinned", body: "x", pinned: true)
+    a = Announcement.create!(title: "a", body: "x", created_at: 2.days.ago)
+    b = Announcement.create!(title: "b", body: "x", created_at: 1.day.ago)
+    assert_equal [ b, a ], Announcement.unpinned.to_a
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,6 +3,7 @@
 # Table name: users
 #
 #  id              :bigint           not null, primary key
+#  admin           :boolean          default(FALSE), not null
 #  approved        :boolean          default(FALSE)
 #  email_address   :string           not null
 #  handle          :string           not null
@@ -108,5 +109,12 @@ class UserTest < ActiveSupport::TestCase
   test "online? is false once the one minute window has elapsed" do
     users(:chris).update!(last_seen_at: 61.seconds.ago)
     assert_not users(:chris).online?
+  end
+
+  # --- admin? ---
+
+  test "admin? reflects the admin column" do
+    assert users(:chris).admin?
+    assert_not users(:paula).admin?
   end
 end

--- a/test/system/admin_announcements_test.rb
+++ b/test/system/admin_announcements_test.rb
@@ -1,0 +1,37 @@
+require "application_system_test_case"
+
+class AdminAnnouncementsTest < ApplicationSystemTestCase
+  def sign_in(email_address:, password: "password")
+    visit root_url
+    panel = find("#sign-in-panel")
+    set_field(panel.find("input[name='email_address']"), email_address)
+    set_field(panel.find("input[name='password']"), password)
+    submit_form panel.find("form")
+    assert_selector "h1", text: "KBC Dashboard"
+  end
+
+  def fill_rich_text(html)
+    editor = find("trix-editor")
+    page.execute_script("arguments[0].editor.loadHTML(arguments[1])", editor, html)
+  end
+
+  test "admin creates, edits, and deletes an announcement" do
+    sign_in(email_address: "chris@example.com")
+    visit new_admin_announcement_url
+    set_field(find("input[name='announcement[title]']"), "Server maintenance")
+    fill_rich_text("<div>Down at 2am</div>")
+    submit_form find("form")
+    assert_text "Server maintenance"
+
+    a = Announcement.find_by!(title: "Server maintenance")
+    visit edit_admin_announcement_url(a)
+    set_field(find("input[name='announcement[title]']"), "Server maintenance (updated)")
+    submit_form find("form")
+    assert_text "Server maintenance (updated)"
+
+    assert_difference -> { Announcement.count }, -1 do
+      accept_confirm { page.execute_script("document.querySelector('##{ActionView::RecordIdentifier.dom_id(a)} form button').click()") }
+      assert_no_text "Server maintenance (updated)"
+    end
+  end
+end

--- a/test/system/admin_announcements_test.rb
+++ b/test/system/admin_announcements_test.rb
@@ -30,8 +30,17 @@ class AdminAnnouncementsTest < ApplicationSystemTestCase
     assert_text "Server maintenance (updated)"
 
     assert_difference -> { Announcement.count }, -1 do
-      accept_confirm { page.execute_script("document.querySelector('##{ActionView::RecordIdentifier.dom_id(a)} form button').click()") }
+      accept_confirm { page.execute_script("document.querySelector('##{ActionView::RecordIdentifier.dom_id(a)} .delete-toggle button').click()") }
       assert_no_text "Server maintenance (updated)"
     end
+  end
+
+  test "admin pins and unpins from the index" do
+    a = Announcement.create!(title: "Pin me", body: "x", pinned: false)
+    sign_in(email_address: "chris@example.com")
+    visit admin_announcements_url
+    page.execute_script("document.querySelector('##{ActionView::RecordIdentifier.dom_id(a)} .pin-toggle button').click()")
+    assert_text "unpin", wait: 5
+    assert a.reload.pinned?
   end
 end

--- a/test/system/admin_dashboard_test.rb
+++ b/test/system/admin_dashboard_test.rb
@@ -1,0 +1,24 @@
+require "application_system_test_case"
+
+class AdminDashboardTest < ApplicationSystemTestCase
+  def sign_in(email_address:, password: "password")
+    visit root_url
+    panel = find("#sign-in-panel")
+    set_field(panel.find("input[name='email_address']"), email_address)
+    set_field(panel.find("input[name='password']"), password)
+    submit_form panel.find("form")
+    assert_selector "h1", text: "KBC Dashboard"
+  end
+
+  test "admin sees the Admin menu link and can open the admin page" do
+    sign_in(email_address: "chris@example.com")
+    assert_selector "a", text: "Admin", visible: :all
+    visit admin_url
+    assert_selector "h1", text: "Admin"
+  end
+
+  test "non-admin does not see the Admin menu link" do
+    sign_in(email_address: "paula@example.com")
+    assert_no_selector "a", text: "Admin", visible: :all
+  end
+end

--- a/test/system/admin_users_test.rb
+++ b/test/system/admin_users_test.rb
@@ -1,0 +1,26 @@
+require "application_system_test_case"
+
+class AdminUsersTest < ApplicationSystemTestCase
+  def sign_in(email_address:, password: "password")
+    visit root_url
+    panel = find("#sign-in-panel")
+    set_field(panel.find("input[name='email_address']"), email_address)
+    set_field(panel.find("input[name='password']"), password)
+    submit_form panel.find("form")
+    assert_selector "h1", text: "KBC Dashboard"
+  end
+
+  test "admin toggles a user's approved flag from the admin page" do
+    pending = User.create!(handle: "Pending", email_address: "pending@example.com", password: "password", approved: false)
+    sign_in(email_address: "chris@example.com")
+    visit admin_url
+    checkbox_id = "approved_#{pending.id}"
+    page.execute_script("document.getElementById('#{checkbox_id}').click()")
+    # Wait for the Turbo Stream round-trip: the server only renders the
+    # `checked` attribute once @user.approved is actually true, unlike the
+    # JS click which flips the DOM property immediately. See the same
+    # pattern in admin_announcements_test.rb's pin-toggle test.
+    assert_selector "##{checkbox_id}[checked]", wait: 5
+    assert pending.reload.approved?, "expected user to become approved"
+  end
+end

--- a/test/system/admin_users_test.rb
+++ b/test/system/admin_users_test.rb
@@ -23,4 +23,14 @@ class AdminUsersTest < ApplicationSystemTestCase
     assert_selector "##{checkbox_id}[checked]", wait: 5
     assert pending.reload.approved?, "expected user to become approved"
   end
+
+  test "admin unapproves a user by unchecking the box" do
+    approved_user = User.create!(handle: "Approved", email_address: "approved@example.com", password: "password", approved: true)
+    sign_in(email_address: "chris@example.com")
+    visit admin_url
+    checkbox_id = "approved_#{approved_user.id}"
+    page.execute_script("document.getElementById('#{checkbox_id}').click()")
+    assert_no_selector "##{checkbox_id}[checked]", wait: 5
+    assert_not approved_user.reload.approved?, "expected user to become unapproved"
+  end
 end

--- a/test/system/announcements_index_test.rb
+++ b/test/system/announcements_index_test.rb
@@ -1,0 +1,34 @@
+require "application_system_test_case"
+
+class AnnouncementsIndexTest < ApplicationSystemTestCase
+  def sign_in(email_address:, password: "password")
+    visit root_url
+    panel = find("#sign-in-panel")
+    set_field(panel.find("input[name='email_address']"), email_address)
+    set_field(panel.find("input[name='password']"), password)
+    submit_form panel.find("form")
+    assert_selector "h1", text: "KBC Dashboard"
+  end
+
+  test "pinned appear first and scrolling loads more unpinned" do
+    Announcement.create!(title: "PINNED", body: "p", pinned: true)
+    8.times { |i| Announcement.create!(title: "unpinned-#{i}", body: "u", created_at: i.minutes.ago) }
+
+    sign_in(email_address: "paula@example.com")
+
+    # Shrink the viewport so page 0's content + lazy sentinel can't both fit on
+    # load (the default 1400px-tall window is borderline and flakes: the lazy
+    # frame sometimes intersects the viewport before any scroll happens).
+    page.driver.browser.manage.window.resize_to(1400, 400)
+
+    visit announcements_url
+
+    assert_text "PINNED"
+    assert_text "unpinned-0"          # first (newest) unpinned in page 0
+    assert_no_text "unpinned-7", wait: 1  # 8th unpinned is on page 2, not loaded yet
+
+    # Scroll the lazy sentinel into view to trigger the next page.
+    page.execute_script("window.scrollTo(0, document.body.scrollHeight)")
+    assert_text "unpinned-7", wait: 5
+  end
+end

--- a/test/system/dashboard_announcements_test.rb
+++ b/test/system/dashboard_announcements_test.rb
@@ -1,0 +1,24 @@
+require "application_system_test_case"
+
+class DashboardAnnouncementsTest < ApplicationSystemTestCase
+  def sign_in(email_address:, password: "password")
+    visit root_url
+    panel = find("#sign-in-panel")
+    set_field(panel.find("input[name='email_address']"), email_address)
+    set_field(panel.find("input[name='password']"), password)
+    submit_form panel.find("form")
+    assert_selector "h1", text: "KBC Dashboard"
+  end
+
+  test "dashboard shows pinned announcements and the latest unpinned" do
+    Announcement.create!(title: "PINNED-NEWS", body: "x", pinned: true)
+    Announcement.create!(title: "OLD-UNPINNED", body: "x", created_at: 2.days.ago)
+    Announcement.create!(title: "LATEST-UNPINNED", body: "x", created_at: 1.hour.ago)
+
+    sign_in(email_address: "paula@example.com")
+    assert_text "PINNED-NEWS"
+    assert_text "LATEST-UNPINNED"
+    assert_no_text "OLD-UNPINNED"
+    assert_link "All announcements"
+  end
+end


### PR DESCRIPTION
Adds an **Announcements** feature: admins publish (optionally pinned) Action Text announcements that players see on their dashboard and a dedicated infinite-scroll index. Also adds a lightweight admin area with a user-approval toggle.

## What's included
- **`admin` flag on User** — single `admin:boolean` (`admin?` gate); promote via console only. (The broader patronage/role ladder is intentionally a separate future spec.)
- **`Announcement` model** — Action Text `body`, `pinned` flag, `pinned`/`unpinned` scopes.
- **Admin area** (`Admin::` namespace behind a `head :forbidden` base-controller gate):
  - Admin page: last-2 announcements + per-user **approval checkboxes** (immediate, Turbo Stream + Stimulus `auto-submit`).
  - Full announcement **CRUD** (edit every announcement, delete) with a Trix form + **one-click pin toggle**.
- **Player-facing**:
  - Dashboard area showing all pinned + the latest unpinned announcement.
  - Index with **native Turbo lazy-frame infinite scroll** (5/page, pinned first) — no pagination gem, no custom JS.
- All new views reuse the existing `dashboard-box`/`dashboard-section` theme.

## Notes
- Production has no Active Storage service by design, so Trix's file-attach button is hidden — text-only announcements can't 500 in prod. Configure storage if image attachments are ever wanted.
- Deferred follow-up (non-blocking): `with_rich_text_body` preload to remove the N+1 on body renders.

## Testing
Full suite green: **980 unit + 22 system tests, 0 failures.** Every change was built TDD-first; each commit passed spec+quality review plus a whole-branch review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)