### PR TITLE
Fix login password maxlength to match signup

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -14,7 +14,7 @@
           <div>
             <%= form.email_field :email_address, required: true, autocomplete: "email", placeholder: "Enter your email address", value: params[:email_address] %><br>
             <%= form.text_field :handle, required: true, placeholder: "Enter your desired handle", value: params[:handle] %><br>
-            <%= form.password_field :password, required: true, placeholder: "Create a password", value: params[:password] %><br>
+            <%= form.password_field :password, required: true, placeholder: "Create a password", value: params[:password], maxlength: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED %><br>
             <%= form.submit %>
           </div>
         <% end %>
@@ -33,7 +33,7 @@
             required: true,
             autocomplete: "current-password",
             placeholder: "Enter your password",
-            maxlength: 24
+            maxlength: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED
           %><br>
           <%= form.submit "Sign In" %>
         <% end %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -3,7 +3,7 @@
 <%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
 
 <%= form_with url: password_path(params[:token]), method: :put do |form| %>
-  <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72 %><br>
-  <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: 72 %><br>
+  <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED %><br>
+  <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED %><br>
   <%= form.submit "Save" %>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -16,7 +16,7 @@
       required: true,
       autocomplete: "current-password",
       placeholder: "Enter your password",
-      maxlength: 24
+      maxlength: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED
     %><br>
     <%= form.submit "Sign In" %>
   <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -15,7 +15,7 @@
     <div>
       <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", value: params[:email_address] %><br>
       <%= form.text_field :handle, required: true, placeholder: "Enter your desired handle", value: params[:handle] %><br>
-      <%= form.password_field :password, required: true, placeholder: "Create a password", value: params[:password] %><br>
+      <%= form.password_field :password, required: true, placeholder: "Create a password", value: params[:password], maxlength: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED %><br>
       <%= form.submit %>
     </div>
   <% end %>

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -5,4 +5,13 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get home_index_url
     assert_response :success
   end
+
+  test "sign-in password field allows passwords as long as sign-up allows" do
+    get home_index_url
+    doc = Nokogiri::HTML(response.body)
+    signup_maxlength = doc.at_css("#sign-up-panel input[name='user[password]']")["maxlength"]
+    signin_maxlength = doc.at_css("#sign-in-panel input[name='password']")["maxlength"]
+    assert_equal signup_maxlength, signin_maxlength
+    assert_equal ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED.to_s, signin_maxlength
+  end
 end


### PR DESCRIPTION
## Summary
- Login capped passwords at 24 characters while signup allowed the full bcrypt limit, locking out users with longer passwords.
- All password fields (signup, login ×2 forms, password reset) now share `ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED` (72), the actual server-side bcrypt limit already enforced by `has_secure_password`.

Fixes #277

## Test plan
- [x] `bin/rails test test/controllers/home_controller_test.rb` — new test pins that sign-in and sign-up maxlength match (72)
- [x] `bin/rails test test/controllers/sessions_controller_test.rb test/controllers/users_controller_test.rb test/system/users_test.rb` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgLfUTiRtjnnWUC8ff8YUo