### PR TITLE
fix: honor an already-locked played terrain in Barn/Oracle/Quarry

### DIFF
--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -668,20 +668,22 @@ end
 class TurnPhase::SettlementMovePhase < TurnPhase
   include TurnPhase::SettlementMoveTargets
   include TurnPhase::SettlementMoveOrchestration
-  attr_reader :action_type, :klass_value, :from_value
+  attr_reader :action_type, :klass_value, :from_value, :chosen_terrain
 
   def self.from_hash(hash)
     new(
       action_type: hash.fetch("type"),
       klass_name: hash["klass"],
-      from: hash["from"]
+      from: hash["from"],
+      chosen_terrain: hash["chosen_terrain"]
     )
   end
 
-  def initialize(action_type:, klass_name:, from: nil)
+  def initialize(action_type:, klass_name:, from: nil, chosen_terrain: nil)
     @action_type = action_type
     @klass_value = klass_name
     @from_value = from
+    @chosen_terrain = chosen_terrain
   end
 
   def type
@@ -694,6 +696,13 @@ class TurnPhase::SettlementMovePhase < TurnPhase
 
   def from
     from_value
+  end
+
+  # A terrain already locked for the turn (a mandatory build before this
+  # action started) stays locked; a fresh SettlementMovePhase built with the
+  # default (chosen_terrain: nil) never re-widens it back to the full hand.
+  def with_chosen_terrain(terrain)
+    self.class.new(action_type: action_type, klass_name: klass_name, from: from, chosen_terrain: terrain)
   end
 
   # A single settlement move (paddock/harbor/barn). Reads hand terrain back from
@@ -726,7 +735,9 @@ class TurnPhase::SettlementMovePhase < TurnPhase
     game.board_contents.move_settlement(*from_coord, row, col)
     phase_result = transition(
       TurnPhase::Events::DestinationChosen.new,
-      TurnPhase::Facts::DestinationChoice.new(next_phase: TurnPhase::MandatoryBuildPhase.new)
+      TurnPhase::Facts::DestinationChoice.new(
+        next_phase: TurnPhase::MandatoryBuildPhase.new(chosen_terrain: game.turn_phase.chosen_terrain)
+      )
     )
     game.turn_phase = phase_result.next_phase
     game.current_player.mark_tile_used!(tile_klass)
@@ -743,7 +754,8 @@ class TurnPhase::SettlementMovePhase < TurnPhase
         next_phase: self.class.new(
           action_type: action_type,
           klass_name: klass_name,
-          from: event.coordinate_key
+          from: event.coordinate_key,
+          chosen_terrain: chosen_terrain
         ),
         source_cleared: false
       )
@@ -762,6 +774,7 @@ class TurnPhase::SettlementMovePhase < TurnPhase
     hash = { "type" => action_type }
     hash["klass"] = klass_name if klass_name
     hash["from"] = from if from
