### PR TITLE
Fix City Hall placement: collect tiles, score Ambassadors/Shepherds

### DIFF
--- a/app/models/turn_phase.rb
+++ b/app/models/turn_phase.rb
@@ -1470,6 +1470,11 @@ class TurnPhase::CityHallPhase < TurnPhase
     cluster.each { |r, c| game.board_contents.place_city_hall_hex(r, c, game_player.order) }
     game_player.decrement_city_hall_supply!
     game_player.mark_tile_permanently_used!("CityHallTile")
+    cluster.each do |r, c|
+      engine.check_ambassadors_goal(game_player, r, c)
+      engine.check_shepherds_goal(game_player, r, c, game.board_contents.terrain_at(r, c))
+      engine.apply_tile_pickup(game_player, r, c)
+    end
     engine.reset_to_mandatory
     game_player.save
     game.save

--- a/app/services/turn_engine.rb
+++ b/app/services/turn_engine.rb
@@ -717,5 +717,5 @@ class TurnEngine
   # (select_action, end_turn, activate_fort_tile, ...) that no single phase owns.
   public :capture_undo_snapshot, :record_move, :reset_to_mandatory, :apply_tile_forfeit,
          :lock_terrain!, :build_on_terrain, :apply_tile_pickup, :log_piece_movement_steps,
-         :check_families_goal
+         :check_families_goal, :check_ambassadors_goal, :check_shepherds_goal
 end

--- a/test/scenarios/tiles/city_hall_tile_test.rb
+++ b/test/scenarios/tiles/city_hall_tile_test.rb
@@ -81,6 +81,99 @@ class CityHallTileTest < ActiveSupport::TestCase
     assert_not_includes scenario.usable_tiles(0), "CityHallTile"
   end
 
