### PR TITLE
docs: drop stale SwordTile "known bugs" note

### DIFF
--- a/docs/agents/scenario-coverage.md
+++ b/docs/agents/scenario-coverage.md
@@ -82,7 +82,7 @@ All Tier-1 (board-derived, no `TurnEngine` callback).
 | CityHallTile | ✅ | `tiles/city_hall_tile_test.rb` | `on_pickup` grants supply, `valid_destinations`/`activatable?` find a 7-hex cluster adjacent to another settlement, `place_city_hall` |
 | CrossroadsTile | ✅ | `tiles/crossroads_tile_test.rb` | extra card draw on `end_turn`, always-false `activatable?` |
 | QuarryTile | ✅ | `tiles/quarry_tile_test.rb` | wall placement on played-terrain hexes adjacent to a settlement, up to 2 walls, `activatable?` |
-| Nomad::SwordTile | ✅ | `tiles/sword_tile_test.rb` | targeted removal of an opponent's settlement, returned to supply; documents 2 known bugs (see test comments) |
+| Nomad::SwordTile | ✅ | `tiles/sword_tile_test.rb` | targeted removal of an opponent's settlement or meeple, returned to the matching supply; location-tile forfeit, undo round trip |
 | Nomad::TreasureTile | ✅ | `tiles/treasure_tile_test.rb` | pickup immediately scores 3 points and is not held |
 | CastleTile | ✅ | `goals/castles_test.rb` | pure-data location tile; scoring covered by the Castles goal, no custom tile logic |
 


### PR DESCRIPTION
`docs/agents/scenario-coverage.md` still claimed the Sword row "documents 2 known bugs (see test comments)". Those two bugs — the `"nomad::sword"` vs `"sword"` action-type mismatch that stopped targets highlighting, and the `.demodulize` klass mismatch that stopped the tile being marked used — were fixed in cc08e0e, and the scenario tests have asserted correct behavior ever since.

Audited the current Sword net against the rules before editing: meeple removal, the City Hall exclusion, and the always-true `activatable?` are all correct. (`activatable?` needs no guard: activating a Sword implies two of your turns have passed, so every opponent has built at least 3 settlements and can have lost at most 1 to the other Sword.)

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LCQgEqQd5RQRo3kx4XHbg