+    hash["chosen_terrain"] = chosen_terrain if chosen_terrain
     hash
   end
 end

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -87,13 +87,15 @@ class TurnEngine
         TurnPhase::TileBuildPhase.new(
           action_type: type,
           klass_name: klass_name,
+          chosen_terrain: @game.turn_phase.chosen_terrain,
           remaining: (tile_obj.build_quota if tile_obj.repeats_build?),
           walls_placed: (0 if tile_obj.places_wall?)
         )
       elsif tile_obj&.moves_settlement? && !tile_obj.resettles?
         TurnPhase::SettlementMovePhase.new(
           action_type: type,
-          klass_name: klass_name
+          klass_name: klass_name,
+          chosen_terrain: @game.turn_phase.chosen_terrain
         )
       elsif tile_obj&.resettles?
         TurnPhase::ResettlementPhase.new(

--- a/test/scenarios/tiles/barn_tile_test.rb
+++ b/test/scenarios/tiles/barn_tile_test.rb
@@ -52,4 +52,22 @@ class BarnTileTest < ActiveSupport::TestCase
     assert_equal 0, scenario.owner_at(destination)
     assert_nil scenario.owner_at(moving_spot)
   end
+
+  test "limits moves to the already-locked played terrain when the hand still holds two cards" do
+    scenario = GameScenario.new(hands: { 0 => %w[G T] })
+    moving_spot = [ 10, 10 ]
+    scenario.place_settlement(0, at: moving_spot)
+    scenario.give_tile(0, "BarnTile", from: [ 0, 0 ])
+    scenario.set_mandatory(1)
+
+    build_spot = scenario.buildable_cells.find { |spot| scenario.terrain_at(spot) == "G" }
+    scenario.build_settlement(at: build_spot)
+
+    scenario.activate_tile(:barn)
+    scenario.select_settlement(at: moving_spot)
+    destinations = scenario.buildable_cells
+
+    assert destinations.any?
+    destinations.each { |dest| assert_equal "G", scenario.terrain_at(dest) }
+  end
 end

--- a/test/scenarios/tiles/oracle_tile_test.rb
+++ b/test/scenarios/tiles/oracle_tile_test.rb
@@ -85,6 +85,21 @@ class OracleTileTest < ActiveSupport::TestCase
     assert_includes destinations, g_target
   end
 
+  test "with multiple hand terrains, limits destinations to the already-locked played terrain" do
+    scenario = GameScenario.new(hands: { 0 => %w[D G] })
+    scenario.give_tile(0, "OracleTile", from: [ 0, 0 ])
+    scenario.set_mandatory(1)
+
+    build_spot = scenario.buildable_cells.find { |spot| scenario.terrain_at(spot) == "D" }
+    scenario.build_settlement(at: build_spot)
+
+    scenario.activate_tile(:oracle)
+    destinations = scenario.buildable_cells
+
+    assert destinations.any?
+    destinations.each { |dest| assert_equal "D", scenario.terrain_at(dest) }
+  end
+
   test "with multiple hand terrains, builds on whichever terrain the player chooses" do
     scenario = GameScenario.new(hands: { 0 => %w[D G] })
     scenario.give_tile(0, "OracleTile", from: [ 0, 0 ])

--- a/test/scenarios/tiles/quarry_tile_test.rb
+++ b/test/scenarios/tiles/quarry_tile_test.rb
@@ -29,6 +29,26 @@ class QuarryTileTest < ActiveSupport::TestCase
     end
   end
 
+  test "with multiple hand terrains, limits wall placement to the already-locked played terrain" do
+    scenario = GameScenario.new(hands: { 0 => %w[G T] })
+    # [0, 6] is adjacent to both an empty G hex ([0, 7]) and an empty T hex
+    # ([0, 5]), so an unlocked two-card hand would offer both as wall spots.
+    settlement = [ 0, 6 ]
+    scenario.place_settlement(0, at: settlement)
+    scenario.give_tile(0, "QuarryTile", from: [ 0, 0 ])
+    scenario.set_mandatory(1)
+
+    build_spot = scenario.buildable_cells.find { |spot| scenario.terrain_at(spot) == "G" }
+    scenario.build_settlement(at: build_spot)
+
+    scenario.activate_tile(:quarry)
+    destinations = scenario.buildable_cells
+
+    assert destinations.any?
+    assert_not_includes destinations, [ 0, 5 ]
+    destinations.each { |dest| assert_equal "G", scenario.terrain_at(dest) }
+  end
+
   test "places up to 2 stone walls, consuming the supply and the tile" do
     scenario = GameScenario.new(hands: { 0 => "G" })
     scenario.place_settlement(0, at: SETTLEMENT)


### PR DESCRIPTION
## Summary
- With a two-card hand, a mandatory build locks one card as the turn's played terrain (`game.turn_phase.chosen_terrain`). Any tile action started afterward via `select_action` built a fresh phase without threading that lock through, so Barn's settlement-move destinations — and Oracle/Quarry's build/wall destinations — still spanned both hand terrains instead of just the one already played.
- `SettlementMovePhase` (Barn) gained `chosen_terrain` storage it never had, threaded through its transition and `with_chosen_terrain`.
- `TileBuildPhase` (Oracle/Quarry) already had full `chosen_terrain` plumbing; `select_action` just wasn't seeding it from the current phase.
- Both phase constructions in `select_action` now seed `chosen_terrain: @game.turn_phase.chosen_terrain`.

## Test plan
- [x] New scenario test: build locks "G" with a two-card hand, then Barn's move destinations are restricted to "G" only (failed red before the fix, green after).
- [x] New scenario test: same for Oracle's build destinations.
- [x] New scenario test: same for Quarry's wall destinations (using a settlement position with both hand terrains adjacent, so the test actually discriminates the bug).
- [x] Full suite (`bin/test-all`): 974 unit/scenario tests + 14 system tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KfXND16GWb2c4Fg3MdQLh