+  test "placing the City Hall collects a tile it lands adjacent to" do
+    scenario = GameScenario.new
+    scenario.place_settlement(0, at: OTHER_SETTLEMENT)
+    scenario.give_tile(0, "CityHallTile", from: [ 0, 0 ])
+    scenario.give_city_halls(0, 1)
+    tile_spot = [ 1, 7 ] # sole outside neighbor of cluster hex [1, 6]
+    scenario.place_tile("OasisTile", at: tile_spot, qty: 2)
+
+    scenario.activate_tile(:cityhall)
+    scenario.place_city_hall(at: CENTER)
+
+    assert scenario.holds_tile?(0, klass: "OasisTile", from: tile_spot)
+    assert_equal 1, scenario.tile_qty(tile_spot)
+  end
+
+  test "placing the City Hall adjacent to 2 opponent settlements scores 2 Ambassadors points" do
+    scenario = GameScenario.new(goals: [ "ambassadors" ])
+    scenario.place_settlement(0, at: OTHER_SETTLEMENT)
+    scenario.give_tile(0, "CityHallTile", from: [ 0, 0 ])
+    scenario.give_city_halls(0, 1)
+    # [1, 7] and [3, 4] are each the sole outside neighbor of a distinct
+    # cluster hex ([1, 6] and [2, 5]), so each scores independently.
+    scenario.place_settlement(1, at: [ 1, 7 ])
+    scenario.place_settlement(1, at: [ 3, 4 ])
+
+    scenario.activate_tile(:cityhall)
+    scenario.place_city_hall(at: CENTER)
+
+    assert_equal 2, scenario.score_for("ambassadors", 0)
+  end
+
+  test "placing the City Hall away from opponent settlements scores no Ambassadors points" do
+    scenario = GameScenario.new(goals: [ "ambassadors" ])
+    scenario.place_settlement(0, at: OTHER_SETTLEMENT)
+    scenario.give_tile(0, "CityHallTile", from: [ 0, 0 ])
+    scenario.give_city_halls(0, 1)
+
+    scenario.activate_tile(:cityhall)
+    scenario.place_city_hall(at: CENTER)
+
+    assert_equal 0, scenario.score_for("ambassadors", 0)
+  end
+
+  test "placing the City Hall scores the minimum 2 Shepherds points (only the center hex)" do
+    scenario = GameScenario.new(goals: [ "shepherds" ])
+    center = [ 3, 4 ]
+    # Own settlement adjacent to ring hex [3, 3], on non-matching terrain (W)
+    # so it satisfies the placement's adjacency rule without blocking any
+    # ring hex's same-terrain emptiness check.
+    scenario.place_settlement(0, at: [ 4, 3 ])
+    scenario.give_tile(0, "CityHallTile", from: [ 0, 0 ])
+    scenario.give_city_halls(0, 1)
+
+    scenario.activate_tile(:cityhall)
+    scenario.place_city_hall(at: center)
+
+    assert_equal 2, scenario.score_for("shepherds", 0)
+  end
+
+  test "placing the City Hall scores 8 Shepherds points (center plus 3 blocked ring hexes)" do
+    scenario = GameScenario.new(goals: [ "shepherds" ])
+    center = [ 3, 4 ]
+    scenario.place_settlement(0, at: [ 4, 3 ])
+    scenario.give_tile(0, "CityHallTile", from: [ 0, 0 ])
+    scenario.give_city_halls(0, 1)
+    # Each fill removes the last empty same-terrain neighbor for one ring
+    # hex: [2, 3] -> [3, 3] (Farm), [2, 6] -> [3, 5] (Terrain), [5, 4] -> [4, 4] (Grass).
+    [ [ 2, 3 ], [ 2, 6 ], [ 5, 4 ] ].each { |hex| scenario.place_settlement(1, at: hex) }
+
+    scenario.activate_tile(:cityhall)
+    scenario.place_city_hall(at: center)
+
+    assert_equal 8, scenario.score_for("shepherds", 0)
+  end
+
+  test "placing the City Hall scores the maximum 14 Shepherds points (all 7 hexes)" do
+    scenario = GameScenario.new(goals: [ "shepherds" ])
+    center = [ 3, 4 ]
+    scenario.place_settlement(0, at: [ 4, 3 ])
+    scenario.give_tile(0, "CityHallTile", from: [ 0, 0 ])
+    scenario.give_city_halls(0, 1)
+    # Every same-terrain outside neighbor of every ring hex is filled, so
+    # none has an empty same-terrain neighbor left.
+    [ [ 2, 3 ], [ 1, 3 ], [ 1, 4 ], [ 2, 6 ], [ 1, 5 ], [ 5, 4 ], [ 4, 6 ], [ 5, 5 ] ].each do |hex|
+      scenario.place_settlement(1, at: hex)
+    end
+
+    scenario.activate_tile(:cityhall)
+    scenario.place_city_hall(at: center)
+
+    assert_equal 14, scenario.score_for("shepherds", 0)
+  end
+
   test "an opponent's Sword cannot remove a City Hall hex" do
     scenario = GameScenario.new
     scenario.place_settlement(0, at: OTHER_SETTLEMENT)


### PR DESCRIPTION
## Summary
- Placing a City Hall's 7-hex cluster now picks up any adjacent tiles per cluster hex, matching normal settlement build behavior.
- City Hall placement now scores Ambassadors (1 pt per cluster hex adjacent to an opponent settlement) and Shepherds (2 pts per cluster hex with no adjacent empty same-terrain hex, counting other City Hall hexes as filled).
- Exposed `check_ambassadors_goal` and `check_shepherds_goal` publicly on `TurnEngine` alongside the existing `check_families_goal`, and call them per cluster hex from `CityHallPhase#click` after all 7 hexes are placed.

Closes #284

## Test plan
- [x] New scenario test: placing City Hall collects a tile it lands adjacent to
- [x] New scenario tests: Ambassadors scoring (0 and 2 points cases)
- [x] New scenario tests: Shepherds scoring minimum (2), medium (8), and maximum (14) cases
- [x] `bin/test-all` — full suite green (993 + 22 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgLfUTiRtjnnWUC8ff8YUo