### PR TITLE
test: cover the reverse direction of the played-terrain lock

### DIFF
--- a/test/scenarios/tiles/barn_tile_test.rb
+++ b/test/scenarios/tiles/barn_tile_test.rb
@@ -70,4 +70,20 @@ class BarnTileTest < ActiveSupport::TestCase
     assert destinations.any?
     destinations.each { |dest| assert_equal "G", scenario.terrain_at(dest) }
   end
+
+  test "activating before the mandatory build locks the terrain for the rest of the turn" do
+    scenario = GameScenario.new(hands: { 0 => %w[G T] })
+    moving_spot = [ 10, 10 ]
+    scenario.place_settlement(0, at: moving_spot)
+    scenario.give_tile(0, "BarnTile", from: [ 0, 0 ])
+
+    scenario.activate_tile(:barn)
+    scenario.select_settlement(at: moving_spot)
+    destination = scenario.buildable_cells.find { |spot| scenario.terrain_at(spot) == "G" }
+    scenario.move_step(to: destination)
+
+    mandatory_destinations = scenario.buildable_cells
+    assert mandatory_destinations.any?
+    mandatory_destinations.each { |dest| assert_equal "G", scenario.terrain_at(dest) }
+  end
 end

--- a/test/scenarios/tiles/oracle_tile_test.rb
+++ b/test/scenarios/tiles/oracle_tile_test.rb
@@ -100,6 +100,19 @@ class OracleTileTest < ActiveSupport::TestCase
     destinations.each { |dest| assert_equal "D", scenario.terrain_at(dest) }
   end
 
+  test "activating before the mandatory build locks the terrain for the rest of the turn" do
+    scenario = GameScenario.new(hands: { 0 => %w[D G] })
+    scenario.give_tile(0, "OracleTile", from: [ 0, 0 ])
+
+    scenario.activate_tile(:oracle)
+    target = scenario.buildable_cells.find { |spot| scenario.terrain_at(spot) == "D" }
+    scenario.build_settlement(at: target)
+
+    mandatory_destinations = scenario.buildable_cells
+    assert mandatory_destinations.any?
+    mandatory_destinations.each { |dest| assert_equal "D", scenario.terrain_at(dest) }
+  end
+
   test "with multiple hand terrains, builds on whichever terrain the player chooses" do
     scenario = GameScenario.new(hands: { 0 => %w[D G] })
     scenario.give_tile(0, "OracleTile", from: [ 0, 0 ])

--- a/test/scenarios/tiles/quarry_tile_test.rb
+++ b/test/scenarios/tiles/quarry_tile_test.rb
@@ -49,6 +49,20 @@ class QuarryTileTest < ActiveSupport::TestCase
     destinations.each { |dest| assert_equal "G", scenario.terrain_at(dest) }
   end
 
+  test "activating before the mandatory build locks the terrain for the rest of the turn" do
+    scenario = GameScenario.new(hands: { 0 => %w[G T] })
+    scenario.place_settlement(0, at: SETTLEMENT)
+    scenario.give_tile(0, "QuarryTile", from: [ 0, 0 ])
+
+    scenario.activate_tile(:quarry)
+    scenario.place_wall(at: WALL_SPOTS[0])
+    scenario.place_wall(at: WALL_SPOTS[1])
+
+    mandatory_destinations = scenario.buildable_cells
+    assert mandatory_destinations.any?
+    mandatory_destinations.each { |dest| assert_equal "G", scenario.terrain_at(dest) }
+  end
+
   test "places up to 2 stone walls, consuming the supply and the tile" do
     scenario = GameScenario.new(hands: { 0 => "G" })
     scenario.place_settlement(0, at: SETTLEMENT)


### PR DESCRIPTION
## Summary
Follow-up to #281 (already merged). That PR fixed the case of a mandatory build locking a terrain and a subsequent tile action (Barn/Oracle/Quarry) needing to honor the lock. This adds the missing reverse-direction coverage: a tile action activated *before* any mandatory build should lock the terrain for the mandatory-build phase that follows.

- Oracle/Quarry already carried the lock forward correctly via `TileBuildOrchestration#reset_to_mandatory` — untouched by #281, was already correct on `main`.
- Barn's version exercises the `DestinationChoice` fix from #281 — confirmed by temporarily reverting that one line and watching the new test fail before restoring it.

No production code changes; test-only.

## Test plan
- [x] 3 new scenario tests (Barn/Oracle/Quarry), each: activate the tile first, complete its action on one hand terrain, then assert the following mandatory-build phase's destinations are restricted to that same terrain.
- [x] Full suite (`bin/test-all`): 977 unit/scenario tests + 14 system tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KfXND16GWb2c4Fg3MdQLh